### PR TITLE
Implement define directives as named value aliases

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -81,6 +81,16 @@ pub enum Directive {
         /// The full account name it expands to.
         account: String,
     },
+    /// A `define name = expr` named value alias.
+    ///
+    /// After this directive, any occurrence of `name` in a value expression
+    /// is substituted with the stored `expr` during elaboration.
+    Define {
+        /// The alias name (a plain identifier).
+        name: String,
+        /// The value expression the name expands to.
+        expr: ValueExpr,
+    },
 }
 
 /// A single key/value item inside a `commodity` directive block.

--- a/src/elaboration.rs
+++ b/src/elaboration.rs
@@ -721,9 +721,17 @@ mod evaluator {
                 _ => Err(EvaluationError::UnknownFunctionArgs((name, args))),
             },
 
-            // A bare commodity symbol — returned as-is; the Binary handler
-            // above resolves it when combined with an adjacent number.
-            c @ ast::ValueExpr::Commodity(_) => Ok(c),
+            // A bare commodity symbol or identifier. If the name matches a
+            // `define` alias in the active context, substitute and re-evaluate
+            // the stored expression. Otherwise return the Commodity as-is;
+            // the Binary handler above resolves it when paired with a number.
+            ast::ValueExpr::Commodity(ref name) => {
+                if let Some(defined_expr) = eval_context.defines.get(name.as_str()) {
+                    eval(defined_expr.clone(), eval_context, state)
+                } else {
+                    Ok(val)
+                }
+            }
 
             ast::ValueExpr::Typed {
                 expr,
@@ -832,5 +840,114 @@ mod tests {
         assert_eq!(price.commodity, "AAPL");
         assert_eq!(price.price, rust_decimal::Decimal::from(182));
         assert_eq!(price.price_commodity, "$");
+    }
+
+    /// Parse a ledger journal string through the full pipeline and return the
+    /// elaborated `Journal`. Panics on any parse/resolution/elaboration error.
+    fn elaborate(input: &str) -> Journal {
+        use crate::{parser::parse_ledger, resolution::HIR};
+        let ast = parse_ledger(input).expect("parse failed");
+        let hir = HIR::try_from(ast).expect("resolution failed");
+        Journal::try_from(hir).expect("elaboration failed")
+    }
+
+    #[test]
+    fn test_define_simple_amount_alias() {
+        // `monthly_rent` is defined as $1500.00 and used in a posting amount.
+        let input = "\
+define monthly_rent = $1500.00
+
+2024-01-01 Rent Payment
+    Expenses:Rent  monthly_rent
+    Assets:Checking
+";
+        let journal = elaborate(input);
+        assert_eq!(journal.transactions.len(), 1);
+        let tx = &journal.transactions[0];
+        // The Expenses:Rent posting should have $1500.00
+        let rent_posting = tx.postings.iter().find(|p| p.account == "Expenses:Rent").unwrap();
+        assert_eq!(
+            rent_posting.amount.0.get("$").copied(),
+            Some(dec!(1500.00)),
+            "define alias should expand to $1500.00"
+        );
+        // Assets:Checking should be the balancing null posting: -$1500.00
+        let checking_posting =
+            tx.postings.iter().find(|p| p.account == "Assets:Checking").unwrap();
+        assert_eq!(
+            checking_posting.amount.0.get("$").copied(),
+            Some(dec!(-1500.00)),
+            "balancing posting should be -$1500.00"
+        );
+    }
+
+    #[test]
+    fn test_define_used_in_arithmetic_expression() {
+        // Aliases can appear inside arithmetic: `2 * base_amount`.
+        let input = "\
+define base_amount = 100 USD
+
+2024-02-01 Double Amount
+    Expenses:Food  2 * base_amount
+    Assets:Cash
+";
+        // The expression `2 * base_amount` becomes `2 * 100 USD` = `200 USD`.
+        // Note: `base_amount` parses as Commodity("base_amount"); after define
+        // substitution it becomes Amount{100, Some("USD")}.
+        // `2` parses as Amount{2, None}. Mul of (None, USD) → 200 USD.
+        let journal = elaborate(input);
+        let tx = &journal.transactions[0];
+        let food = tx.postings.iter().find(|p| p.account == "Expenses:Food").unwrap();
+        assert_eq!(
+            food.amount.0.get("USD").copied(),
+            Some(dec!(200)),
+            "2 * define alias should expand to 200 USD"
+        );
+    }
+
+    #[test]
+    fn test_define_does_not_affect_earlier_transactions() {
+        // A define directive must not retroactively affect transactions that
+        // appeared before it in the source file.
+        //
+        // We test this by parsing a transaction where `myval` is NOT yet
+        // defined — it should be treated as a bare commodity rather than an
+        // alias, causing an evaluation error (non-amount commodity alone does
+        // not balance). The transaction after the define succeeds.
+        //
+        // Actually: a bare Commodity alone won't resolve to an amount, so the
+        // first transaction would fail to elaborate. Instead, use an explicit
+        // amount for the first transaction and verify the define is only in
+        // context 1 via the HIR, not context 0.
+        use crate::{parser::parse_ledger, resolution::HIR};
+
+        let input = "\
+2024-01-01 Before Define
+    Expenses:A  $10.00
+    Assets:Cash
+
+define myval = $99.00
+
+2024-01-02 After Define
+    Expenses:B  myval
+    Assets:Cash
+";
+        let ast = parse_ledger(input).expect("parse failed");
+        let hir = HIR::try_from(ast).expect("resolution failed");
+
+        // There should be 2 contexts (0 = initial, 1 = after define).
+        assert_eq!(hir.contexts.len(), 2);
+        // First transaction references context 0 — no defines.
+        assert_eq!(hir.entries[0].context_id, 0);
+        assert!(hir.contexts[0].defines.is_empty());
+        // Second transaction references context 1 — has the define.
+        assert_eq!(hir.entries[1].context_id, 1);
+        assert!(hir.contexts[1].defines.contains_key("myval"));
+
+        // Elaboration should succeed end-to-end.
+        let journal = Journal::try_from(hir).expect("elaboration failed");
+        let after_tx = &journal.transactions[1];
+        let b_posting = after_tx.postings.iter().find(|p| p.account == "Expenses:B").unwrap();
+        assert_eq!(b_posting.amount.0.get("$").copied(), Some(dec!(99.00)));
     }
 }

