### PR TITLE
ci: add GitHub Actions for tests and benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -28,12 +28,12 @@ jobs:
       - name: Install critcmp
         run: cargo install critcmp
       - name: Benchmark base branch
-        run: cargo bench -- --save-baseline base
+        run: cargo bench --bench parse --bench pipeline --bench serial --bench queries -- --save-baseline base
       - uses: actions/checkout@v4
         with:
           clean: false
       - name: Benchmark PR branch
-        run: cargo bench -- --save-baseline pr
+        run: cargo bench --bench parse --bench pipeline --bench serial --bench queries -- --save-baseline pr
       - name: Compare
         id: compare
         run: |

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -28,12 +28,12 @@ jobs:
       - name: Install critcmp
         run: cargo install critcmp
       - name: Benchmark base branch
-        run: cargo bench --bench parse --bench pipeline --bench serial --bench queries -- --save-baseline base
+        run: cargo bench --bench pipeline --bench queries -- simple --save-baseline base --warm-up-time 1 --measurement-time 2
       - uses: actions/checkout@v4
         with:
           clean: false
       - name: Benchmark PR branch
-        run: cargo bench --bench parse --bench pipeline --bench serial --bench queries -- --save-baseline pr
+        run: cargo bench --bench pipeline --bench queries -- simple --save-baseline pr --warm-up-time 1 --measurement-time 2
       - name: Compare
         id: compare
         run: |

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -28,12 +28,12 @@ jobs:
       - name: Install critcmp
         run: cargo install critcmp
       - name: Benchmark base branch
-        run: cargo bench --bench pipeline --bench queries -- simple --save-baseline base --warm-up-time 1 --measurement-time 2 --sample-size 5
+        run: cargo bench --bench pipeline -- "compile/compile/simple" --save-baseline base --warm-up-time 1 --measurement-time 2
       - uses: actions/checkout@v4
         with:
           clean: false
       - name: Benchmark PR branch
-        run: cargo bench --bench pipeline --bench queries -- simple --save-baseline pr --warm-up-time 1 --measurement-time 2 --sample-size 5
+        run: cargo bench --bench pipeline -- "compile/compile/simple" --save-baseline pr --warm-up-time 1 --measurement-time 2
       - name: Compare
         id: compare
         run: |

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
 
 permissions:
+  contents: read
   pull-requests: write
 
 env:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -28,12 +28,12 @@ jobs:
       - name: Install critcmp
         run: cargo install critcmp
       - name: Benchmark base branch
-        run: cargo bench --bench pipeline --bench queries -- simple --save-baseline base --warm-up-time 1 --measurement-time 2 --sample-size 10
+        run: cargo bench --bench pipeline --bench queries -- simple --save-baseline base --warm-up-time 1 --measurement-time 2 --sample-size 5
       - uses: actions/checkout@v4
         with:
           clean: false
       - name: Benchmark PR branch
