### PR TITLE
Remove dead Price(()) and Assertion(()) stubs from resolution::Entry

### DIFF
--- a/src/elaboration.rs
+++ b/src/elaboration.rs
@@ -456,8 +456,6 @@ impl TryFrom<resolution::HIR> for Journal {
                         postings: resolved_postings,
                     });
                 }
-                resolution::Entry::Price(()) => todo!(),
-                resolution::Entry::Assertion(()) => todo!(),
             }
         }
 

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -136,10 +136,6 @@ pub struct ResolutionEntry {
 pub enum Entry {
     /// A double-entry transaction with resolved dates and extracted metadata.
     Transaction(Transaction),
-    /// A price directive (not yet elaborated; placeholder).
-    Price(()),
-    /// A balance assertion directive (not yet elaborated; placeholder).
-    Assertion(()),
 }
 
 /// A transaction with fully resolved dates, tags, and metadata.
@@ -691,7 +687,7 @@ mod resolution_tests {
         let journal = ast::Journal { entries: vec![ast::Entry::Transaction(txn_ast)] };
         let hir = HIR::try_from(journal).unwrap();
 
-        let Entry::Transaction(ref txn) = hir.entries[0].data else { panic!() };
+        let Entry::Transaction(ref txn) = hir.entries[0].data;
         assert_eq!(txn.comments, vec!["just a note"]);
         assert_eq!(txn.metadata.get("Invoice").unwrap(), "42");
         assert_eq!(txn.tags, vec!["groceries"]);


### PR DESCRIPTION
Closes #11

## Summary

- Removes the `Price(())` variant from `resolution::Entry`. This variant was unreachable: price directives were moved to `HIR::prices` in a prior PR (#9) and no parse path produced an `Entry::Price` value.
- Removes the `Assertion(())` variant from `resolution::Entry`. This placeholder was never wired to a parse path and had no implementation.
- Removes the corresponding `todo!()` match arms from `elaboration.rs` that guarded both variants.
- Fixes the now-irrefutable `let...else` pattern in the resolution test that matched on the (now sole) `Entry::Transaction` variant.

A properly typed `Assertion` variant will be introduced when standalone balance-assertion directives (`!`) are implemented.

## Test plan

- [ ] `cargo test --lib` passes with no warnings (33 tests)