### PR TITLE
Document budget entries (~) as intentionally out of scope

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -96,6 +96,12 @@ impl<F: Fn(&str) -> String> Parser<F> {
                     // the parent file.
                     let _ = std::mem::replace(&mut self.base_path, old_base_path);
                 }
+                Rule::budget => {
+                    // Budget entries (`~ monthly ...`) are intentionally not
+                    // modelled in this implementation. They represent
+                    // planned/expected amounts in ledger-cli but have no effect
+                    // on balances or reports. See GitHub issue #13.
+                }
                 _ => {}
             }
         }


### PR DESCRIPTION
## Summary

- Budget entries (`~ monthly ...`) are recognised by the grammar but were silently dropped in the parser via the catch-all `_ => {}` arm — easy to mistake for a missing feature.
- Adds an explicit `Rule::budget` arm with a comment explaining the design decision: budget entries have no effect on balances or reports and are out of scope for this implementation.
- No functional change; all existing tests pass.

Closes #13.