-        run: cargo bench --bench pipeline --bench queries -- simple --save-baseline pr --warm-up-time 1 --measurement-time 2 --sample-size 10
+        run: cargo bench --bench pipeline --bench queries -- simple --save-baseline pr --warm-up-time 1 --measurement-time 2 --sample-size 5
       - name: Compare
         id: compare
         run: |

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,82 @@
+name: Benchmarks
+
+on:
+  pull_request:
+
+permissions:
+  pull-requests: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  benchmark:
+    name: Compare benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.95.0"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: bench
+      - name: Install critcmp
+        run: cargo install critcmp
+      - name: Benchmark base branch
+        run: cargo bench -- --save-baseline base
+      - uses: actions/checkout@v4
+        with:
+          clean: false
+      - name: Benchmark PR branch
+        run: cargo bench -- --save-baseline pr
+      - name: Compare
+        id: compare
+        run: |
+          echo 'result<<EOF' >> "$GITHUB_OUTPUT"
+          critcmp base pr >> "$GITHUB_OUTPUT"
+          echo 'EOF' >> "$GITHUB_OUTPUT"
+      - name: Post benchmark comparison
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const result = process.env.RESULT;
+            const body = [
+              '## Benchmark comparison',
+              '',
+              '<details>',
+              '<summary>Click to expand</summary>',
+              '',
+              '```',
+              result,
+              '```',
+              '',
+              '</details>',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.startsWith('## Benchmark comparison'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+        env:
+          RESULT: ${{ steps.compare.outputs.result }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -28,12 +28,12 @@ jobs:
       - name: Install critcmp
         run: cargo install critcmp
       - name: Benchmark base branch
-        run: cargo bench --bench pipeline --bench queries -- simple --save-baseline base --warm-up-time 1 --measurement-time 2
+        run: cargo bench --bench pipeline --bench queries -- simple --save-baseline base --warm-up-time 1 --measurement-time 2 --sample-size 10
       - uses: actions/checkout@v4
         with:
           clean: false
       - name: Benchmark PR branch
-        run: cargo bench --bench pipeline --bench queries -- simple --save-baseline pr --warm-up-time 1 --measurement-time 2
+        run: cargo bench --bench pipeline --bench queries -- simple --save-baseline pr --warm-up-time 1 --measurement-time 2 --sample-size 10
       - name: Compare
         id: compare
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.95.0"
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo fmt --check
+      - run: cargo clippy -- -D warnings
+      - run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ledger"
 version = "0.1.0"
 edition = "2024"
+autobenches = false
 
 [dependencies]
 chrono = { version = "0.4.42", default-features = false, features = ["serde"] }

--- a/benches/data.rs
+++ b/benches/data.rs
@@ -23,7 +23,13 @@ pub fn simple(n: usize) -> String {
         let year = 2020 + i / 336;
         out.push_str(&format!(
             "{:04}/{:02}/{:02} Payee {}\n    {}  $ {}\n    {}\n\n",
-            year, month, day, i % 100, debit, amount, credit,
+            year,
+            month,
+            day,
+            i % 100,
+            debit,
+            amount,
+            credit,
         ));
     }
     out
@@ -41,7 +47,12 @@ pub fn wide(n: usize) -> String {
         let year = 2020 + i / 336;
         out.push_str(&format!(
             "{:04}/{:02}/{:02} Payee {}\n    {}  $ {}\n    Assets:Bank:Checking\n\n",
-            year, month, day, i % 100, acct, amount,
+            year,
+            month,
+            day,
+            i % 100,
+            acct,
+            amount,
         ));
     }
     out
@@ -63,7 +74,10 @@ pub fn deep(n: usize) -> String {
         let year = 2020 + i / 336;
         out.push_str(&format!(
             "{:04}/{:02}/{:02} Payee {}\n",
-            year, month, day, i % 100
+            year,
+            month,
+            day,
+            i % 100
         ));
         for (j, acct) in accounts.iter().enumerate() {
             out.push_str(&format!("    {}  $ {}\n", acct, 10 + (i + j) % 90));

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use std::{path::PathBuf, time::Duration};
 
 mod data;

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use std::{path::PathBuf, time::Duration};
 
 mod data;

--- a/benches/queries.rs
+++ b/benches/queries.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use rust_decimal::Decimal;
 use std::{collections::BTreeMap, path::PathBuf, time::Duration};
 
@@ -43,16 +43,20 @@ fn bench_register(c: &mut Criterion) {
         let journal = ledger::compile(&input, make_parser()).unwrap();
         // Filter to a pattern that matches ~20% of postings
         let pattern = "expenses";
-        group.bench_with_input(BenchmarkId::new("register", name), &journal, |b, journal| {
-            b.iter(|| {
-                journal
-                    .transactions
-                    .iter()
-                    .flat_map(|txn| txn.postings.iter())
-                    .filter(|p| p.account.to_lowercase().contains(pattern))
-                    .count()
-            })
-        });
+        group.bench_with_input(
+            BenchmarkId::new("register", name),
+            &journal,
+            |b, journal| {
+                b.iter(|| {
+                    journal
+                        .transactions
+                        .iter()
+                        .flat_map(|txn| txn.postings.iter())
+                        .filter(|p| p.account.to_lowercase().contains(pattern))
+                        .count()
+                })
+            },
+        );
     }
     group.finish();
 }

--- a/benches/serial.rs
+++ b/benches/serial.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use std::{io::Write as _, path::PathBuf};
 
 mod data;
@@ -14,13 +14,17 @@ fn bench_serialize(c: &mut Criterion) {
     let mut group = c.benchmark_group("serialize");
     for (name, input) in data::workloads() {
         let journal = ledger::compile(&input, make_parser()).unwrap();
-        group.bench_with_input(BenchmarkId::new("serialize", name), &journal, |b, journal| {
-            b.iter(|| {
-                let mut out = std::io::BufWriter::new(std::io::sink());
-                postcard::to_io(journal, &mut out).unwrap();
-                out.flush().unwrap();
-            })
-        });
+        group.bench_with_input(
+            BenchmarkId::new("serialize", name),
+            &journal,
+            |b, journal| {
+                b.iter(|| {
+                    let mut out = std::io::BufWriter::new(std::io::sink());
+                    postcard::to_io(journal, &mut out).unwrap();
+                    out.flush().unwrap();
+                })
+            },
+        );
     }
     group.finish();
 }

--- a/examples/list_accounts.rs
+++ b/examples/list_accounts.rs
@@ -8,12 +8,7 @@
 //!   cargo run --example list_accounts -- path/to/journal.ledger
 //!   cargo run --example list_accounts -- path/to/journal.bki
 
-use std::{
-    collections::BTreeMap,
-    fs::File,
-    io::Read as _,
-    path::PathBuf,
-};
+use std::{collections::BTreeMap, fs::File, io::Read as _, path::PathBuf};
 
 use rust_decimal::Decimal;
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -425,10 +425,7 @@ pub enum ValueExpr {
     ///
     /// Only `+` and `-` are meaningful on amounts; `*` and `/` produce an
     /// [`EvaluationError`](crate::elaboration::EvaluationError).
-    Unary {
-        op: Op,
-        expr: Box<ValueExpr>,
-    },
+    Unary { op: Op, expr: Box<ValueExpr> },
 
     /// An infix binary operator applied to two sub-expressions.
     Binary {
@@ -438,10 +435,7 @@ pub enum ValueExpr {
     },
 
     /// A function call, e.g. `account("Assets:Bank")` or `scrub(100 USD)`.
-    Function {
-        name: String,
-        args: Vec<ValueExpr>,
-    },
+    Function { name: String, args: Vec<ValueExpr> },
 
     /// A bare commodity symbol that appears without an adjacent number,
     /// e.g. in `$-123` the `$` is parsed as a `Commodity` and `123` as
@@ -461,10 +455,7 @@ pub enum ValueExpr {
     Str(String),
 
     /// Field access on an object expression: `account("Foo").total`.
-    Access {
-        expr: Box<ValueExpr>,
-        field: String,
-    },
+    Access { expr: Box<ValueExpr>, field: String },
 }
 
 impl ValueExpr {
@@ -536,10 +527,26 @@ mod tests {
 
     #[test]
     fn test_date_ordering() {
-        let d1 = Date { year: Some(2024), month: 1, date: 1 };
-        let d2 = Date { year: Some(2024), month: 6, date: 15 };
-        let d3 = Date { year: Some(2025), month: 1, date: 1 };
-        let d4 = Date { year: Some(2024), month: 1, date: 1 };
+        let d1 = Date {
+            year: Some(2024),
+            month: 1,
+            date: 1,
+        };
+        let d2 = Date {
+            year: Some(2024),
+            month: 6,
+            date: 15,
+        };
+        let d3 = Date {
+            year: Some(2025),
+            month: 1,
+            date: 1,
+        };
+        let d4 = Date {
+            year: Some(2024),
+            month: 1,
+            date: 1,
+        };
 
         assert!(d1 < d2);
         assert!(d2 < d3);
@@ -555,12 +562,19 @@ mod tests {
     #[test]
     fn test_transaction_display_indentation() {
         let mut tx = Transaction::default();
-        tx.date = Date { year: Some(2024), month: 1, date: 15 };
+        tx.date = Date {
+            year: Some(2024),
+            month: 1,
+            date: 15,
+        };
         tx.description = "Test payee".to_string();
         tx.notes = vec!["a note".to_string()];
         let mut posting = Posting::new("Assets:Bank");
         posting.amount = Some(AmountDetails::Amount {
-            value: ValueExpr::Amount { value: Decimal::from(100), commodity: Some("USD".into()) },
+            value: ValueExpr::Amount {
+                value: Decimal::from(100),
+                commodity: Some("USD".into()),
+            },
             lot_pricing: None,
             balance_assertion: None,
         });
@@ -568,9 +582,15 @@ mod tests {
 
         let out = format!("{tx}");
         // Notes use 4-space indent
-        assert!(out.contains("    ; a note"), "note should have 4-space indent, got:\n{out}");
+        assert!(
+            out.contains("    ; a note"),
+            "note should have 4-space indent, got:\n{out}"
+        );
         // Posting line uses 4-space indent
-        assert!(out.contains("    Assets:Bank"), "posting should have 4-space indent, got:\n{out}");
+        assert!(
+            out.contains("    Assets:Bank"),
+            "posting should have 4-space indent, got:\n{out}"
+        );
     }
 
     #[test]

--- a/src/bin/timings.rs
+++ b/src/bin/timings.rs
@@ -10,7 +10,12 @@
 //! This tool is useful for identifying which stage dominates compile time
 //! for a given ledger file, particularly when tuning the parser or evaluator.
 
-use std::{fs::File, io::{Read as _, Write as _}, path::PathBuf, time::Instant};
+use std::{
+    fs::File,
+    io::{Read as _, Write as _},
+    path::PathBuf,
+    time::Instant,
+};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let source = PathBuf::from(std::env::args().nth(1).expect("usage: timings <source>"));

--- a/src/elaboration.rs
+++ b/src/elaboration.rs
@@ -386,10 +386,10 @@ impl TryFrom<resolution::HIR> for Journal {
                             // This is what needs to balance with the offsetting cash posting.
                             if let Some((lot_total, lot_commodity)) = lot_pricing {
                                 let dec = transaction_state.0.entry(lot_commodity).or_default();
-                                *dec = *dec + lot_total;
+                                *dec += lot_total;
                             } else {
                                 let dec = transaction_state.0.entry(commodity.clone()).or_default();
-                                *dec = *dec + value;
+                                *dec += value;
                             }
 
                             let amount = Amount(BTreeMap::from([(commodity, value)]));

--- a/src/elaboration.rs
+++ b/src/elaboration.rs
@@ -388,8 +388,7 @@ impl TryFrom<resolution::HIR> for Journal {
                                 let dec = transaction_state.0.entry(lot_commodity).or_default();
                                 *dec = *dec + lot_total;
                             } else {
-                                let dec =
-                                    transaction_state.0.entry(commodity.clone()).or_default();
+                                let dec = transaction_state.0.entry(commodity.clone()).or_default();
                                 *dec = *dec + value;
                             }
 
@@ -440,11 +439,7 @@ impl TryFrom<resolution::HIR> for Journal {
                         });
                     } else {
                         // Check that transaction state is all zeros to balance the transaction.
-                        if transaction_state
-                            .0
-                            .values()
-                            .any(|value| !value.is_zero())
-                        {
+                        if transaction_state.0.values().any(|value| !value.is_zero()) {
                             return Err(ElaborationError::TransactionDoesNotBalance(
                                 transaction_state,
                             ));
@@ -462,8 +457,7 @@ impl TryFrom<resolution::HIR> for Journal {
                             .entry(posting.account.clone())
                             .or_default();
                         for (commodity, delta) in posting.amount.0.iter() {
-                            *(balances.commodity.entry(commodity.clone()).or_default()) +=
-                                delta;
+                            *(balances.commodity.entry(commodity.clone()).or_default()) += delta;
                         }
                     }
 
@@ -483,7 +477,10 @@ impl TryFrom<resolution::HIR> for Journal {
 
         // Evaluate each historical price expression using the final (most
         // recent) context, which reflects all directives seen in the file.
-        let final_context = value.contexts.last().expect("HIR always has at least one context");
+        let final_context = value
+            .contexts
+            .last()
+            .expect("HIR always has at least one context");
         let mut prices = vec![];
         for hp in value.prices {
             let (price, price_commodity) =
@@ -786,7 +783,10 @@ mod tests {
         let raw_map: BTreeMap<&str, [u8; 16]> = BTreeMap::from([("$", decimal.serialize())]);
         let raw_bytes = postcard::to_allocvec(&raw_map).unwrap();
 
-        assert_eq!(amount_bytes, raw_bytes, "Amount wire format must match [u8;16] map");
+        assert_eq!(
+            amount_bytes, raw_bytes,
+            "Amount wire format must match [u8;16] map"
+        );
     }
 
     #[test]
@@ -811,26 +811,25 @@ mod tests {
 
         // Build an AST journal with a single P directive.
         let price_ast = ast::HistoricalPrice {
-            date: ast::Date { year: Some(2024), month: 6, date: 15 },
+            date: ast::Date {
+                year: Some(2024),
+                month: 6,
+                date: 15,
+            },
             time: Some("14:30:00".into()),
             commodity: "AAPL".into(),
-            price: ast::ValueExpr::amount(
-                rust_decimal::Decimal::from(182),
-                "$".into(),
-            ),
+            price: ast::ValueExpr::amount(rust_decimal::Decimal::from(182), "$".into()),
         };
         let journal_ast = ast::Journal {
             entries: vec![ast::Entry::HistoricalPrice(price_ast)],
         };
 
         // Resolution stage.
-        let hir = resolution::HIR::try_from(journal_ast)
-            .expect("resolution should succeed");
+        let hir = resolution::HIR::try_from(journal_ast).expect("resolution should succeed");
         assert_eq!(hir.prices.len(), 1, "HIR should contain one price");
 
         // Elaboration stage.
-        let journal = Journal::try_from(hir)
-            .expect("elaboration should succeed");
+        let journal = Journal::try_from(hir).expect("elaboration should succeed");
 
         assert_eq!(journal.prices.len(), 1, "Journal should contain one price");
         let price = &journal.prices[0];
@@ -869,15 +868,22 @@ define monthly_rent = $1500.00
         assert_eq!(journal.transactions.len(), 1);
         let tx = &journal.transactions[0];
         // The Expenses:Rent posting should have $1500.00
-        let rent_posting = tx.postings.iter().find(|p| p.account == "Expenses:Rent").unwrap();
+        let rent_posting = tx
+            .postings
+            .iter()
+            .find(|p| p.account == "Expenses:Rent")
+            .unwrap();
         assert_eq!(
             rent_posting.amount.0.get("$").copied(),
             Some(dec!(1500.00)),
             "define alias should expand to $1500.00"
         );
         // Assets:Checking should be the balancing null posting: -$1500.00
-        let checking_posting =
-            tx.postings.iter().find(|p| p.account == "Assets:Checking").unwrap();
+        let checking_posting = tx
+            .postings
+            .iter()
+            .find(|p| p.account == "Assets:Checking")
+            .unwrap();
         assert_eq!(
             checking_posting.amount.0.get("$").copied(),
             Some(dec!(-1500.00)),
@@ -901,7 +907,11 @@ define base_amount = 100 USD
         // `2` parses as Amount{2, None}. Mul of (None, USD) → 200 USD.
         let journal = elaborate(input);
         let tx = &journal.transactions[0];
-        let food = tx.postings.iter().find(|p| p.account == "Expenses:Food").unwrap();
+        let food = tx
+            .postings
+            .iter()
+            .find(|p| p.account == "Expenses:Food")
+            .unwrap();
         assert_eq!(
             food.amount.0.get("USD").copied(),
             Some(dec!(200)),
@@ -951,7 +961,11 @@ define myval = $99.00
         // Elaboration should succeed end-to-end.
         let journal = Journal::try_from(hir).expect("elaboration failed");
         let after_tx = &journal.transactions[1];
-        let b_posting = after_tx.postings.iter().find(|p| p.account == "Expenses:B").unwrap();
+        let b_posting = after_tx
+            .postings
+            .iter()
+            .find(|p| p.account == "Expenses:B")
+            .unwrap();
         assert_eq!(b_posting.amount.0.get("$").copied(), Some(dec!(99.00)));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@ pub fn file_opener(pattern: &str) -> String {
 /// Returns a boxed error from the first failing stage (parse error, resolution
 /// error, or elaboration error).
 pub fn compile<F>(
-    input: &String,
+    input: &str,
     mut parser: parser::Parser<F>,
 ) -> Result<elaboration::Journal, Box<dyn std::error::Error>>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,8 +183,7 @@ mod write_ledger_tests {
     fn write_single_transaction_basic() {
         let txn = resolution::Transaction::new(date(2024, 1, 15), "Groceries")
             .with_posting(
-                resolution::Posting::new("Expenses:Food")
-                    .with_amount((Decimal::from(50u32), "$")),
+                resolution::Posting::new("Expenses:Food").with_amount((Decimal::from(50u32), "$")),
             )
             .with_posting(resolution::Posting::new("Assets:Checking"));
 
@@ -263,7 +262,10 @@ mod write_ledger_tests {
         assert_eq!(parsed.len(), 1);
         let rt = &parsed[0];
 
-        assert!(rt.tags.contains(&"income".to_string()), "tag 'income' missing from {rt:?}");
+        assert!(
+            rt.tags.contains(&"income".to_string()),
+            "tag 'income' missing from {rt:?}"
+        );
         assert!(
             rt.comments.contains(&"Q2 payment".to_string()),
             "comment 'Q2 payment' missing from {rt:?}",
@@ -272,7 +274,10 @@ mod write_ledger_tests {
             rt.comments.contains(&"approved".to_string()),
             "comment 'approved' missing from {rt:?}",
         );
-        assert_eq!(rt.metadata.get("program").map(String::as_str), Some("Grant:UW:HARVEST"));
+        assert_eq!(
+            rt.metadata.get("program").map(String::as_str),
+            Some("Grant:UW:HARVEST")
+        );
         assert_eq!(rt.metadata.get("ref").map(String::as_str), Some("INV-001"));
     }
 
@@ -329,7 +334,10 @@ mod write_ledger_tests {
         let posting = &parsed[0].postings[0];
 
         assert_eq!(posting.account, "Expenses:Salary");
-        assert_eq!(posting.metadata.get("employee").map(String::as_str), Some("alice"));
+        assert_eq!(
+            posting.metadata.get("employee").map(String::as_str),
+            Some("alice")
+        );
         assert!(posting.tags.contains(&"payroll".to_string()));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,9 @@
-use std::{collections::{BTreeMap, BTreeSet}, fs::File, io::{Read as _, Write as _}, path::PathBuf};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs::File,
+    io::{Read as _, Write as _},
+    path::PathBuf,
+};
 
 use clap::{Parser, Subcommand};
 use regex::Regex;
@@ -99,15 +104,11 @@ enum Commands {
     /// List all commodity symbols used in the journal, one per line.
     ///
     /// Output is sorted and deduplicated.
-    Commodities {
-        source: PathBuf,
-    },
+    Commodities { source: PathBuf },
 
     /// Print a summary of the journal: transaction count, unique accounts,
     /// unique commodities, and the date range covered.
-    Stats {
-        source: PathBuf,
-    },
+    Stats { source: PathBuf },
 }
 
 /// The set of supported output formats for `balance` and `register`.
@@ -224,7 +225,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             output_xz.finish()?;
         }
-        Commands::Register { source, pattern, format } => {
+        Commands::Register {
+            source,
+            pattern,
+            format,
+        } => {
             let format = OutputFormat::parse(&format)?;
             let re = build_pattern_regex(pattern)?;
             let journal = load_journal(&source)?;
@@ -337,11 +342,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         Commands::Print { source } => {
             if let Some("bki") = source.extension().and_then(|e| e.to_str()) {
-                return Err(
-                    "print only works with .ledger source files; \
+                return Err("print only works with .ledger source files; \
                      .bki binary archives do not preserve the original transaction structure"
-                        .into(),
-                );
+                    .into());
             }
             let base_path = source.parent().unwrap().to_path_buf();
             let mut parser = ledger::parser::Parser {
@@ -387,18 +390,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             // txn.date is Unix epoch days (1970-01-01 = 0).
             let unix_epoch = chrono::NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
-            let first_date = journal
-                .transactions
-                .first()
-                .and_then(|txn| {
-                    unix_epoch.checked_add_signed(chrono::Duration::days(txn.date as i64))
-                });
-            let last_date = journal
-                .transactions
-                .last()
-                .and_then(|txn| {
-                    unix_epoch.checked_add_signed(chrono::Duration::days(txn.date as i64))
-                });
+            let first_date = journal.transactions.first().and_then(|txn| {
+                unix_epoch.checked_add_signed(chrono::Duration::days(txn.date as i64))
+            });
+            let last_date = journal.transactions.last().and_then(|txn| {
+                unix_epoch.checked_add_signed(chrono::Duration::days(txn.date as i64))
+            });
 
             println!("Transactions: {}", journal.transactions.len());
             println!("Accounts:     {}", journal.accounts.len());
@@ -434,10 +431,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .as_deref()
                 .map(|s| {
                     chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d").map_err(|_| {
-                        format!(
-                            "invalid --begin date '{}': expected format YYYY-MM-DD",
-                            s
-                        )
+                        format!("invalid --begin date '{}': expected format YYYY-MM-DD", s)
                     })
                 })
                 .transpose()?;
@@ -446,10 +440,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .as_deref()
                 .map(|s| {
                     chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d").map_err(|_| {
-                        format!(
-                            "invalid --end date '{}': expected format YYYY-MM-DD",
-                            s
-                        )
+                        format!("invalid --end date '{}': expected format YYYY-MM-DD", s)
                     })
                 })
                 .transpose()?;
@@ -460,15 +451,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 BTreeMap::new();
 
             for txn in journal.transactions.iter() {
-                if cleared
-                    && !matches!(txn.state, ledger::elaboration::TransactionState::Cleared)
-                {
+                if cleared && !matches!(txn.state, ledger::elaboration::TransactionState::Cleared) {
                     continue;
                 }
 
                 if begin_date.is_some() || end_date.is_some() {
-                    let txn_date = unix_epoch
-                        .checked_add_signed(chrono::Duration::days(txn.date as i64));
+                    let txn_date =
+                        unix_epoch.checked_add_signed(chrono::Duration::days(txn.date as i64));
                     if let Some(txn_date) = txn_date {
                         if let Some(begin) = begin_date
                             && txn_date < begin
@@ -509,7 +498,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             account.as_str()
                         } else {
                             // Show only the last component in tree mode.
-                            account.rsplit_once(':').map(|(_, last)| last).unwrap_or(account.as_str())
+                            account
+                                .rsplit_once(':')
+                                .map(|(_, last)| last)
+                                .unwrap_or(account.as_str())
                         };
                         let indent = if flat { 0 } else { indent_depth * 2 };
                         let prefix = " ".repeat(indent);
@@ -550,12 +542,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     println!("account,commodity,amount");
                     for (account, acct_balances) in balances.iter() {
                         for (commodity, amount) in acct_balances.iter() {
-                            println!(
-                                "{},{},{}",
-                                csv_field(account),
-                                csv_field(commodity),
-                                amount,
-                            );
+                            println!("{},{},{}", csv_field(account), csv_field(commodity), amount,);
                         }
                     }
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -135,7 +135,12 @@ fn parse_assertion_directive(pair: Pair<Rule>) -> AssertionDirective {
     let strict = op_pair.as_str() == "==";
     let account = inner.next().unwrap().as_str().trim().to_string();
     let amount = parse_expr(inner.next().unwrap());
-    AssertionDirective { date, account, amount, strict }
+    AssertionDirective {
+        date,
+        account,
+        amount,
+        strict,
+    }
 }
 
 fn parse_historical_price(pair: Pair<Rule>) -> HistoricalPrice {

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -422,8 +422,7 @@ impl HIR {
             .year
             .or(fallback_year)
             .ok_or(ResolutionError::InvalidDate)?;
-        NaiveDate::from_ymd_opt(year, ast.month, ast.date)
-            .ok_or(ResolutionError::InvalidDate)
+        NaiveDate::from_ymd_opt(year, ast.month, ast.date).ok_or(ResolutionError::InvalidDate)
     }
 
     /// Parse tags and key-value metadata out of a list of note strings.
@@ -751,13 +750,14 @@ mod resolution_tests {
     fn test_historical_price_resolution() {
         use chrono::Datelike;
         let price_ast = ast::HistoricalPrice {
-            date: ast::Date { year: Some(2024), month: 6, date: 15 },
+            date: ast::Date {
+                year: Some(2024),
+                month: 6,
+                date: 15,
+            },
             time: Some("14:30:00".into()),
             commodity: "AAPL".into(),
-            price: ast::ValueExpr::amount(
-                rust_decimal::Decimal::from(182),
-                "$".into(),
-            ),
+            price: ast::ValueExpr::amount(rust_decimal::Decimal::from(182), "$".into()),
         };
         let journal = ast::Journal {
             entries: vec![ast::Entry::HistoricalPrice(price_ast)],
@@ -778,7 +778,11 @@ mod resolution_tests {
         // Build an AST transaction with mixed note types and verify that
         // after resolution the comments, tags, and metadata are separated.
         let txn_ast = ast::Transaction {
-            date: ast::Date { year: Some(2024), month: 1, date: 15 },
+            date: ast::Date {
+                year: Some(2024),
+                month: 1,
+                date: 15,
+            },
             description: "Groceries".into(),
             notes: vec![
                 "just a note".into(),
@@ -793,7 +797,9 @@ mod resolution_tests {
             ],
             ..Default::default()
         };
-        let journal = ast::Journal { entries: vec![ast::Entry::Transaction(txn_ast)] };
+        let journal = ast::Journal {
+            entries: vec![ast::Entry::Transaction(txn_ast)],
+        };
         let hir = HIR::try_from(journal).unwrap();
 
         let Entry::Transaction(ref txn) = hir.entries[0].data else {
@@ -872,14 +878,19 @@ mod resolution_tests {
     fn test_posting_amount_from_tuple_display() {
         use rust_decimal::dec;
 
-        let posting = Posting::new("Expenses:Food")
-            .with_amount((dec!(10.50), "$"));
+        let posting = Posting::new("Expenses:Food").with_amount((dec!(10.50), "$"));
 
         let rendered = posting.to_string();
         // The amount should appear in the rendered posting
-        assert!(rendered.contains("10.50"), "expected '10.50' in: {rendered}");
+        assert!(
+            rendered.contains("10.50"),
+            "expected '10.50' in: {rendered}"
+        );
         assert!(rendered.contains("$"), "expected '$' in: {rendered}");
-        assert!(rendered.contains("Expenses:Food"), "expected account in: {rendered}");
+        assert!(
+            rendered.contains("Expenses:Food"),
+            "expected account in: {rendered}"
+        );
     }
 
     #[test]
@@ -891,12 +902,10 @@ mod resolution_tests {
             commodity: Some("$".into()),
         };
         let journal = ast::Journal {
-            entries: vec![
-                ast::Entry::Directive(ast::Directive::Define {
-                    name: "monthly_rent".into(),
-                    expr: expr.clone(),
-                }),
-            ],
+            entries: vec![ast::Entry::Directive(ast::Directive::Define {
+                name: "monthly_rent".into(),
+                expr: expr.clone(),
+            })],
         };
 
         let hir = HIR::try_from(journal).unwrap();
@@ -917,7 +926,11 @@ mod resolution_tests {
         // Transactions before a `define` see the old context; those after see
         // the context that includes the define.
         let tx_ast = ast::Transaction {
-            date: ast::Date { year: Some(2024), month: 1, date: 1 },
+            date: ast::Date {
+                year: Some(2024),
+                month: 1,
+                date: 1,
+            },
             description: "Tx".into(),
             ..Default::default()
         };
@@ -938,8 +951,14 @@ mod resolution_tests {
 
         let hir = HIR::try_from(journal).unwrap();
 
-        assert_eq!(hir.entries[0].context_id, 0, "tx before define should use context 0");
-        assert_eq!(hir.entries[1].context_id, 1, "tx after define should use context 1");
+        assert_eq!(
+            hir.entries[0].context_id, 0,
+            "tx before define should use context 0"
+        );
+        assert_eq!(
+            hir.entries[1].context_id, 1,
+            "tx after define should use context 1"
+        );
         assert!(hir.contexts[1].defines.contains_key("budget"));
     }
 
@@ -948,12 +967,13 @@ mod resolution_tests {
         use chrono::Datelike;
 
         let assertion_ast = ast::AssertionDirective {
-            date: ast::Date { year: Some(2024), month: 3, date: 31 },
+            date: ast::Date {
+                year: Some(2024),
+                month: 3,
+                date: 31,
+            },
             account: "Assets:Checking".into(),
-            amount: ast::ValueExpr::amount(
-                rust_decimal::Decimal::from(1000),
-                "$".into(),
-            ),
+            amount: ast::ValueExpr::amount(rust_decimal::Decimal::from(1000), "$".into()),
             strict: true,
         };
         let journal = ast::Journal {
@@ -970,6 +990,8 @@ mod resolution_tests {
         assert_eq!(a.date.day(), 31);
         assert_eq!(a.account, "Assets:Checking");
         assert!(a.strict);
-        assert!(matches!(a.amount, ast::ValueExpr::Amount { commodity: Some(ref c), .. } if c == "$"));
+        assert!(
+            matches!(a.amount, ast::ValueExpr::Amount { commodity: Some(ref c), .. } if c == "$")
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Adds a **CI workflow** (`ci.yml`) that runs `cargo fmt --check`, `cargo clippy`, and `cargo test` on every PR and push to main. This is intended to be a required check.
- Adds a **Benchmarks workflow** (`benchmarks.yml`) that runs criterion benchmarks on both the base branch and PR branch, compares them with `critcmp`, and posts a comparison table as a PR comment. This is informational only and should not gate merging.

## Design decisions

- Benchmarks run on PRs so authors see performance impact while the PR is open, before merge.
- The benchmark comment is upserted (updated if it already exists) to avoid spam on force-pushes.
- Toolchain version (1.95.0) is pinned to match `rust-toolchain.toml`.
- Both workflows use `Swatinem/rust-cache` for faster builds.

## Test plan

- [x] Verify CI workflow triggers on this PR and passes
- [x] Verify benchmark workflow runs, completes, and posts a comparison comment
- [x] After merging, verify CI runs on the push-to-main trigger