### PR TITLE
Add print subcommand to emit journal as canonical Ledger source

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,17 @@ enum Commands {
         source: PathBuf,
         pattern: Option<String>,
     },
+
+    /// Re-emit the journal as canonical Ledger source text.
+    ///
+    /// Parses and resolves the source file, then prints each transaction in
+    /// canonical Ledger format. Only `.ledger` source files are accepted;
+    /// pre-compiled `.bki` files do not preserve the original transaction
+    /// structure needed for faithful re-emission.
+    Print {
+        /// Path to the root `.ledger` source file.
+        source: PathBuf,
+    },
 }
 
 /// Load a [`ledger::Journal`] from either a compiled `.bki` file or a raw
@@ -104,6 +115,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             posting.amount.0.get("$").unwrap()
                         );
                     }
+                }
+            }
+        }
+        Commands::Print { source } => {
+            if let Some("bki") = source.extension().and_then(|e| e.to_str()) {
+                return Err(
+                    "print only works with .ledger source files; \
+                     .bki binary archives do not preserve the original transaction structure"
+                        .into(),
+                );
+            }
+            let base_path = source.parent().unwrap().to_path_buf();
+            let mut parser = ledger::parser::Parser {
+                opener: ledger::file_opener,
+                base_path,
+            };
+            let mut file = String::new();
+            File::open(&source)?.read_to_string(&mut file)?;
+            let ast_journal: ledger::ast::Journal = parser.parse(&file)?;
+            let hir: ledger::resolution::HIR = ast_journal.try_into()?;
+            for entry in hir.entries {
+                if let ledger::resolution::Entry::Transaction(txn) = entry.data {
+                    println!("{txn}");
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Adds a `print` subcommand that parses a `.ledger` source file, resolves it to HIR (stopping before elaboration), and prints each transaction as canonical Ledger source text.
- Leverages the `resolution::Transaction: Display` impl introduced in PR #8 — no new formatting logic needed.
- Rejects `.bki` binary archives with a clear error message, since they don't preserve the original transaction structure.

Closes #19

## Test plan

- [ ] `cargo build` passes with no warnings
- [ ] `cargo test --lib` — all 33 tests pass
- [ ] Manual smoke test: `ledger print <file.ledger>` prints transactions in valid Ledger format
- [ ] Manual error test: `ledger print <file.bki>` returns a helpful error message