### PR TITLE
Add Criterion benchmark suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +193,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +228,33 @@ checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -265,10 +322,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -289,6 +412,12 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embedded-io"
@@ -346,6 +475,17 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
 
 [[package]]
 name = "hash32"
@@ -414,6 +554,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071ed4cc1afd86650602c7b11aa2e1ce30762a1c27193201cb5cee9c6ebb1294"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,6 +584,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "clap",
+ "criterion",
  "glob",
  "pest",
  "pest_derive",
@@ -518,6 +668,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "pest"
 version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,6 +731,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "postcard"
@@ -672,6 +866,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +993,15 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -918,6 +1170,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,6 +1265,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,6 +1324,47 @@ checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ harness = false
 name = "serial"
 harness = false
 
+[[bench]]
+name = "queries"
+harness = false
+
 [dev-dependencies]
 criterion = { version = "0.8.2", features = ["html_reports"] }
 rust_decimal = { version = "1.40.0", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ harness = false
 name = "pipeline"
 harness = false
 
+[[bench]]
+name = "serial"
+harness = false
+
 [dev-dependencies]
 criterion = { version = "0.8.2", features = ["html_reports"] }
 rust_decimal = { version = "1.40.0", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ xz = "0.1.0"
 name = "parse"
 harness = false
 
+[[bench]]
+name = "pipeline"
+harness = false
+
 [dev-dependencies]
 criterion = { version = "0.8.2", features = ["html_reports"] }
 rust_decimal = { version = "1.40.0", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,5 @@ serde-pickle = "1.2.0"
 xz = "0.1.0"
 
 [dev-dependencies]
+criterion = { version = "0.8.2", features = ["html_reports"] }
 rust_decimal = { version = "1.40.0", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde-pickle = "1.2.0"
 xz = "0.1.0"
 
+[[bench]]
+name = "parse"
+harness = false
+
 [dev-dependencies]
 criterion = { version = "0.8.2", features = ["html_reports"] }
 rust_decimal = { version = "1.40.0", features = ["macros"] }

--- a/benches/data.rs
+++ b/benches/data.rs
@@ -23,7 +23,7 @@ pub fn simple(n: usize) -> String {
         let year = 2020 + i / 336;
         out.push_str(&format!(
             "{:04}/{:02}/{:02} Payee {}\n    {}  $ {}\n    {}\n\n",
-            year, month, day, i % 100, amount, debit, credit,
+            year, month, day, i % 100, debit, amount, credit,
         ));
     }
     out

--- a/benches/data.rs
+++ b/benches/data.rs
@@ -1,0 +1,104 @@
+/// Workload generators for benchmarks.
+///
+/// Each function returns a String of ledger-format text that can be fed
+/// directly to the parser. Sizes are chosen to keep each benchmark group
+/// well under a second so the full suite is fast enough for pre-commit use.
+
+/// A plain two-posting transaction: one expense account, one asset account.
+/// Represents the most common real-world pattern.
+pub fn simple(n: usize) -> String {
+    let accounts = [
+        ("Expenses:Food", "Assets:Bank:Checking"),
+        ("Expenses:Transport", "Assets:Bank:Checking"),
+        ("Expenses:Utilities", "Assets:Bank:Checking"),
+        ("Expenses:Shopping", "Liabilities:CreditCard"),
+        ("Income:Salary", "Assets:Bank:Checking"),
+    ];
+    let mut out = String::with_capacity(n * 80);
+    for i in 0..n {
+        let (debit, credit) = accounts[i % accounts.len()];
+        let amount = 10 + (i % 490);
+        let day = (i % 28) + 1;
+        let month = (i % 12) + 1;
+        let year = 2020 + i / 336;
+        out.push_str(&format!(
+            "{:04}/{:02}/{:02} Payee {}\n    {}  $ {}\n    {}\n\n",
+            year, month, day, i % 100, amount, debit, credit,
+        ));
+    }
+    out
+}
+
+/// Many distinct accounts — stresses account-name interning and BTreeMap
+/// lookups during elaboration.
+pub fn wide(n: usize) -> String {
+    let mut out = String::with_capacity(n * 90);
+    for i in 0..n {
+        let acct = format!("Expenses:Category{}", i % 500);
+        let amount = 10 + (i % 490);
+        let day = (i % 28) + 1;
+        let month = (i % 12) + 1;
+        let year = 2020 + i / 336;
+        out.push_str(&format!(
+            "{:04}/{:02}/{:02} Payee {}\n    {}  $ {}\n    Assets:Bank:Checking\n\n",
+            year, month, day, i % 100, acct, amount,
+        ));
+    }
+    out
+}
+
+/// Five postings per transaction — stresses balance resolution and the
+/// implicit-amount inference path.
+pub fn deep(n: usize) -> String {
+    let accounts = [
+        "Expenses:Food",
+        "Expenses:Transport",
+        "Expenses:Utilities",
+        "Expenses:Shopping",
+    ];
+    let mut out = String::with_capacity(n * 200);
+    for i in 0..n {
+        let day = (i % 28) + 1;
+        let month = (i % 12) + 1;
+        let year = 2020 + i / 336;
+        out.push_str(&format!(
+            "{:04}/{:02}/{:02} Payee {}\n",
+            year, month, day, i % 100
+        ));
+        for (j, acct) in accounts.iter().enumerate() {
+            out.push_str(&format!("    {}  $ {}\n", acct, 10 + (i + j) % 90));
+        }
+        // Final posting has implicit amount (sum of the above, negated)
+        out.push_str("    Assets:Bank:Checking\n\n");
+    }
+    out
+}
+
+/// Multiple commodities per transaction — stresses Amount handling and
+/// commodity string interning.
+pub fn multi_commodity(n: usize) -> String {
+    let commodities = ["USD", "EUR", "GBP"];
+    let mut out = String::with_capacity(n * 120);
+    for i in 0..n {
+        let commodity = commodities[i % commodities.len()];
+        let amount = 10 + (i % 490);
+        let day = (i % 28) + 1;
+        let month = (i % 12) + 1;
+        let year = 2020 + i / 336;
+        out.push_str(&format!(
+            "{:04}/{:02}/{:02} Payee {}\n    Expenses:Foreign  {} {}\n    Assets:Bank:Checking  {} -{}\n\n",
+            year, month, day, i % 100, commodity, amount, commodity, amount,
+        ));
+    }
+    out
+}
+
+/// All workloads paired with a name and the default transaction count.
+pub fn workloads() -> Vec<(&'static str, String)> {
+    vec![
+        ("simple", simple(10_000)),
+        ("wide", wide(10_000)),
+        ("deep", deep(10_000)),
+        ("multi_commodity", multi_commodity(10_000)),
+    ]
+}

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -1,0 +1,21 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::path::PathBuf;
+
+mod data;
+
+fn bench_parse(c: &mut Criterion) {
+    let mut group = c.benchmark_group("parse");
+    for (name, input) in data::workloads() {
+        let mut parser = ledger::parser::Parser {
+            openner: |_: &str| String::new(),
+            base_path: PathBuf::new(),
+        };
+        group.bench_with_input(BenchmarkId::new("parse", name), &input, |b, input| {
+            b.iter(|| parser.parse(input).unwrap())
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_parse);
+criterion_main!(benches);

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -1,10 +1,11 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Duration};
 
 mod data;
 
 fn bench_parse(c: &mut Criterion) {
     let mut group = c.benchmark_group("parse");
+    group.measurement_time(Duration::from_secs(15));
     for (name, input) in data::workloads() {
         let mut parser = ledger::parser::Parser {
             openner: |_: &str| String::new(),

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Duration};
 
 mod data;
 
@@ -12,12 +12,13 @@ fn make_parser() -> ledger::parser::Parser<impl Fn(&str) -> String> {
 
 fn bench_resolution(c: &mut Criterion) {
     let mut group = c.benchmark_group("resolution");
+    group.measurement_time(Duration::from_secs(15));
     for (name, input) in data::workloads() {
         group.bench_with_input(BenchmarkId::new("resolution", name), &input, |b, input| {
             b.iter_batched(
                 || make_parser().parse(input).unwrap(),
                 |ast| -> ledger::resolution::HIR { ast.try_into().unwrap() },
-                criterion::BatchSize::LargeInput,
+                criterion::BatchSize::PerIteration,
             )
         });
     }
@@ -26,6 +27,7 @@ fn bench_resolution(c: &mut Criterion) {
 
 fn bench_elaboration(c: &mut Criterion) {
     let mut group = c.benchmark_group("elaboration");
+    group.measurement_time(Duration::from_secs(20));
     for (name, input) in data::workloads() {
         group.bench_with_input(BenchmarkId::new("elaboration", name), &input, |b, input| {
             b.iter_batched(
@@ -35,7 +37,7 @@ fn bench_elaboration(c: &mut Criterion) {
                     hir
                 },
                 |hir| -> ledger::elaboration::Journal { hir.try_into().unwrap() },
-                criterion::BatchSize::LargeInput,
+                criterion::BatchSize::PerIteration,
             )
         });
     }
@@ -44,6 +46,7 @@ fn bench_elaboration(c: &mut Criterion) {
 
 fn bench_compile(c: &mut Criterion) {
     let mut group = c.benchmark_group("compile");
+    group.measurement_time(Duration::from_secs(20));
     for (name, input) in data::workloads() {
         group.bench_with_input(BenchmarkId::new("compile", name), &input, |b, input| {
             b.iter(|| ledger::compile(input, make_parser()).unwrap())

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -1,0 +1,56 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::path::PathBuf;
+
+mod data;
+
+fn make_parser() -> ledger::parser::Parser<impl Fn(&str) -> String> {
+    ledger::parser::Parser {
+        openner: |_: &str| String::new(),
+        base_path: PathBuf::new(),
+    }
+}
+
+fn bench_resolution(c: &mut Criterion) {
+    let mut group = c.benchmark_group("resolution");
+    for (name, input) in data::workloads() {
+        group.bench_with_input(BenchmarkId::new("resolution", name), &input, |b, input| {
+            b.iter_batched(
+                || make_parser().parse(input).unwrap(),
+                |ast| -> ledger::resolution::HIR { ast.try_into().unwrap() },
+                criterion::BatchSize::LargeInput,
+            )
+        });
+    }
+    group.finish();
+}
+
+fn bench_elaboration(c: &mut Criterion) {
+    let mut group = c.benchmark_group("elaboration");
+    for (name, input) in data::workloads() {
+        group.bench_with_input(BenchmarkId::new("elaboration", name), &input, |b, input| {
+            b.iter_batched(
+                || {
+                    let ast = make_parser().parse(input).unwrap();
+                    let hir: ledger::resolution::HIR = ast.try_into().unwrap();
+                    hir
+                },
+                |hir| -> ledger::elaboration::Journal { hir.try_into().unwrap() },
+                criterion::BatchSize::LargeInput,
+            )
+        });
+    }
+    group.finish();
+}
+
+fn bench_compile(c: &mut Criterion) {
+    let mut group = c.benchmark_group("compile");
+    for (name, input) in data::workloads() {
+        group.bench_with_input(BenchmarkId::new("compile", name), &input, |b, input| {
+            b.iter(|| ledger::compile(input, make_parser()).unwrap())
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_resolution, bench_elaboration, bench_compile);
+criterion_main!(benches);

--- a/benches/queries.rs
+++ b/benches/queries.rs
@@ -1,0 +1,60 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use rust_decimal::Decimal;
+use std::{collections::BTreeMap, path::PathBuf};
+
+mod data;
+
+fn make_parser() -> ledger::parser::Parser<impl Fn(&str) -> String> {
+    ledger::parser::Parser {
+        openner: |_: &str| String::new(),
+        base_path: PathBuf::new(),
+    }
+}
+
+fn bench_balance(c: &mut Criterion) {
+    let mut group = c.benchmark_group("balance");
+    for (name, input) in data::workloads() {
+        let journal = ledger::compile(&input, make_parser()).unwrap();
+        group.bench_with_input(BenchmarkId::new("balance", name), &journal, |b, journal| {
+            b.iter(|| {
+                let mut balances: BTreeMap<&str, BTreeMap<&str, Decimal>> = BTreeMap::new();
+                for txn in journal.transactions.iter() {
+                    for posting in txn.postings.iter() {
+                        for (commodity, amount) in posting.amount.0.iter() {
+                            *balances
+                                .entry(posting.account.as_str())
+                                .or_default()
+                                .entry(commodity.as_str())
+                                .or_default() += Decimal::deserialize(*amount);
+                        }
+                    }
+                }
+                balances
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_register(c: &mut Criterion) {
+    let mut group = c.benchmark_group("register");
+    for (name, input) in data::workloads() {
+        let journal = ledger::compile(&input, make_parser()).unwrap();
+        // Filter to a pattern that matches ~20% of postings
+        let pattern = "expenses";
+        group.bench_with_input(BenchmarkId::new("register", name), &journal, |b, journal| {
+            b.iter(|| {
+                journal
+                    .transactions
+                    .iter()
+                    .flat_map(|txn| txn.postings.iter())
+                    .filter(|p| p.account.to_lowercase().contains(pattern))
+                    .count()
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_balance, bench_register);
+criterion_main!(benches);

--- a/benches/queries.rs
+++ b/benches/queries.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use rust_decimal::Decimal;
-use std::{collections::BTreeMap, path::PathBuf};
+use std::{collections::BTreeMap, path::PathBuf, time::Duration};
 
 mod data;
 
@@ -13,6 +13,7 @@ fn make_parser() -> ledger::parser::Parser<impl Fn(&str) -> String> {
 
 fn bench_balance(c: &mut Criterion) {
     let mut group = c.benchmark_group("balance");
+    group.measurement_time(Duration::from_secs(12));
     for (name, input) in data::workloads() {
         let journal = ledger::compile(&input, make_parser()).unwrap();
         group.bench_with_input(BenchmarkId::new("balance", name), &journal, |b, journal| {

--- a/benches/serial.rs
+++ b/benches/serial.rs
@@ -1,0 +1,41 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::{io::Write as _, path::PathBuf};
+
+mod data;
+
+fn make_parser() -> ledger::parser::Parser<impl Fn(&str) -> String> {
+    ledger::parser::Parser {
+        openner: |_: &str| String::new(),
+        base_path: PathBuf::new(),
+    }
+}
+
+fn bench_serialize(c: &mut Criterion) {
+    let mut group = c.benchmark_group("serialize");
+    for (name, input) in data::workloads() {
+        let journal = ledger::compile(&input, make_parser()).unwrap();
+        group.bench_with_input(BenchmarkId::new("serialize", name), &journal, |b, journal| {
+            b.iter(|| {
+                let mut out = std::io::BufWriter::new(std::io::sink());
+                postcard::to_io(journal, &mut out).unwrap();
+                out.flush().unwrap();
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_deserialize(c: &mut Criterion) {
+    let mut group = c.benchmark_group("deserialize");
+    for (name, input) in data::workloads() {
+        let journal = ledger::compile(&input, make_parser()).unwrap();
+        let bytes = postcard::to_allocvec(&journal).unwrap();
+        group.bench_with_input(BenchmarkId::new("deserialize", name), &bytes, |b, bytes| {
+            b.iter(|| postcard::from_bytes::<ledger::Journal>(bytes).unwrap())
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_serialize, bench_deserialize);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

- Adds `criterion` as a dev dependency
- Adds `benches/data.rs`: four synthetic workload generators (no external files required)
  - `simple` — 2-posting transactions, 5 accounts
  - `wide` — 2-posting transactions, 500 distinct accounts
  - `deep` — 5-posting transactions with implicit final amount
  - `multi_commodity` — cycling USD/EUR/GBP commodities
- Adds benchmark groups covering every pipeline stage:
  - `parse` — text → `ast::Journal`
  - `resolution`, `elaboration`, `compile` — each stage isolated via `iter_batched`
  - `serialize`, `deserialize` — postcard round-trip
  - `balance`, `register` — query operations on a compiled `Journal`

Run with `cargo bench` for full measurements, or `cargo bench -- --test` for a fast no-measurement correctness check suitable for pre-commit.

## Test plan

- [ ] `cargo bench -- --test` passes (32/32)
- [ ] `cargo bench` runs without "Unable to complete N samples" warnings