--- a/src/ledger.pest
+++ b/src/ledger.pest
@@ -192,8 +192,9 @@ account_val = @{ (!NEWLINE ~ ANY)* }
 // A top-level "alias short = long" shorthand for account names.
 alias_directive = ${ "alias" ~ ws+ ~ account ~ ws* ~ "=" ~ ws* ~ account ~ (ws+ ~ note)? ~ (NEWLINE | EOI) }
 
-// Consumed but not elaborated.
-define_directive = @{ "define" ~ ws+ ~ (!NEWLINE ~ ANY)* ~ (NEWLINE | EOI) }
+// A define directive: "define name = expr"
+// Associates a name with a value expression usable in posting amounts.
+define_directive = ${ "define" ~ ws+ ~ identifier ~ ws* ~ "=" ~ ws* ~ value_expr ~ (NEWLINE | EOI) }
 
 // Include another file by path (glob patterns are resolved in parser.rs).
 include_directive = ${ "include" ~ ws+ ~ filename ~ (NEWLINE | EOI) }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -75,6 +75,9 @@ impl<F: Fn(&str) -> String> Parser<F> {
                 Rule::alias_directive => {
                     entries.push(Entry::Directive(parse_alias_directive(pair)));
                 }
+                Rule::define_directive => {
+                    entries.push(Entry::Directive(parse_define_directive(pair)));
+                }
                 Rule::historical_price => {
                     entries.push(Entry::HistoricalPrice(parse_historical_price(pair)));
                 }
@@ -151,6 +154,15 @@ fn parse_alias_directive(pair: Pair<Rule>) -> Directive {
     let alias = pairs.next().unwrap().as_str().trim().to_string();
     let account = pairs.next().unwrap().as_str().trim().to_string();
     Directive::Alias { alias, account }
+}
+
+fn parse_define_directive(pair: Pair<Rule>) -> Directive {
+    let mut pairs = pair.into_inner();
+    // The grammar rule is: identifier ~ "=" ~ value_expr
+    let name = pairs.next().unwrap().as_str().to_string();
+    let expr_pair = pairs.next().unwrap();
+    let expr = parse_expr(expr_pair);
+    Directive::Define { name, expr }
 }
 
 fn parse_account_directive(pair: Pair<Rule>) -> Directive {

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -91,6 +91,11 @@ pub struct Context {
     pub commodity_aliases: BTreeMap<String, String>,
     /// The commodity assumed when a posting amount has no explicit commodity.
     pub default_commodity: Option<String>,
+    /// Named value aliases defined with `define name = expr`.
+    ///
+    /// During elaboration, a bare identifier in a value expression is looked
+    /// up here and substituted with the stored expression.
+    pub defines: BTreeMap<String, ast::ValueExpr>,
 }
 
 /// Global properties of commodities and accounts that are shared across all
@@ -529,6 +534,13 @@ impl TryFrom<ast::Journal> for HIR {
                         ctx
                     });
                 }
