### PR TITLE
docs: improve public API doc comments for v0.1

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -175,6 +175,9 @@ impl From<NaiveDate> for Date {
 /// Amounts in the postings are unevaluated [`ValueExpr`] trees; the
 /// [`crate::elaboration`] stage evaluates them and ensures the transaction
 /// balances.
+///
+/// This is the raw parse-tree representation. For programmatic transaction
+/// construction, use [`crate::resolution::Transaction`] and its builder methods instead.
 #[derive(Clone, Default, Debug)]
 pub struct Transaction {
     /// The primary (effective) date.
@@ -234,6 +237,9 @@ impl Display for Transaction {
 }
 
 /// A single posting (debit or credit line) within a transaction.
+///
+/// This is the raw parse-tree representation. For programmatic posting
+/// construction, use [`crate::resolution::Posting`] and its builder methods instead.
 #[derive(Clone, Default, Debug)]
 pub struct Posting {
     /// The account name, e.g. `"Expenses:Food"`.

--- a/src/elaboration.rs
+++ b/src/elaboration.rs
@@ -92,6 +92,10 @@ struct RunningState {
 }
 
 /// A fully evaluated and balanced transaction, ready for serialisation.
+///
+/// Note: this type does not implement [`std::fmt::Display`]. To serialise
+/// transactions back to Ledger source text, use [`crate::resolution::Transaction`]
+/// with [`crate::write_ledger`].
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ResolvedTransaction {
     /// Days since the Unix epoch (1970-01-01 = 0).
@@ -228,7 +232,11 @@ pub enum ElaborationError {
     TransactionDoesNotBalance(Amount),
 }
 
-/// Errors from evaluating a [`ast::ValueExpr`].
+/// Error produced when evaluating a value expression (e.g., an amount or
+/// balance assertion expression) fails.
+///
+/// This error is always wrapped in [`ElaborationError::EvaluationError`]; it
+/// is unlikely to be matched directly by callers.
 #[derive(Debug)]
 pub enum EvaluationError {
     /// `*` or `/` used as a unary prefix operator, which is not meaningful.

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -25,7 +25,14 @@ use chrono::NaiveDate;
 
 use crate::ast;
 
-/// The Higher-level Intermediate Representation produced by the resolution stage.
+/// Higher-level Intermediate Representation (HIR) produced by the resolution stage.
+///
+/// The HIR holds all resolved entries (transactions, balance assertions, price
+/// directives) together with the evaluation contexts needed to elaborate them.
+/// It is the input to [`crate::elaboration::Journal`] via `TryFrom`.
+///
+/// Library callers should obtain an `HIR` via [`crate::compile`] rather than
+/// constructing one directly.
 ///
 /// All entries retain their source-order position. Each [`ResolutionEntry`]
 /// carries a `context_id` that indexes into [`HIR::contexts`], recording which


### PR DESCRIPTION
## Summary

- `ast::Transaction` and `ast::Posting`: added a note steering callers toward `resolution::Transaction`/`Posting` and their builder APIs for programmatic construction
- `resolution::HIR`: expanded the struct doc to spell out the HIR acronym, describe its role in the pipeline, name its output consumer (`elaboration::Journal`), and advise callers to use `crate::compile` rather than constructing one directly
- `elaboration::EvaluationError`: replaced the one-line comment with a proper doc block that names the error's origin and notes it is always wrapped in `ElaborationError::EvaluationError`
- `elaboration::ResolvedTransaction`: added a note that the type has no `Display` impl and points callers to `resolution::Transaction` + `crate::write_ledger` for round-tripping back to Ledger text

All intra-doc links verified against existing items. `cargo doc --no-deps` produces no new warnings. `cargo test` passes.

## Test plan

- [x] `cargo doc --no-deps 2>&1 | grep "warning\|error"` — no new warnings introduced
- [x] `cargo test` — all unit, integration, and doc tests pass