### PR TITLE
docs: comprehensive documentation for all modules and public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,82 @@
+# ledger-rs
+
+A compiler and query tool for the [Ledger](https://ledger-cli.org/) plain-text accounting format. It parses `.ledger` files through a multi-stage pipeline, producing a compact binary format (`.bki`) suitable for fast repeated querying, and provides simple balance and register views.
+
+## Build
+
+```
+cargo build --release
+```
+
+The resulting binary is `target/release/ledger`.
+
+## Usage
+
+### `compile` — pre-process a ledger file
+
+```
+ledger compile --output my-journal.bki my-journal.ledger
+```
+
+Parses the source file, runs it through the full compilation pipeline, and writes the result as a postcard-serialized, XZ-compressed `.bki` file. Use this for large ledgers to avoid re-parsing on every query.
+
+### `balance` — account balances
+
+```
+ledger balance my-journal.ledger
+ledger balance my-journal.bki
+```
+
+Prints the running balance for every account across all transactions, grouped by commodity. Both raw `.ledger` files and pre-compiled `.bki` files are accepted.
+
+### `register` — posting register
+
+```
+ledger register my-journal.ledger [PATTERN]
+```
+
+Lists individual postings, optionally filtered to accounts whose name contains `PATTERN` (case-insensitive). Useful for inspecting the history of a specific account or category.
+
+## Pipeline
+
+ledger-rs processes source text through four sequential stages:
+
+```
+ .ledger text
+      │
+      ▼
+ ┌─────────┐
+ │  parse  │  pest PEG grammar → ast::Journal
+ └─────────┘
+      │  unresolved dates, aliases, raw ValueExpr amounts
+      ▼
+ ┌────────────┐
+ │ resolution │  ast::Journal → resolution::HIR
+ └────────────┘
+      │  dates normalized, aliases indexed, notes → tags/metadata
+      ▼
+ ┌─────────────┐
+ │ elaboration │  resolution::HIR → elaboration::Journal
+ └─────────────┘
+      │  amounts evaluated, transactions balanced, accounts registered
+      ▼
+ ┌─────────────┐
+ │ serialization│  postcard + XZ → .bki
+ └─────────────┘
+```
+
+### Stage details
+
+**Parse** (`src/parser.rs`, `src/ledger.pest`): A [pest](https://pest.rs/) PEG grammar tokenises the source into an `ast::Journal` containing transactions, directives, and comments. Amount expressions are kept as unevaluated `ValueExpr` trees. `include` directives are resolved recursively here.
+
+**Resolution** (`src/resolution.rs`): Converts `ast::Journal` to a Higher-level Intermediate Representation (`HIR`). Dates are resolved to `NaiveDate` (a full year is required). Commodity and account aliases are accumulated into a versioned `Context` stack so each transaction sees the aliases that were in effect when it was defined. Structured metadata and tags are extracted from freeform notes.
+
+**Elaboration** (`src/elaboration.rs`): Converts `HIR` to the final `elaboration::Journal`. `ValueExpr` trees are evaluated to `(Decimal, commodity)` pairs, commodity aliases are applied, and each transaction is balanced — if exactly one posting has no explicit amount its value is inferred as the negation of the sum of the rest. Balance assertions (`= amount`) and balance assignments (`=amount`) are checked or applied at this stage.
+
+**Serialization**: The `Journal` implements `serde::Serialize`/`Deserialize`. The `compile` command writes it through [postcard](https://github.com/jamesmunns/postcard) into an XZ-compressed stream; the `balance` and `register` commands decompress and deserialize it in the reverse direction.
+
+## API documentation
+
+```
+cargo doc --no-deps --open
+```

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -8,7 +8,7 @@ fn bench_parse(c: &mut Criterion) {
     group.measurement_time(Duration::from_secs(15));
     for (name, input) in data::workloads() {
         let mut parser = ledger::parser::Parser {
-            openner: |_: &str| String::new(),
+            opener: |_: &str| String::new(),
             base_path: PathBuf::new(),
         };
         group.bench_with_input(BenchmarkId::new("parse", name), &input, |b, input| {

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -5,7 +5,7 @@ mod data;
 
 fn make_parser() -> ledger::parser::Parser<impl Fn(&str) -> String> {
     ledger::parser::Parser {
-        openner: |_: &str| String::new(),
+        opener: |_: &str| String::new(),
         base_path: PathBuf::new(),
     }
 }

--- a/benches/queries.rs
+++ b/benches/queries.rs
@@ -6,7 +6,7 @@ mod data;
 
 fn make_parser() -> ledger::parser::Parser<impl Fn(&str) -> String> {
     ledger::parser::Parser {
-        openner: |_: &str| String::new(),
+        opener: |_: &str| String::new(),
         base_path: PathBuf::new(),
     }
 }

--- a/benches/serial.rs
+++ b/benches/serial.rs
@@ -5,7 +5,7 @@ mod data;
 
 fn make_parser() -> ledger::parser::Parser<impl Fn(&str) -> String> {
     ledger::parser::Parser {
-        openner: |_: &str| String::new(),
+        opener: |_: &str| String::new(),
         base_path: PathBuf::new(),
     }
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,60 +1,108 @@
+//! Abstract Syntax Tree (AST) for the Ledger file format.
+//!
+//! This module defines the data types produced by the parser. The AST is a
+//! faithful, low-level representation of the source text: dates may lack a
+//! year, amounts are unevaluated [`ValueExpr`] trees, and directives are kept
+//! in their raw form. Subsequent pipeline stages ([`crate::resolution`] and
+//! [`crate::elaboration`]) refine these into higher-level structures.
+
 use std::{collections::BTreeMap, fmt::Display};
 
 use chrono::{Datelike, NaiveDate};
 use rust_decimal::Decimal;
 
+/// The root of a parsed ledger file.
+///
+/// Contains all top-level entries in source order.
 #[derive(Debug)]
 pub struct Journal {
     pub entries: Vec<Entry>,
 }
 
+/// A single top-level entry in the journal.
 #[derive(Debug)]
 pub enum Entry {
+    /// A double-entry accounting transaction (date, description, postings).
     Transaction(Transaction),
+    /// A configuration directive (`commodity`, `account`, `alias`, …).
     Directive(Directive),
+    /// A comment line starting with `;`, `#`, `*`, `%`, or `|`.
     Comment(String),
 }
 
+/// A configuration directive parsed from the ledger source.
 #[derive(Debug)]
 pub enum Directive {
+    /// A `commodity` block declaring properties of a commodity symbol.
     Commodity {
+        /// The canonical commodity name (e.g. `"USD"`, `"BTC"`, `"$"`).
         name: String,
+        /// Free-form notes attached to the commodity block header.
         notes: Vec<String>,
+        /// Structured sub-items (`alias`, `format`, `nomarket`, `default`, …).
         items: Vec<CommodityItem>,
     },
+    /// An `account` block declaring properties of an account.
     Account {
+        /// The canonical account name (e.g. `"Assets:Bank:Checking"`).
         name: String,
+        /// Free-form notes attached to the account block header.
         notes: Vec<String>,
+        /// Structured sub-items (`alias`, `note`, …).
         items: Vec<AccountItem>,
     },
+    /// A directive whose keyword was not recognised.
     Unknown(String),
+    /// A top-level `alias <from> = <to>` account shorthand.
     Alias {
+        /// The short name to be used in postings.
         alias: String,
+        /// The full account name it expands to.
         account: String,
     },
 }
 
+/// A single key/value item inside a `commodity` directive block.
 #[derive(Clone, Debug)]
 pub enum CommodityItem {
+    /// An alternative name for this commodity (`alias <name>`).
     Alias(String),
-    Format(String), // Format strings are usually "settings" literals
+    /// A display format string, e.g. `"1,000.00 USD"`.
+    Format(String),
+    /// Marks the commodity as having no market price data (`nomarket`).
     NoMarket,
+    /// Marks this commodity as the default when no commodity is specified.
     Default,
+    /// A free-form note describing the commodity.
     Note(String),
+    /// An unrecognised sub-directive with an optional value.
     Unknown(String, Option<String>),
 }
 
+/// A single key/value item inside an `account` directive block.
 #[derive(Clone, Debug)]
 pub enum AccountItem {
+    /// An alternative name for this account (`alias <name>`).
     Alias(String),
+    /// A free-form note describing the account.
     Note(String),
+    /// An unrecognised sub-directive with an optional value.
     Unknown(String, Option<String>),
 }
 
+/// A parsed date, with an optional year.
+///
+/// Ledger's grammar always requires a four-digit year, but this struct
+/// keeps it `Option<i32>` so the parser can represent partially-specified
+/// dates uniformly. The [`crate::resolution`] stage rejects dates where
+/// no year can be determined.
 #[derive(Clone, Default, Debug)]
 pub struct Date {
+    /// The calendar year, e.g. `2024`. `None` if not present in the source.
     pub year: Option<i32>,
+    /// Month of the year (1–12).
     pub month: u32,
+    /// Day of the month (1–31).
     pub date: u32,
 }
 
@@ -68,14 +116,27 @@ impl From<NaiveDate> for Date {
     }
 }
 
+/// A double-entry accounting transaction as it appears in the source.
+///
+/// Amounts in the postings are unevaluated [`ValueExpr`] trees; the
+/// [`crate::elaboration`] stage evaluates them and ensures the transaction
+/// balances.
 #[derive(Clone, Default, Debug)]
 pub struct Transaction {
+    /// The primary (effective) date.
     pub date: Date,
+    /// An optional secondary date (`date=secondary_date`), used for the
+    /// "date the transaction was actually processed" semantics.
     pub secondary_date: Option<Date>,
+    /// Cleared (`*`), pending (`!`), or uncleared (no marker).
     pub state: TransactionState,
+    /// An optional reference code in parentheses, e.g. `(INV-42)`.
     pub code: Option<String>,
+    /// The payee / description text following the header date and state.
     pub description: String,
+    /// Lines starting with `;` in the transaction header (before postings).
     pub notes: Vec<String>,
+    /// The individual account postings that make up this transaction.
     pub postings: Vec<Posting>,
 }
 
@@ -118,15 +179,22 @@ impl Display for Transaction {
     }
 }
 
+/// A single posting (debit or credit line) within a transaction.
 #[derive(Clone, Default, Debug)]
 pub struct Posting {
+    /// The account name, e.g. `"Expenses:Food"`.
     pub account: String,
+    /// The amount, or `None` if this is a "null posting" whose value should
+    /// be inferred by the elaboration stage as the negation of all others.
     pub amount: Option<AmountDetails>,
+    /// Per-posting cleared/pending state (overrides the transaction state).
     pub state: TransactionState,
+    /// Lines starting with `;` indented beneath the posting line.
     pub notes: Vec<String>,
 }
 
 impl Posting {
+    /// Creates a new posting for `account` with no amount and no notes.
     pub fn new<S: Into<String>>(account: S) -> Self {
         Self {
             account: account.into(),
@@ -136,11 +204,13 @@ impl Posting {
         }
     }
 
+    /// Appends a note to this posting (builder pattern).
     pub fn with_note<S: Into<String>>(mut self, note: S) -> Self {
         self.notes.push(note.into());
         self
     }
 
+    /// Sets the amount for this posting (builder pattern).
     pub fn with_amount<A: Into<AmountDetails>>(mut self, amount: A) -> Self {
         self.amount = Some(amount.into());
         self
@@ -170,13 +240,24 @@ impl Display for Posting {
     }
 }
 
+/// The amount field of a posting, in one of two forms.
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub enum AmountDetails {
+    /// A standard amount expression, with optional lot pricing and/or a
+    /// balance assertion.
+    ///
+    /// Example: `10 AAPL @ $150 = $1500`
     Amount {
+        /// The value expression (may be arithmetic, e.g. `(100 + 50) USD`).
         value: ValueExpr,
+        /// Cost basis: `@ price_per_unit` or `@@ total_cost`.
         lot_pricing: Option<LotPricing>,
+        /// If present, the account balance after this posting must equal this
+        /// value (`= expected_balance`).
         balance_assertion: Option<ValueExpr>,
     },
+    /// A balance assignment: `= target_balance`, with no explicit debit/credit
+    /// value. The posting amount is computed as `target - current_balance`.
     BalanceAssignment(ValueExpr),
 }
 
@@ -265,34 +346,67 @@ impl Display for ValueExpr {
     }
 }
 
+/// An unevaluated value expression, produced by the parser and consumed by
+/// the elaboration stage.
+///
+/// The variants cover all syntactic forms that can appear in a posting amount:
+/// numeric literals, string literals, arithmetic, function calls, and
+/// commodity type annotations.
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub enum ValueExpr {
+    /// A key-value object, used as the return type of the `account()` function.
+    /// Fields are accessed with the [`ValueExpr::Access`] form.
     Object(BTreeMap<String, Self>),
+
+    /// A numeric amount with an optional commodity.
+    ///
+    /// `commodity: None` means the commodity is not yet known; the elaboration
+    /// stage fills it in from the context's default commodity.
     Amount {
         value: Decimal,
         commodity: Option<String>,
     },
-    // For things like: (1 + 2) USD
+
+    /// A prefix unary operator applied to a sub-expression.
+    ///
+    /// Only `+` and `-` are meaningful on amounts; `*` and `/` produce an
+    /// [`EvaluationError`](crate::elaboration::EvaluationError).
     Unary {
         op: Op,
         expr: Box<ValueExpr>,
     },
+
+    /// An infix binary operator applied to two sub-expressions.
     Binary {
         lhs: Box<ValueExpr>,
         rhs: Box<ValueExpr>,
         op: Op,
     },
+
+    /// A function call, e.g. `account("Assets:Bank")` or `scrub(100 USD)`.
     Function {
         name: String,
         args: Vec<ValueExpr>,
     },
-    // For commodities that stand alone or are part of a math group
+
+    /// A bare commodity symbol that appears without an adjacent number,
+    /// e.g. in `$-123` the `$` is parsed as a `Commodity` and `123` as
+    /// `Amount { value: 123, commodity: None }`, with `-` as a `Binary { op: Sub }`
+    /// between them. This special form is resolved in the evaluator.
     Commodity(String),
+
+    /// A type annotation wrapping a parenthesised expression: `(expr) USD`.
+    /// The elaboration stage verifies that the inner expression's commodity
+    /// is compatible with the annotation.
     Typed {
         expr: Box<ValueExpr>,
         commodity: String,
     },
+
+    /// A string literal (double-quoted).
     Str(String),
+
+    /// Field access on an object expression: `account("Foo").total`.
     Access {
         expr: Box<ValueExpr>,
         field: String,
@@ -300,6 +414,7 @@ pub enum ValueExpr {
 }
 
 impl ValueExpr {
+    /// Convenience constructor for an amount with a known commodity.
     pub fn amount(value: Decimal, commodity: String) -> ValueExpr {
         ValueExpr::Amount {
             value,
@@ -314,6 +429,7 @@ impl<S: Into<String>> From<(Decimal, S)> for ValueExpr {
     }
 }
 
+/// Arithmetic operator used in [`ValueExpr::Binary`] and [`ValueExpr::Unary`].
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub enum Op {
     Add,
@@ -322,16 +438,23 @@ pub enum Op {
     Div,
 }
 
+/// The cost-basis annotation on a posting amount.
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub enum LotPricing {
+    /// Per-unit price: `@ price`. The total cost is `amount * price`.
     Unit(ValueExpr),
+    /// Total price: `@@ total`. The total cost is taken as-is.
     Total(ValueExpr),
 }
 
+/// Cleared/pending state of a transaction or individual posting.
 #[derive(Clone, Debug, Default)]
 pub enum TransactionState {
+    /// No state marker — the transaction has not been reviewed.
     #[default]
     Uncleared,
+    /// `!` — the transaction is pending confirmation.
     Pending,
+    /// `*` — the transaction has been confirmed/reconciled.
     Cleared,
 }

--- a/src/bin/timings.rs
+++ b/src/bin/timings.rs
@@ -1,30 +1,54 @@
+//! Pipeline timing tool for per-stage performance profiling.
+//!
+//! Usage: `timings <source.ledger>`
+//!
+//! Runs each compilation stage in sequence and prints the wall-clock time
+//! spent in each stage to stderr. The final stage serialises to
+//! [`std::io::sink`] (discarding output) so that disk I/O does not
+//! inflate the serialisation time.
+//!
+//! This tool is useful for identifying which stage dominates compile time
+//! for a given ledger file, particularly when tuning the parser or evaluator.
+
 use std::{fs::File, io::{Read as _, Write as _}, path::PathBuf, time::Instant};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let source = PathBuf::from(std::env::args().nth(1).expect("usage: timings <source>"));
 
+    // --- read ---
+    // Measure raw file I/O separately so that parse time is not inflated by
+    // disk latency on the first run (cold page cache).
     let t0 = Instant::now();
     let base_path = source.parent().unwrap().to_path_buf();
     let mut parser = ledger::parser::Parser {
-        openner: ledger::file_openner,
+        opener: ledger::file_opener,
         base_path,
     };
     let mut file = String::new();
     File::open(&source)?.read_to_string(&mut file)?;
     eprintln!("read:        {:>8.3}s", t0.elapsed().as_secs_f64());
 
+    // --- parse ---
+    // PEG tokenisation and construction of the ast::Journal.
     let t1 = Instant::now();
     let ast = parser.parse(&file)?;
     eprintln!("parse:       {:>8.3}s", t1.elapsed().as_secs_f64());
 
+    // --- resolution ---
+    // Date normalisation, alias indexing, metadata extraction.
     let t2 = Instant::now();
     let hir: ledger::resolution::HIR = ast.try_into()?;
     eprintln!("resolution:  {:>8.3}s", t2.elapsed().as_secs_f64());
 
+    // --- elaboration ---
+    // Expression evaluation, transaction balancing, account registration.
     let t3 = Instant::now();
     let journal: ledger::elaboration::Journal = hir.try_into()?;
     eprintln!("elaboration: {:>8.3}s", t3.elapsed().as_secs_f64());
 
+    // --- serialize ---
+    // Postcard serialisation to a no-op sink. BufWriter batches postcard's
+    // many small writes so that sink overhead does not distort the measurement.
     let t4 = Instant::now();
     let mut output = std::io::BufWriter::new(std::io::sink());
     postcard::to_io(&journal, &mut output)?;

--- a/src/elaboration.rs
+++ b/src/elaboration.rs
@@ -1,3 +1,30 @@
+//! Elaboration stage: evaluate expressions, balance transactions, and
+//! produce the final serialisable [`Journal`].
+//!
+//! This stage converts a [`resolution::HIR`] into an [`elaboration::Journal`]
+//! by performing the following work:
+//!
+//! - **Expression evaluation** — [`ast::ValueExpr`] trees are evaluated to
+//!   concrete `(Decimal, commodity)` pairs by the [`evaluator`] submodule.
+//!   Commodity aliases from the active [`resolution::Context`] are applied.
+//!
+//! - **Transaction balancing** — if a transaction has exactly one posting with
+//!   no explicit amount (a "null posting"), its amount is inferred as the
+//!   negation of all other postings' sum. If all postings have amounts their
+//!   sum must be zero; otherwise [`ElaborationError::TransactionDoesNotBalance`]
+//!   is returned.
+//!
+//! - **Balance assertions / assignments** — `= expected` checks are verified
+//!   against the running account balance. `= target` assignments set the
+//!   posting amount to `target − current_balance`.
+//!
+//! - **Lot pricing** — `@ unit` and `@@ total` cost annotations are converted
+//!   into a cash amount in the lot's commodity for the purpose of balancing.
+//!
+//! - **Account registration** — every account mentioned in a posting is added
+//!   to [`Journal::accounts`], merging any properties declared in `account`
+//!   directives.
+
 use std::{collections::BTreeMap, fmt::Display};
 
 use rust_decimal::Decimal;
@@ -8,58 +35,113 @@ use crate::{
     resolution,
 };
 
+/// The fully elaborated journal: the final output of the compilation pipeline.
+///
+/// `Journal` implements [`serde::Serialize`] and [`serde::Deserialize`] so it
+/// can be written to a `.bki` file (via `postcard` + XZ) and read back later
+/// without re-parsing the source.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Journal {
+    /// All transactions in source order, with amounts fully evaluated.
     pub transactions: Vec<ResolvedTransaction>,
+    /// All accounts referenced by any posting, with their declared properties.
     pub accounts: BTreeMap<String, AccountProperties>,
 }
 
+/// Properties of an account declared with an `account` directive.
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct AccountProperties {
+    /// A free-form note describing the account.
     pub note: Option<String>,
 }
 
+/// Per-account running balance, used during elaboration to evaluate balance
+/// assertions and the `account()` expression function.
 #[derive(Default, Clone, Debug)]
 struct AccountBalances {
+    /// The balance for each commodity held in this account.
     commodity: BTreeMap<String, Decimal>,
 }
 
+/// Mutable state threaded through the elaboration of all transactions.
+///
+/// Account balances are updated as each transaction is processed so that
+/// balance assertions and the `account()` function see the balance *before*
+/// the current posting is applied (which matches ledger-cli semantics).
 #[derive(Default, Clone, Debug)]
 struct RunningState {
     account_balances: BTreeMap<String, AccountBalances>,
 }
 
+/// A fully evaluated and balanced transaction, ready for serialisation.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ResolvedTransaction {
+    /// Days since the Unix epoch (1970-01-01 = 0).
+    ///
+    /// Stored as `i32` rather than a `NaiveDate` because `i32` serialises
+    /// compactly with postcard (4 bytes, fixed-width), is trivially sortable,
+    /// and avoids embedding chrono's internal representation in the on-disk
+    /// format.
     pub date: i32,
+    /// Optional secondary date in the same epoch-days format.
     pub secondary_date: Option<i32>,
+    /// Cleared / pending / uncleared state.
     pub state: TransactionState,
+    /// Optional reference code from the transaction header.
     pub code: Option<String>,
+    /// The payee / description.
     pub description: String,
+    /// Tags extracted from header notes.
     pub tags: Vec<String>,
+    /// Key-value metadata extracted from header notes.
     pub metadata: BTreeMap<String, String>,
+    /// The resolved postings (all amounts concrete, null posting filled in).
     pub postings: Vec<ResolvedPosting>,
 }
 
+/// A posting with a fully evaluated, concrete amount.
 #[derive(Deserialize, Serialize, Debug)]
 pub struct ResolvedPosting {
+    /// The canonical account name (after alias resolution).
     pub account: String,
+    /// The payee for this posting — taken from posting-level `payee:` metadata
+    /// if present, otherwise inherited from the transaction description.
     pub payee: String,
+    /// The posting amount, keyed by commodity.
     pub amount: Amount,
+    /// Per-posting state.
     pub state: TransactionState,
+    /// Tags extracted from posting notes.
     pub tags: Vec<String>,
+    /// Key-value metadata from posting notes.
     pub metadata: BTreeMap<String, String>,
 }
 
+/// A commodity name (e.g. `"USD"`, `"BTC"`, `"$"`).
 pub type Commodity = String;
 
+/// A multi-commodity amount stored as a map from commodity to serialised decimal.
+///
+/// Each value is `[u8; 16]` — the binary representation produced by
+/// [`rust_decimal::Decimal::serialize`]. Using fixed-size byte arrays instead of
+/// `Decimal` directly lets the struct derive `serde::Serialize`/`Deserialize`
+/// via postcard without needing a custom codec, while preserving exact decimal
+/// precision (no floating-point rounding).
 #[derive(Deserialize, Default, Serialize, Debug)]
 pub struct Amount(pub BTreeMap<Commodity, [u8; 16]>);
 
+/// Cleared/pending state of a resolved transaction or posting.
+///
+/// This is a separate type from [`ast::TransactionState`] because it derives
+/// `Serialize`/`Deserialize` for the on-disk format; `ast::TransactionState`
+/// does not need those traits.
 #[derive(Deserialize, Serialize, Debug)]
 pub enum TransactionState {
+    /// No state marker.
     Uncleared,
+    /// `!` — pending confirmation.
     Pending,
+    /// `*` — confirmed / reconciled.
     Cleared,
 }
 
@@ -73,25 +155,47 @@ impl From<ast::TransactionState> for TransactionState {
     }
 }
 
+/// Errors that can occur during the elaboration stage.
 #[derive(Debug)]
 pub enum ElaborationError {
+    /// A posting amount evaluated to a bare number with no commodity, and no
+    /// default commodity was set in the active context.
     AmountWithNoCommodity,
+    /// A value expression evaluated to a non-amount type (e.g. a string or
+    /// object) where an amount was expected.
     NonAmountWhereAmountExpected(ValueExpr),
+    /// An error from the expression evaluator.
     EvaluationError(EvaluationError),
+    /// A `= expected` balance assertion failed: the account's balance after
+    /// this posting does not equal the asserted value.
     PostingBalanceAssertionFailed,
+    /// A transaction has more than one null posting (only one is allowed, since
+    /// multiple unknowns cannot be uniquely determined).
     TooManyNullPostings,
+    /// All postings have explicit amounts but they do not sum to zero.
     TransactionDoesNotBalance(Amount),
 }
 
+/// Errors from evaluating a [`ast::ValueExpr`].
 #[derive(Debug)]
 pub enum EvaluationError {
+    /// `*` or `/` used as a unary prefix operator, which is not meaningful.
     UnaryMultiplyOrDivide,
+    /// A unary operator was applied to a non-amount value (e.g. a string).
     UnaryOnNonAmount(ValueExpr),
+    /// A binary operator was applied to incompatible types or mismatched
+    /// commodities (e.g. `USD + EUR`).
     BinaryOperationTypeError((ValueExpr, ValueExpr, crate::ast::Op)),
+    /// Field access on an object referenced a field that does not exist.
     NoSuchField(String),
+    /// Field access was attempted on a non-object value.
     FieldAccessTypeError(ValueExpr),
+    /// A function call with unrecognised name or argument count.
     UnknownFunctionArgs((String, Vec<ValueExpr>)),
+    /// A `Typed` annotation specified a commodity that is incompatible with
+    /// the inner expression's commodity.
     TypedCommodityToIncompatibleAmount((String, ValueExpr)),
+    /// A function received an argument of the wrong type.
     InvalidFunctionArgs((String, ValueExpr)),
 }
 
@@ -117,8 +221,9 @@ impl TryFrom<resolution::HIR> for Journal {
 
         let mut transactions = vec![];
 
+        // Pre-populate the accounts map from directives so that accounts
+        // declared with notes but never posted to still appear in the output.
         let mut accounts = BTreeMap::new();
-
         for (name, properties) in value.global_context.account_properties {
             accounts.insert(
                 name,
@@ -132,14 +237,25 @@ impl TryFrom<resolution::HIR> for Journal {
             let entry_context = &value.contexts[entry.context_id];
             match entry.data {
                 resolution::Entry::Transaction(mut transaction) => {
+                    // `transaction_state` accumulates the running sum of all
+                    // explicit posting amounts (per commodity) for balancing.
                     let mut transaction_state = Amount(BTreeMap::default());
 
+                    // Prefer an explicit "payee:" metadata key; fall back to
+                    // the transaction description as the default payee.
                     let payee = transaction
                         .metadata
                         .remove("payee")
                         .unwrap_or_else(|| transaction.description.clone());
+
+                    // Two-pass approach: first evaluate all postings that have
+                    // explicit amounts, accumulating the running sum. Null
+                    // postings are collected for the second pass, where the
+                    // single allowed null posting is filled in as the negation
+                    // of the total.
                     let mut null_postings = vec![];
                     let mut resolved_postings = vec![];
+
                     for mut posting in transaction.postings {
                         if let Some(amount) = posting.amount {
                             let account_name = entry_context
@@ -166,12 +282,15 @@ impl TryFrom<resolution::HIR> for Journal {
                                                 entry_context,
                                                 &state,
                                             )?;
+                                            // For a negative lot (selling), negate the cash total
+                                            // so that it offsets correctly in transaction_state.
                                             if value.is_sign_negative() {
                                                 v = -v;
                                             }
                                             Some((v, c))
                                         }
                                         Some(ast::LotPricing::Unit(expr)) => {
+                                            // "@ unit_price" — total cash = units * price
                                             let (v, c) = evaluator::eval_and_normalize_amount(
                                                 expr,
                                                 entry_context,
@@ -188,6 +307,10 @@ impl TryFrom<resolution::HIR> for Journal {
                                                 entry_context,
                                                 &state,
                                             )?;
+                                        // Assertion: current_balance + this_posting == expected.
+                                        // The assertion is checked BEFORE the posting updates the
+                                        // running state, so `account_balance` reflects the balance
+                                        // *before* this posting — consistent with ledger-cli.
                                         if !(bacommodity == commodity
                                             && account_balance
                                                 .and_then(|ab| ab.commodity.get(&commodity))
@@ -201,6 +324,8 @@ impl TryFrom<resolution::HIR> for Journal {
                                     (value, commodity, lot_pricing)
                                 }
                                 AmountDetails::BalanceAssignment(assignment) => {
+                                    // "= target_balance" — compute the delta needed to reach the
+                                    // target from the current running balance.
                                     let (newsum, commodity) = evaluator::eval_and_normalize_amount(
                                         assignment,
                                         entry_context,
@@ -215,6 +340,9 @@ impl TryFrom<resolution::HIR> for Journal {
                             };
                             let payee = posting.metadata.remove("payee").unwrap_or(payee.clone());
 
+                            // For lot-priced postings, add the *cash* total (in the lot's
+                            // commodity) to transaction_state rather than the commodity units.
+                            // This is what needs to balance with the offsetting cash posting.
                             if let Some((lot_total, lot_commodity)) = lot_pricing {
                                 let decb = transaction_state.0.entry(lot_commodity).or_default();
                                 let dec = Decimal::deserialize(*decb) + lot_total;
@@ -253,6 +381,8 @@ impl TryFrom<resolution::HIR> for Journal {
                             .unwrap_or(posting.account);
                         let payee = posting.metadata.remove("payee").unwrap_or(payee.clone());
 
+                        // The null posting's amount is the negation of the sum of all
+                        // other postings, making the transaction balance to zero.
                         let amount = Amount(
                             transaction_state
                                 .0
@@ -282,7 +412,7 @@ impl TryFrom<resolution::HIR> for Journal {
                         }
                     }
 
-                    // Finally, update account balances and names
+                    // Update running account balances and register new accounts.
                     for posting in resolved_postings.iter() {
                         if !accounts.contains_key(&posting.account) {
                             accounts.insert(posting.account.clone(), Default::default());
@@ -321,6 +451,7 @@ impl TryFrom<resolution::HIR> for Journal {
     }
 }
 
+/// Expression evaluator: reduces [`ast::ValueExpr`] trees to concrete values.
 mod evaluator {
     use std::collections::BTreeMap;
 
@@ -333,6 +464,12 @@ mod evaluator {
 
     use super::{ElaborationError, EvaluationError, RunningState};
 
+    /// Evaluate a value expression and extract the `(Decimal, commodity)` pair.
+    ///
+    /// After evaluation, commodity aliases from `eval_context` are applied so
+    /// that e.g. `"Bitcoin"` becomes `"BTC"`. If the result still has no
+    /// commodity, the context's `default_commodity` is used. Returns an error
+    /// if the result is not an amount or no commodity can be determined.
     pub fn eval_and_normalize_amount(
         val: ast::ValueExpr,
         eval_context: &resolution::Context,
@@ -341,12 +478,14 @@ mod evaluator {
         match eval(val, eval_context, running_state)? {
             ast::ValueExpr::Amount { value, commodity } => {
                 let commodity = if let Some(commodity) = commodity {
+                    // Apply commodity alias (e.g. "Bitcoin" → "BTC")
                     eval_context
                         .commodity_aliases
                         .get(&commodity)
                         .unwrap_or(&commodity)
                         .clone()
                 } else {
+                    // No commodity in the expression — use the context default
                     eval_context
                         .default_commodity
                         .clone()
@@ -358,15 +497,22 @@ mod evaluator {
         }
     }
 
+    /// Recursively evaluate a [`ast::ValueExpr`] to a simpler form.
+    ///
+    /// The evaluator reduces arithmetic, applies unary operators, resolves
+    /// function calls, and handles type annotations. It does not resolve
+    /// commodity aliases — that is done by `eval_and_normalize_amount`.
     fn eval(
         val: ast::ValueExpr,
         eval_context: &resolution::Context,
         state: &RunningState,
     ) -> Result<ast::ValueExpr, EvaluationError> {
         match val {
+            // Base cases: already-reduced values pass through unchanged.
             a @ ast::ValueExpr::Amount { .. } => Ok(a),
             s @ ast::ValueExpr::Str(_) => Ok(s),
             o @ ast::ValueExpr::Object(_) => Ok(o),
+
             ast::ValueExpr::Unary { op, expr } => match eval(*expr, eval_context, state)? {
                 ast::ValueExpr::Amount { value, commodity } => match op {
                     ast::Op::Sub => Ok(ast::ValueExpr::Amount {
@@ -374,15 +520,20 @@ mod evaluator {
                         commodity,
                     }),
                     ast::Op::Add => Ok(ast::ValueExpr::Amount { value, commodity }),
+                    // Unary * and / are not defined for amounts.
                     _ => Err(EvaluationError::UnaryMultiplyOrDivide),
                 },
                 val => Err(EvaluationError::UnaryOnNonAmount(val)),
             },
+
             ast::ValueExpr::Binary { lhs, rhs, op } => {
                 match (
                     eval(*lhs, eval_context, state)?,
                     eval(*rhs, eval_context, state)?,
                 ) {
+                    // One side has a commodity, the other is dimensionless —
+                    // the commodity propagates to the result. Both match arms
+                    // handle the two orderings (commodity first or second).
                     (
                         ast::ValueExpr::Amount {
                             value: v1,
@@ -420,6 +571,8 @@ mod evaluator {
                             commodity: c,
                         },
                     }),
+
+                    // Both sides have the same commodity — straightforward arithmetic.
                     (
                         ast::ValueExpr::Amount {
                             value: v1,
@@ -447,7 +600,11 @@ mod evaluator {
                             commodity: c,
                         },
                     }),
-                    // Case where someone wrote "-$123" or "$-123"
+
+                    // Special case: "$-123" parses as Commodity("$") sub Amount(123, None).
+                    // The grammar sees the minus sign as a binary subtraction between the
+                    // currency symbol and the following number because of how prefix_op and
+                    // the amount rule interact. We handle it by treating Sub as negation.
                     (
                         ast::ValueExpr::Commodity(commodity),
                         ast::ValueExpr::Amount {
@@ -472,11 +629,19 @@ mod evaluator {
                         }),
                         _ => Err(EvaluationError::UnaryMultiplyOrDivide),
                     },
+
                     (a, b) => Err(EvaluationError::BinaryOperationTypeError((a, b, op))),
                 }
             }
+
             ast::ValueExpr::Function { name, args } => match (name.as_str(), args.as_slice()) {
+                // scrub(x) — identity function used by some ledger-cli extensions
+                // to mark amounts as "scrubbed" (processed). Treated as a no-op.
                 ("scrub", [arg]) => eval(arg.clone(), eval_context, state),
+
+                // account("Name") — returns an object with a "total" field
+                // containing the current running balance of the named account.
+                // Only the primary commodity ($) is currently surfaced.
                 ("account", [account]) => {
                     if let ValueExpr::Str(account) = eval(account.clone(), eval_context, state)? {
                         let account = eval_context
@@ -505,11 +670,16 @@ mod evaluator {
                 }
                 _ => Err(EvaluationError::UnknownFunctionArgs((name, args))),
             },
+
+            // A bare commodity symbol — returned as-is; the Binary handler
+            // above resolves it when combined with an adjacent number.
             c @ ast::ValueExpr::Commodity(_) => Ok(c),
+
             ast::ValueExpr::Typed {
                 expr,
                 commodity: new_commodity,
             } => match eval(*expr, eval_context, state)? {
+                // Accept if the inner expression has no commodity or the same commodity.
                 ast::ValueExpr::Amount { value, commodity }
                     if commodity.is_none() || commodity.as_ref() == Some(&new_commodity) =>
                 {
@@ -523,6 +693,7 @@ mod evaluator {
                     a,
                 ))),
             },
+
             ast::ValueExpr::Access { expr, field } => match eval(*expr, eval_context, state)? {
                 ast::ValueExpr::Object(map) => map
                     .get(&field)

--- a/src/ledger.pest
+++ b/src/ledger.pest
@@ -1,6 +1,28 @@
+// ============================================================
+// ledger.pest — PEG grammar for the Ledger plain-text accounting format
+//
+// Parsing is handled by pest (https://pest.rs/). This file defines the
+// *structure* of the source language. Operator precedence for value
+// expressions is NOT encoded here — it is applied by a Pratt parser in
+// parser.rs after the grammar has produced a flat token stream.
+//
+// Rule naming conventions (pest):
+//   UPPERCASE  — built-in rules (NEWLINE, EOI, ANY, ASCII_DIGIT, …)
+//   _{ … }    — silent rule: matched but not included in the pair tree
+//   @{ … }    — atomic rule: inner tokens are NOT individually paired
+//   ${ … }    — compound-atomic: inner named rules ARE paired, but
+//               implicit whitespace skipping is disabled
+// ============================================================
+
 // --- Top Level ---
+
+// The entire file is a sequence of entries separated by blank lines.
+// A compound-atomic ($) root rule is used so that leading/trailing
+// whitespace is preserved exactly as written in the source.
 journal = ${ (entry | NEWLINE)* ~ EOI }
 
+// An entry is one of: transaction, directive, comment, or budget.
+// Silent (_) so the match is transparent — callers see the inner rule.
 entry = _{
     transaction
     | directive
@@ -9,16 +31,24 @@ entry = _{
 }
 
 // --- Transactions ---
+
+// A transaction is a header line followed by zero or more postings/notes.
+// The compound-atomic modifier ($) is critical: it prevents the grammar
+// from silently swallowing the indentation that separates postings.
 transaction = ${
     header ~ NEWLINE ~
     (transaction_note | posting | empty_indented_line)*
 }
 
+// Budget entries (e.g. "~ monthly ...") share the same posting structure
+// but are not yet elaborated by the compiler.
 budget = ${
     "~" ~ ws+ ~ ("yearly" | "monthly" | "weekly") ~ NEWLINE ~
     (transaction_note | posting | empty_indented_line)*
 }
 
+// The header line: date, optional secondary date, state, code, description,
+// and an optional trailing note.
 header = ${
     date ~ (ws* ~ "=" ~ ws* ~ date)?
     ~ (ws+ ~ state)?
@@ -27,17 +57,33 @@ header = ${
     ~ (ws* ~ note)?
 }
 
+// A note line that is part of the transaction header (indented, starts with ;)
 transaction_note = ${ indent+ ~ note ~ (NEWLINE | EOI) }
+
+// A blank indented line allowed between postings — consumed silently.
 empty_indented_line = _{ indent+ ~ NEWLINE }
 
 // --- Postings ---
+
+// A posting is an indented account name, optionally followed by an amount
+// and/or a trailing note, plus zero or more indented note lines.
+//
+// The !NEWLINE lookahead prevents a truly empty indented line from being
+// matched as a posting with an empty account name.
 posting = ${
     indent+ ~ !NEWLINE ~ (state ~ ws+)? ~ account ~ (amount_logic)? ~ (ws* ~ note)? ~ (NEWLINE | EOI) ~
     posting_note*
 }
 
+// A note line indented beneath a posting.
 posting_note = ${ indent+ ~ note ~ (NEWLINE | EOI) }
 
+// The amount field of a posting.
+//
+// Two or more spaces (or a tab) are REQUIRED before the amount. This is the
+// canonical Ledger convention: it unambiguously separates the account name
+// from the amount, since account names may contain single spaces (e.g.
+// "Equity:Opening Balances").
 amount_logic = ${
     (ws{2,} | "\t") ~ (
         value_logic
@@ -45,28 +91,59 @@ amount_logic = ${
     )
 }
 
+// A value expression, optionally followed by lot pricing and/or a balance
+// assertion check.
 value_logic = ${ value_expr ~ (ws* ~ lot_price)? ~ (ws* ~ assertion)? }
 
+// A balance check or balance assignment: `= target` or `== target`.
+// Used in two ways within `amount_logic`:
+//   - After `value_logic`: a post-posting balance assertion (becomes `balance_assertion`
+//     in `AmountDetails::Amount`).
+//   - Standalone (no preceding amount): parsed by the parser as
+//     `AmountDetails::BalanceAssignment`; the posting amount is inferred to bring
+//     the account to the target balance.
 assertion = ${ "="{1, 2} ~ ws* ~ value_expr }
 
 // --- Atoms ---
+
+// A full date: YYYY/MM/DD or YYYY-MM-DD. The four-digit year is mandatory.
 date = ${ year ~ ("/" | "-") ~ monthdate ~ ("/" | "-") ~ monthdate }
 year = @{ ASCII_DIGIT{4} }
 monthdate = @{ ASCII_DIGIT{1,2} }
+
+// Cleared (*) or pending (!) state marker.
 state = { "*" | "!" }
+
+// An optional reference code in parentheses, e.g. "(INV-042)".
 code = { "(" ~ (!")" ~ ANY)* ~ ")" }
+
+// Everything after the header fields up to a semicolon or newline.
 description = { (!(";" | NEWLINE) ~ ANY)* }
+
+// An account name: any characters that are not a double-space, semicolon,
+// tab, equals sign, or newline. The double-space exclusion is what
+// makes the "two-space rule" for amounts work — the account name stops
+// as soon as two consecutive spaces are encountered.
 account = @{ (!("  " | ";" | "\t" | "=" | NEWLINE) ~ ANY)+ }
 
+// Lot pricing: "@ unit_price" or "@@ total_price".
 lot_price = ${ ("@@" | "@") ~ ws* ~ value_expr }
 
+// Whitespace helpers (silent — not included in the pair tree).
 indent = _{ " " | "\t" }
 ws = _{ " " | "\t" }
 
+// A semicolon-prefixed note. The note_str captures everything up to EOL.
 note = ${ ";" ~ note_str }
 note_str = ${ (!NEWLINE ~ ANY)* }
+
+// A full-line comment. Ledger accepts several comment characters.
 comment_line = @{ (";" | "#" | "*" | "%" | "|") ~ (!NEWLINE ~ ANY)* }
+
 // --- Directives ---
+
+// The optional leading "!" is allowed by some Ledger implementations.
+// define and tag directives are parsed but not yet elaborated.
 directive = _{ "!"? ~ (commodity_directive | account_directive | alias_directive | include_directive | define_directive | tag_directive ) }
 
 tag_directive = ${
@@ -74,6 +151,8 @@ tag_directive = ${
     (indent+ ~ (!NEWLINE ~ ANY )* ~ (NEWLINE | EOI))*
 }
 
+// A commodity block: declares properties such as aliases, display format,
+// and whether market prices are tracked.
 commodity_directive = ${
     "commodity" ~ ws+ ~ commodity ~ (ws* ~ note)? ~ NEWLINE ~
     ((indent+ ~ note ~ NEWLINE) | commodity_item)*
@@ -83,9 +162,11 @@ commodity_item = ${
     indent+ ~ commodity_key ~ (ws+ ~ commodity_val)? ~ (ws* ~ note)? ~ (NEWLINE | EOI)
 }
 
+// Known commodity keys are enumerated first; anything else is "identifier".
 commodity_key = @{ "alias" | "format" | "nomarket" | "default" | identifier }
 commodity_val = @{ (!NEWLINE ~ ANY)* }
 
+// An account block: declares an account and its properties (alias, note).
 account_directive = ${
     "account" ~ ws+ ~ account ~ (ws* ~ note)? ~ NEWLINE ~
     ((indent+ ~ note ~ NEWLINE) | account_item)*
@@ -97,19 +178,35 @@ account_item = ${
 account_key = @{ "note" | "alias" | identifier }
 account_val = @{ (!NEWLINE ~ ANY)* }
 
+// A top-level "alias short = long" shorthand for account names.
 alias_directive = ${ "alias" ~ ws+ ~ account ~ ws* ~ "=" ~ ws* ~ account ~ (ws+ ~ note)? ~ (NEWLINE | EOI) }
 
+// Consumed but not elaborated.
 define_directive = @{ "define" ~ ws+ ~ (!NEWLINE ~ ANY)* ~ (NEWLINE | EOI) }
 
+// Include another file by path (glob patterns are resolved in parser.rs).
 include_directive = ${ "include" ~ ws+ ~ filename ~ (NEWLINE | EOI) }
 filename = @{ (!NEWLINE ~ ANY)+ }
 
 // --- Expressions (Explicit Whitespace) ---
+//
+// These rules define the *syntax* of value expressions. Operator PRECEDENCE
+// is NOT handled here — the grammar produces a flat left-to-right token
+// stream that is then processed by a Pratt parser in parser.rs, which
+// applies the correct precedence (* and / bind tighter than + and -).
+
+// A value_expr is an expression optionally followed by a commodity annotation.
+// The trailing commodity form "(1 + 2) USD" creates a ValueExpr::Typed node.
 value_expr = ${ expr ~ (ws+ ~ commodity)? }
 
+// An expression is one or more terms joined by infix operators.
 expr = ${ term ~ (ws* ~ infix_op ~ ws* ~ term)* }
 
+// A term is an optional prefix operator followed by a primary atom.
 term = ${ (prefix_op ~ ws*)? ~ primary }
+
+// A primary is a base atom optionally followed by dot-access chains.
+// base_primary is silent, so the parser sees the child rule directly.
 primary = { base_primary ~ access* }
 
 base_primary = _{
@@ -120,33 +217,49 @@ base_primary = _{
     | commodity
 }
 
+// A dot-accessor: ".fieldname"
 access = ${ "." ~ identifier }
 
+// A double-quoted string literal.
 // Atomic string: matches anything between double quotes
 string = ${ "\"" ~ (!"\"" ~ ANY)* ~ "\"" }
 
+// A function call: name(arg1, arg2, …). Arguments are full expr trees.
 function_call = ${ identifier ~ ws* ~ "(" ~ ws* ~ (expr ~ (ws* ~ "," ~ ws* ~ expr)*)? ~ ws* ~ ")" }
 
+// An amount literal: commodity-prefixed, number-first, or bare number.
+//   "$100"      — symbol before number (no space required)
+//   "100 USD"   — identifier commodity after number (space required)
+//   "100"       — bare number (commodity filled in from context later)
 amount = ${
     (commodity ~ ws* ~ number)
     | (number ~ ws+ ~ commodity)
     | number
 }
 
+// Numbers may use comma thousands-separators ("1,234.56") or start with a
+// decimal point (".5"). Commas are stripped in parser.rs before parsing.
 // Comma followed by 3 digits to distinguish from function arguments
 number = @{
     ASCII_DIGIT+ ~ ("," ~ ASCII_DIGIT{3})* ~ ("." ~ ASCII_DIGIT+)?
     | "." ~ ASCII_DIGIT+
 }
 
+// A commodity is either one or more currency symbols ($, €, £, ¥) or
+// an identifier-style name (USD, BTC, AAPL, …).
 commodity = @{
     symbol+
     | (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_" | "." | ":" | "#")*
 }
 
+// Currency symbols treated as single-character commodities.
 symbol = _{ "$" | "€" | "£" | "¥" }
+
+// A plain identifier: letter or underscore, then alphanumeric or underscore.
 identifier = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 
+// Infix and prefix operators. These rules are named (not silent) so that
+// the Pratt parser in parser.rs can match on their Rule variants.
 // Operators must be visible to Pratt
 infix_op = _{ add | sub | mul | div }
     add = { "+" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,31 @@
+//! ledger-rs — a compiler and query library for the Ledger plain-text
+//! accounting format.
+//!
+//! # Pipeline
+//!
+//! Source text is processed through four stages:
+//!
+//! ```text
+//! source text
+//!   → [parser]      ast::Journal        (PEG grammar + Pratt expressions)
+//!   → [resolution]  resolution::HIR     (dates, aliases, metadata)
+//!   → [elaboration] elaboration::Journal (evaluation, balancing)
+//!   → serialisation                     (postcard + XZ → .bki)
+//! ```
+//!
+//! The top-level entry point is [`compile`], which runs all three in-memory
+//! stages and returns the elaborated [`Journal`]. For CLI usage see the
+//! `ledger` binary in `src/main.rs`.
+//!
+//! # Modules
+//!
+//! - [`ast`] — abstract syntax tree produced by the parser.
+//! - [`parser`] — pest-based parser and `include` directive handling.
+//! - [`resolution`] — alias resolution, date normalisation, metadata
+//!   extraction.
+//! - [`elaboration`] — expression evaluation, transaction balancing, and the
+//!   final serialisable [`Journal`] type.
+
 pub mod ast;
 pub mod elaboration;
 pub mod parser;
@@ -5,7 +33,15 @@ pub mod resolution;
 
 pub use elaboration::Journal;
 
-pub fn file_openner(pattern: &str) -> String {
+/// Load and concatenate all files matching a glob pattern.
+///
+/// This is the default file-opener used by the CLI when processing `include`
+/// directives. Multiple files matched by a single glob (e.g.
+/// `include accounts/*.ledger`) are concatenated in the order that
+/// [`glob::glob`] returns them (lexicographic on most platforms).
+///
+/// Panics if the pattern is invalid or a matched path cannot be read.
+pub fn file_opener(pattern: &str) -> String {
     use std::io::Read as _;
 
     let mut buf = String::new();
@@ -18,6 +54,23 @@ pub fn file_openner(pattern: &str) -> String {
     buf
 }
 
+/// Compile Ledger source text into a fully elaborated [`Journal`].
+///
+/// Runs the three in-memory pipeline stages in sequence:
+///
+/// 1. [`parser::Parser::parse`] — tokenise `input` into an [`ast::Journal`].
+/// 2. [`resolution::HIR::try_from`] — resolve dates, aliases, and metadata.
+/// 3. [`elaboration::Journal::try_from`] — evaluate amounts and balance
+///    transactions.
+///
+/// The `parser` argument supplies the file-opener for `include` directives and
+/// the base path for relative path resolution. For single-file inputs without
+/// includes, use [`parser::parse_ledger`] instead.
+///
+/// # Errors
+///
+/// Returns a boxed error from the first failing stage (parse error, resolution
+/// error, or elaboration error).
 pub fn compile<F>(
     input: &String,
     mut parser: parser::Parser<F>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,31 +12,58 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// does testing things
+    /// Parse and compile a ledger source file into a binary `.bki` archive.
+    ///
+    /// The output is a postcard-serialised, XZ-compressed snapshot of the
+    /// elaborated journal. Loading a `.bki` file is much faster than
+    /// re-parsing the source, making it suitable for large ledgers that are
+    /// queried repeatedly.
     Compile {
-        /// lists test values
+        /// Path for the output `.bki` file.
         #[arg(short, long)]
         output: PathBuf,
+        /// Path to the root `.ledger` source file (may use `include`).
         source: PathBuf,
     },
+
+    /// Print the running balance for every account.
+    ///
+    /// Accepts either a raw `.ledger` source file or a pre-compiled `.bki`
+    /// file. Output is formatted with the commodity and value right-aligned,
+    /// followed by the account name.
     Balance {
         source: PathBuf,
     },
+
+    /// List individual postings, optionally filtered by account name.
+    ///
+    /// `PATTERN` is matched case-insensitively as a substring of the account
+    /// name. Omit it to list all postings.
     Register {
         source: PathBuf,
         pattern: Option<String>,
     },
 }
 
+/// Load a [`ledger::Journal`] from either a compiled `.bki` file or a raw
+/// `.ledger` source file.
+///
+/// The file type is detected by extension:
+/// - `.bki` — decompress with XZ and deserialise with postcard.
+/// - anything else — parse as Ledger source text, resolving `include`
+///   directives relative to the file's parent directory.
 fn load_journal(path: &PathBuf) -> Result<ledger::Journal, Box<dyn std::error::Error>> {
     if let Some("bki") = path.extension().and_then(|e| e.to_str()) {
+        // Pre-compiled binary format: decompress then deserialise.
+        // The 100 KiB scratch buffer is required by postcard's `from_io` API;
+        // it does not limit the total data read.
         let input_xz = xz::read::XzDecoder::new(File::open(path)?);
         let mut buf = vec![0; 102400];
         Ok(postcard::from_io((input_xz, &mut buf))?.0)
     } else {
         let base_path = path.parent().unwrap().to_path_buf();
         let parser = ledger::parser::Parser {
-            openner: ledger::file_openner,
+            opener: ledger::file_opener,
             base_path,
         };
         let mut file = String::new();
@@ -52,7 +79,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Commands::Compile { output, source } => {
             let base_path = source.parent().unwrap().to_path_buf();
             let parser = ledger::parser::Parser {
-                openner: ledger::file_openner,
+                opener: ledger::file_opener,
                 base_path,
             };
             let mut file = String::new();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,3 +1,18 @@
+//! Parsing stage: convert raw Ledger source text into an [`ast::Journal`].
+//!
+//! This module has two layers:
+//!
+//! 1. **[`LedgerParser`]** — a `pest`-derived parser that tokenises source
+//!    text according to the grammar in `ledger.pest`.
+//! 2. **[`Parser<F>`]** — the public API that wraps `LedgerParser`, walks
+//!    the pair tree, handles `include` directives recursively, and builds
+//!    the [`ast::Journal`].
+//!
+//! Amount expressions (see [`ast::ValueExpr`]) are parsed using a **Pratt
+//! parser** ([`PRATT_PARSER`]) to apply operator precedence: `*` and `/`
+//! bind tighter than `+` and `-`. The grammar itself treats the token
+//! sequence as flat — precedence is applied as a post-processing step.
+
 use crate::ast::*;
 use pest::Parser as _;
 use pest::iterators::{Pair, Pairs};
@@ -7,16 +22,38 @@ use rust_decimal::Decimal;
 use std::path::PathBuf;
 use std::sync::LazyLock; // Or once_cell
 
+/// The raw pest parser generated from `ledger.pest` via `pest_derive`.
+///
+/// This type is only used internally by [`Parser<F>::parse`]. Callers
+/// should use [`Parser`] or the convenience function [`parse_ledger`].
 #[derive(Parser)]
 #[grammar = "ledger.pest"]
 pub struct LedgerParser;
 
+/// A stateful parser that resolves `include` directives.
+///
+/// The generic parameter `F` is the file-opener: a callable that accepts a
+/// file-system path (potentially a glob pattern) and returns its contents as
+/// a `String`. This design makes the parser testable without touching the
+/// file system — pass `|_| String::new()` for a no-op opener.
 pub struct Parser<F: Fn(&str) -> String> {
-    pub openner: F,
+    /// Called with an absolute path (or glob pattern) to load included files.
+    /// The path passed in may contain glob wildcards when the source uses
+    /// `include path/to/*.ledger`.
+    pub opener: F,
+    /// The directory of the file currently being parsed. Used to resolve
+    /// relative paths in `include` directives.
     pub base_path: PathBuf,
 }
 
 impl<F: Fn(&str) -> String> Parser<F> {
+    /// Parse `input` (Ledger-format source text) into an [`ast::Journal`].
+    ///
+    /// `include` directives are expanded inline: the included file's entries
+    /// are inserted at the position of the directive in the parent journal.
+    /// The `base_path` and `opener` fields are used to locate included files.
+    ///
+    /// Returns a `pest` parse error if the source is syntactically invalid.
     pub fn parse(&mut self, input: &str) -> Result<Journal, pest::error::Error<Rule>> {
         let pairs = LedgerParser::parse(Rule::journal, input)?;
         let mut entries = Vec::new();
@@ -39,14 +76,21 @@ impl<F: Fn(&str) -> String> Parser<F> {
                     entries.push(Entry::Directive(parse_alias_directive(pair)));
                 }
                 Rule::include_directive => {
+                    // Join the included path with the current base directory so
+                    // relative paths (e.g. "include accounts/*.ledger") work
+                    // regardless of the process working directory.
                     let include_path = self.base_path.join(pair.into_inner().as_str());
-                    let new_input = (self.openner)(include_path.as_os_str().to_str().unwrap());
+                    let new_input = (self.opener)(include_path.as_os_str().to_str().unwrap());
+                    // Temporarily update base_path to the included file's directory
+                    // so that any further includes within it are resolved correctly.
                     let new_base_path = include_path
                         .parent()
                         .map(|p| self.base_path.join(p))
                         .unwrap_or(self.base_path.clone());
                     let old_base_path = std::mem::replace(&mut self.base_path, new_base_path);
                     entries.append(&mut self.parse(&new_input)?.entries);
+                    // Restore the original base_path for subsequent entries in
+                    // the parent file.
                     let _ = std::mem::replace(&mut self.base_path, old_base_path);
                 }
                 _ => {}
@@ -57,9 +101,13 @@ impl<F: Fn(&str) -> String> Parser<F> {
     }
 }
 
+/// Convenience function: parse Ledger source with no `include` support.
+///
+/// Useful in tests and benchmarks where a self-contained string is parsed
+/// and no file I/O is needed.
 pub fn parse_ledger(input: &str) -> Result<Journal, pest::error::Error<Rule>> {
     Parser {
-        openner: |_| String::new(),
+        opener: |_| String::new(),
         base_path: PathBuf::new(),
     }
     .parse(input)
@@ -268,6 +316,8 @@ fn parse_amount_logic(pair: Pair<Rule>) -> AmountDetails {
                         value = Some(parse_expr(p));
                     }
                     Rule::lot_price => {
+                        // Inspect the raw text to distinguish "@" from "@@"
+                        // before descending into the inner value_expr.
                         let s = p.as_str();
                         let inner_val = parse_expr(p.into_inner().next().unwrap());
                         if s.starts_with("@@") {
@@ -298,6 +348,12 @@ fn parse_amount_logic(pair: Pair<Rule>) -> AmountDetails {
     }
 }
 
+// The Pratt parser is constructed once at program start via LazyLock.
+//
+// Building a PrattParser allocates and organises a precedence table.
+// Since this is called for every value expression in every posting, and
+// the table never changes, it is far cheaper to build it once and share
+// the reference across all calls than to rebuild it on each invocation.
 static PRATT_PARSER: LazyLock<PrattParser<Rule>> = LazyLock::new(|| {
     use Rule::*;
     use pest::pratt_parser::{Assoc::*, Op};
@@ -308,6 +364,14 @@ static PRATT_PARSER: LazyLock<PrattParser<Rule>> = LazyLock::new(|| {
         .op(Op::prefix(prefix_op))
 });
 
+/// Parse a `value_expr` pair into a [`ValueExpr`] AST node.
+///
+/// The grammar's `value_expr` rule is `expr (ws+ commodity)?`. The Pratt
+/// parser handles the `expr` part (operator precedence), and then we check
+/// for a trailing commodity annotation *after* Pratt parsing completes.
+/// This two-step approach is necessary because the trailing commodity is
+/// outside the `expr` rule and therefore invisible to the Pratt parser —
+/// it needs to be lifted into a `ValueExpr::Typed` wrapper here.
 fn parse_expr(pair: Pair<Rule>) -> ValueExpr {
     let mut inner = pair.into_inner();
     let expr_pair = inner.next().expect("Empty value_expr");
@@ -329,15 +393,18 @@ fn run_pratt(pairs: pest::iterators::Pairs<Rule>) -> ValueExpr {
             Rule::term => run_pratt(pair.into_inner()),
             Rule::primary => {
                 let mut inner = pair.into_inner();
-                // Get the base atom (Amount, Function, String, etc.)
-                // Note: base_primary is silent, so we get its child directly
+                // base_primary is a silent rule, so its child arrives directly
+                // as the first item in `inner`. We re-enter run_pratt for the
+                // base atom so that all the match arms below can be reused.
                 let base_pair = inner.next().expect("Primary must have a base");
 
-                // Recursively parse the base using run_pratt
-                // We wrap it in a single-item iterator to reuse our logic
+                // Wrap base_pair in a single-item Pairs so we can pass it to
+                // run_pratt, which expects a Pairs iterator.
                 let mut ast = run_pratt(pest::iterators::Pairs::single(base_pair));
 
-                // 3. Fold any dot-accessors into the AST
+                // Fold dot-access chains left-to-right into nested Access nodes.
+                // Iterative rather than recursive because chains are arbitrary
+                // length and we want left-associativity without stack growth.
                 for access in inner {
                     if access.as_rule() == Rule::access {
                         let field = access.into_inner().next().unwrap().as_str().to_string();
@@ -353,6 +420,7 @@ fn run_pratt(pairs: pest::iterators::Pairs<Rule>) -> ValueExpr {
                 let mut inner = pair.into_inner();
                 let first = inner.next().unwrap();
                 match first.as_rule() {
+                    // Prefix-commodity form: "$100" — commodity comes first
                     Rule::commodity => {
                         let comm = first.as_str().to_string();
                         let val_str = inner.next().unwrap().as_str();
@@ -361,6 +429,7 @@ fn run_pratt(pairs: pest::iterators::Pairs<Rule>) -> ValueExpr {
                             commodity: Some(comm),
                         }
                     }
+                    // Number-first form: "100 USD" or bare "100"
                     Rule::number => {
                         let val = clean_parse_decimal(first.as_str());
                         let comm = inner.next().map(|c| c.as_str().to_string());
@@ -376,7 +445,8 @@ fn run_pratt(pairs: pest::iterators::Pairs<Rule>) -> ValueExpr {
             Rule::function_call => {
                 let mut inner = pair.into_inner();
                 let name = inner.next().unwrap().as_str().to_string();
-                // Function args are Rule::expr. run_pratt handles Rule::expr pairs.
+                // Each argument is a full `expr` — recurse via run_pratt so
+                // arithmetic inside function arguments is also parsed correctly.
                 let args = inner.map(|p| run_pratt(p.into_inner())).collect();
                 ValueExpr::Function { name, args }
             }
@@ -409,6 +479,12 @@ fn run_pratt(pairs: pest::iterators::Pairs<Rule>) -> ValueExpr {
         .parse(pairs)
 }
 
+/// Parse a decimal number, stripping comma thousand-separators first.
+///
+/// The Ledger format allows numbers like `1,234.56`. Rust's `Decimal::parse`
+/// does not accept commas, so we remove them before parsing. Falls back to
+/// zero if parsing still fails (which should not happen for well-formed grammar
+/// output, but avoids a panic in error paths).
 fn clean_parse_decimal(s: &str) -> Decimal {
     let cleaned = s.replace(',', "");
     cleaned.parse().unwrap_or(Decimal::ZERO)

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -1,13 +1,48 @@
+//! Resolution stage: convert an [`ast::Journal`] into the Higher-level
+//! Intermediate Representation ([`HIR`]).
+//!
+//! This stage performs three things:
+//!
+//! 1. **Date resolution** — partial dates (missing year) are rejected unless
+//!    a fallback year is available. Dates are converted to [`chrono::NaiveDate`].
+//!
+//! 2. **Alias indexing** — `commodity` and `account` directives that introduce
+//!    aliases (or set a default commodity) are accumulated into a versioned
+//!    [`Context`] stack. Each transaction records which context was active when
+//!    it appeared in the source; the [`crate::elaboration`] stage uses this to
+//!    resolve aliases at evaluation time.
+//!
+//! 3. **Metadata extraction** — freeform note strings attached to transactions
+//!    and postings are parsed for structured data: `:tag:` syntax yields tags,
+//!    and `key: value` syntax yields metadata key-value pairs.
+//!
+//! Amount expressions ([`ast::ValueExpr`]) are passed through untouched; they
+//! are evaluated in the elaboration stage.
+
 use std::collections::BTreeMap;
 
 use chrono::NaiveDate;
 
 use crate::ast;
 
+/// The Higher-level Intermediate Representation produced by the resolution stage.
+///
+/// All entries retain their source-order position. Each [`ResolutionEntry`]
+/// carries a `context_id` that indexes into [`HIR::contexts`], recording which
+/// alias/default state was active for that entry.
 #[derive(Debug)]
 pub struct HIR {
+    /// Transactions and other entries in source order.
     pub entries: Vec<ResolutionEntry>,
+    /// Versioned snapshots of the alias/default-commodity state.
+    ///
+    /// A new [`Context`] is pushed every time a directive changes the alias
+    /// table or default commodity. Entries that preceded the change continue to
+    /// reference the earlier context by index — the contexts vector is
+    /// append-only so old indices remain valid.
     pub contexts: Vec<Context>,
+    /// Global commodity and account properties that are not context-sensitive
+    /// (format strings, `nomarket` flags, notes).
     pub global_context: GlobalContext,
 }
 
@@ -15,73 +50,126 @@ impl Default for HIR {
     fn default() -> Self {
         Self {
             entries: vec![],
+            // Start with one empty context so context_id 0 is always valid.
             contexts: vec![Context::default()],
             global_context: Default::default(),
         }
     }
 }
 
+/// A snapshot of alias and default-commodity state at a point in the file.
+///
+/// Contexts form an immutable history: when a directive changes the state a
+/// *new* `Context` is pushed rather than mutating the existing one. This means
+/// each transaction can reference the context that was active when it was
+/// defined — important because an alias that appears *after* a transaction
+/// must not retroactively affect that transaction's interpretation.
 #[derive(Default, Debug, Clone)]
 pub struct Context {
+    /// Maps short account names to their canonical equivalents.
     pub account_aliases: BTreeMap<String, String>,
+    /// Maps alternative commodity symbols to their canonical names.
     pub commodity_aliases: BTreeMap<String, String>,
+    /// The commodity assumed when a posting amount has no explicit commodity.
     pub default_commodity: Option<String>,
 }
 
+/// Global properties of commodities and accounts that are shared across all
+/// contexts (i.e. not invalidated by later directives).
 #[derive(Default, Debug)]
 pub struct GlobalContext {
+    /// Properties declared in `commodity` directives.
     pub commodity_properties: BTreeMap<String, CommodityProperties>,
+    /// Properties declared in `account` directives.
     pub account_properties: BTreeMap<String, AccountProperties>,
 }
 
+/// Display and market-data properties of a commodity.
 #[derive(Default, Debug)]
 pub struct CommodityProperties {
+    /// A display format string (e.g. `"1,000.00 USD"`).
     pub format: Option<String>,
+    /// If `true`, this commodity is not tracked against market prices.
     pub no_market: bool,
+    /// A free-form note describing the commodity.
     pub note: Option<String>,
 }
 
+/// Properties of an account declared with an `account` directive.
 #[derive(Default, Debug)]
 pub struct AccountProperties {
+    /// A free-form note describing the account.
     pub note: Option<String>,
 }
 
+/// A single entry in the resolved journal, paired with its active context.
 #[derive(Debug)]
 pub struct ResolutionEntry {
+    /// Index into [`HIR::contexts`]. The context at this index is the one that
+    /// was active when this entry appeared in the source file.
     pub context_id: usize, // index into `Journal#contexts`
+    /// The resolved entry data.
     pub data: Entry,
 }
 
+/// A resolved journal entry.
 #[derive(Debug)]
 pub enum Entry {
+    /// A double-entry transaction with resolved dates and extracted metadata.
     Transaction(Transaction),
+    /// A price directive (not yet elaborated; placeholder).
     Price(()),
+    /// A balance assertion directive (not yet elaborated; placeholder).
     Assertion(()),
 }
 
+/// A transaction with fully resolved dates, tags, and metadata.
+///
+/// Amount expressions are still in unevaluated [`ast::AmountDetails`] form;
+/// they are evaluated in the elaboration stage.
 #[derive(Debug)]
 pub struct Transaction {
+    /// The primary (effective) date, resolved to a full calendar date.
     pub date: NaiveDate,
+    /// Optional secondary (processing) date.
     pub secondary_date: Option<NaiveDate>,
+    /// Cleared / pending / uncleared state.
     pub state: ast::TransactionState,
+    /// Optional reference code from the header.
     pub code: Option<String>,
+    /// The payee / description line.
     pub description: String,
+    /// Tags extracted from header notes using the `:tag:` convention.
     pub tags: Vec<String>,
+    /// Structured key-value metadata extracted from header notes.
     pub metadata: BTreeMap<String, String>,
+    /// The postings belonging to this transaction.
     pub postings: Vec<Posting>,
 }
 
+/// A posting with extracted tags and metadata.
+///
+/// The `amount` field is still an unevaluated [`ast::AmountDetails`] tree.
 #[derive(Debug)]
 pub struct Posting {
+    /// The account name as written in the source (not yet alias-resolved).
     pub account: String,
+    /// The unevaluated amount, or `None` for a null posting.
     pub amount: Option<ast::AmountDetails>,
+    /// Per-posting state.
     pub state: ast::TransactionState,
+    /// Tags extracted from posting notes.
     pub tags: Vec<String>,
+    /// Key-value metadata extracted from posting notes.
     pub metadata: BTreeMap<String, String>,
 }
 
+/// Errors that can occur during the resolution stage.
 #[derive(Debug)]
 pub enum ResolutionError {
+    /// A date could not be resolved: either the year was absent and no
+    /// fallback was available, or the resulting calendar date is invalid
+    /// (e.g. February 30).
     InvalidDate,
 }
 
@@ -98,6 +186,11 @@ impl std::fmt::Display for ResolutionError {
 impl std::error::Error for ResolutionError {}
 
 impl HIR {
+    /// Resolve an [`ast::Date`] to a [`NaiveDate`].
+    ///
+    /// If `ast.year` is `None`, `fallback_year` is used instead. Returns
+    /// `Err(ResolutionError::InvalidDate)` if no year is available or if the
+    /// resulting date does not exist in the calendar (e.g. Feb 30).
     fn resolve_date(
         ast: &ast::Date,
         fallback_year: Option<i32>,
@@ -110,6 +203,16 @@ impl HIR {
             .ok_or(ResolutionError::InvalidDate)
     }
 
+    /// Parse tags and key-value metadata out of a list of note strings.
+    ///
+    /// Ledger supports two structured note conventions:
+    ///
+    /// - **Tags**: a note of the form `:tag1:tag2:` (colon-enclosed, colon-
+    ///   separated) produces individual tag strings `["tag1", "tag2"]`.
+    /// - **Metadata**: a note of the form `key: value` produces a key-value
+    ///   pair `("key", "value")`.
+    ///
+    /// Notes that match neither pattern are silently discarded.
     fn resolve_metadata(notes: Vec<String>) -> (Vec<String>, BTreeMap<String, String>) {
         let mut tags: Vec<String> = vec![];
         let mut metadata: BTreeMap<String, String> = Default::default();
@@ -119,12 +222,15 @@ impl HIR {
             if let Some(note) = note.strip_prefix(":")
                 && let Some(note) = note.strip_suffix(":")
             {
+                // ":tag1:tag2:" — split on ":" to get individual tags
                 for tag in note.split(":") {
                     tags.push(tag.into());
                 }
             } else if let Some((key, value)) = note.split_once(":") {
+                // "key: value" — insert as metadata
                 metadata.insert(key.trim().into(), value.trim().into());
             }
+            // Plain comments are discarded
         }
         (tags, metadata)
     }
@@ -140,12 +246,18 @@ impl TryFrom<ast::Journal> for HIR {
         let mut current_default_year = None;
 
         for entry in ast.entries {
+            // `new_context` accumulates changes from directives in this entry.
+            // If any directive modifies the context, a new Context is pushed at
+            // the end of the loop iteration, and subsequent entries reference it.
             let mut new_context: Option<Context> = None;
+
+            // The current context is whichever was most recently pushed.
             let context_id = result.contexts.len() - 1; // always at least zero;
             let context = &result.contexts[context_id];
+
             match entry {
                 ast::Entry::Directive(ast::Directive::Unknown(_)) | ast::Entry::Comment(_) => {
-                    // Discard
+                    // Discard unrecognised directives and comments.
                 }
                 ast::Entry::Directive(ast::Directive::Commodity {
                     name,
@@ -160,6 +272,9 @@ impl TryFrom<ast::Journal> for HIR {
                     for item in items {
                         match item {
                             ast::CommodityItem::Alias(alias) => {
+                                // Clone the current context before mutating so
+                                // entries that precede this directive keep their
+                                // original view of aliases.
                                 new_context = Some(new_context.unwrap_or_else(|| context.clone()))
                                     .map(|mut ctx| {
                                         ctx.commodity_aliases.insert(alias, name.clone());
@@ -261,6 +376,8 @@ impl TryFrom<ast::Journal> for HIR {
                 }
             }
 
+            // If any directive modified the alias/default state, push a new
+            // context version so subsequent entries see the updated aliases.
             if let Some(new_context) = new_context {
                 result.contexts.push(new_context);
             }


### PR DESCRIPTION
## Summary

- Adds `README.md` with project overview, build/usage instructions, CLI examples, and a pipeline architecture diagram
- Adds rustdoc (`///` / `//!`) to every public and private type, function, struct, and module across all source files
- Adds inline `//` comments explaining non-trivial or non-obvious implementation choices
- Annotates `ledger.pest` with explanatory comments covering grammar conventions and design decisions

## Commits

Each commit is a self-contained, independently reviewable unit:

1. `README.md` — overview, usage, pipeline diagram
2. `src/ast.rs` — rustdoc for all AST types and variants
3. `src/ledger.pest` — grammar comments (rule conventions, two-space rule, Pratt parser boundary)
4. `src/parser.rs` — rustdoc + inline comments (LazyLock Pratt, trailing-commodity handling, include resolution)
5. `src/resolution.rs` — rustdoc + inline comments (context versioning design, metadata extraction, date fallback)
6. `src/elaboration.rs` — rustdoc + inline comments (`[u8;16]` decimals, two-pass balancing, lot pricing, `$-123` quirk)
7. `src/lib.rs`, `src/main.rs`, `src/bin/timings.rs` — rustdoc for public API, CLI commands, and timing stages

## Test plan

- [ ] `cargo build` — no compilation errors introduced by doc changes
- [ ] `cargo test` — all existing tests pass
- [ ] `cargo doc --no-deps` — all public items render without warnings