+                ast::Entry::Directive(ast::Directive::Define { name, expr }) => {
+                    new_context = Some({
+                        let mut ctx = new_context.unwrap_or_else(|| context.clone());
+                        ctx.defines.insert(name, expr);
+                        ctx
+                    });
+                }
                 ast::Entry::Transaction(transaction) => {
                     let date = Self::resolve_date(&transaction.date, current_default_year)?;
                     let secondary_date = if let Some(ref d) = transaction.secondary_date {
@@ -825,5 +837,66 @@ mod resolution_tests {
         assert!(rendered.contains("10.50"), "expected '10.50' in: {rendered}");
         assert!(rendered.contains("$"), "expected '$' in: {rendered}");
         assert!(rendered.contains("Expenses:Food"), "expected account in: {rendered}");
+    }
+
+    #[test]
+    fn test_define_directive_stored_in_context() {
+        // A `define` directive should populate `Context::defines` and push
+        // a new context version, just like other alias-modifying directives.
+        let expr = ast::ValueExpr::Amount {
+            value: rust_decimal::Decimal::from(1500),
+            commodity: Some("$".into()),
+        };
+        let journal = ast::Journal {
+            entries: vec![
+                ast::Entry::Directive(ast::Directive::Define {
+                    name: "monthly_rent".into(),
+                    expr: expr.clone(),
+                }),
+            ],
+        };
+
+        let hir = HIR::try_from(journal).unwrap();
+
+        // A new context should have been pushed for the define directive.
+        assert_eq!(hir.contexts.len(), 2);
+        assert_eq!(
+            hir.contexts[1].defines.get("monthly_rent"),
+            Some(&expr),
+            "define should be stored in the new context"
+        );
+        // The original context must not be affected.
+        assert!(hir.contexts[0].defines.is_empty());
+    }
+
+    #[test]
+    fn test_define_directive_context_versioning() {
+        // Transactions before a `define` see the old context; those after see
+        // the context that includes the define.
+        let tx_ast = ast::Transaction {
+            date: ast::Date { year: Some(2024), month: 1, date: 1 },
+            description: "Tx".into(),
+            ..Default::default()
+        };
+        let expr = ast::ValueExpr::Amount {
+            value: rust_decimal::Decimal::from(500),
+            commodity: Some("$".into()),
+        };
+        let journal = ast::Journal {
+            entries: vec![
+                ast::Entry::Transaction(tx_ast.clone()),
+                ast::Entry::Directive(ast::Directive::Define {
+                    name: "budget".into(),
+                    expr: expr.clone(),
+                }),
+                ast::Entry::Transaction(tx_ast),
+            ],
+        };
+
+        let hir = HIR::try_from(journal).unwrap();
+
+        assert_eq!(hir.entries[0].context_id, 0, "tx before define should use context 0");
+        assert_eq!(hir.entries[1].context_id, 1, "tx after define should use context 1");
+        assert!(hir.contexts[1].defines.contains_key("budget"));
     }
 }


### PR DESCRIPTION
## Summary

- Restructures the `define_directive` grammar rule from an opaque atomic rule to a structured compound-atomic rule that exposes the identifier and value expression as named sub-tokens.
- Adds `ast::Directive::Define { name, expr }` and parses it in `parser.rs`.
- Adds `defines: BTreeMap<String, ast::ValueExpr>` to `resolution::Context`; `define` directives push a new context version so later transactions see the alias without affecting earlier ones.
- In the elaboration evaluator, a `ValueExpr::Commodity` whose name matches a define alias is substituted with the stored expression and re-evaluated, enabling bare identifiers like `monthly_rent` in posting amounts.

Closes #16

## Test plan

- `test_define_directive_stored_in_context` — verifies the define is stored in a new context and the original context is unaffected.
- `test_define_directive_context_versioning` — verifies transactions before the define use context 0 and those after use context 1.
- `test_define_simple_amount_alias` — full pipeline test: `define monthly_rent = $1500.00` used in a posting elaborates to the correct amount.
- `test_define_used_in_arithmetic_expression` — alias used inside arithmetic: `2 * base_amount` where `base_amount = 100 USD` evaluates to `200 USD`.
- `test_define_does_not_affect_earlier_transactions` — confirms the context-versioning invariant holds end-to-end.