### PR TITLE
feat: add magic header and version marker to .bki format (closes #42)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,22 @@
 //! ledger-rs — a compiler and query library for the Ledger plain-text
 //! accounting format.
 //!
+//! # `.bki` binary format
+//!
+//! The `ledger compile` command serialises an elaborated journal to a `.bki`
+//! file. The file begins with an 8-byte header followed by the postcard +
+//! XZ-compressed journal body:
+//!
+//! ```text
+//! Offset  Length  Content
+//! 0       4       Magic: b"BKI\0"
+//! 4       2       Version: u16 LE (currently 1)
+//! 6       2       Reserved: u16 LE (write 0, ignore on read)
+//! ```
+//!
+//! Use [`bki_write_header`] / [`bki_read_header`] for portable, tested I/O of
+//! this header.
+//!
 //! # Pipeline
 //!
 //! Source text is processed through four stages:
@@ -209,6 +225,86 @@ pub fn eval_transaction(
         .into_iter()
         .next()
         .expect("journal should contain exactly one transaction"))
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// .bki header helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Four-byte magic that identifies every `.bki` file.
+pub const BKI_MAGIC: [u8; 4] = *b"BKI\0";
+
+/// Format version embedded in every `.bki` header.
+///
+/// Bump this constant (and update [`bki_read_header`]) whenever the
+/// serialisation format changes in a breaking way.
+pub const BKI_FORMAT_VERSION: u16 = 1;
+
+/// Write the 8-byte `.bki` header to `writer`.
+///
+/// Layout: magic (4 bytes) + version LE u16 (2 bytes) + reserved u16 (2 bytes).
+///
+/// # Errors
+///
+/// Propagates any [`std::io::Error`] from `writer`.
+pub fn bki_write_header<W: std::io::Write>(writer: &mut W) -> std::io::Result<()> {
+    writer.write_all(&BKI_MAGIC)?;
+    writer.write_all(&BKI_FORMAT_VERSION.to_le_bytes())?;
+    writer.write_all(&0u16.to_le_bytes())?;
+    Ok(())
+}
+
+/// Read and validate the 8-byte `.bki` header from `reader`.
+///
+/// `path` is used only for error messages; it should be the path of the file
+/// being opened so diagnostics point to the right location.
+///
+/// # Errors
+///
+/// Returns a boxed error with a user-actionable message if:
+/// - the magic bytes are missing or incorrect,
+/// - the format version is not [`BKI_FORMAT_VERSION`].
+pub fn bki_read_header<R: std::io::Read>(
+    reader: &mut R,
+    path: &std::path::Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut magic = [0u8; 4];
+    // A short read here means the file is too small to be valid.
+    reader.read_exact(&mut magic).map_err(|_| {
+        format!(
+            "{}: not a valid .bki file (missing magic header); \
+             recompile from source with `ledger compile`",
+            path.display()
+        )
+    })?;
+    if magic != BKI_MAGIC {
+        return Err(format!(
+            "{}: not a valid .bki file (missing magic header); \
+             recompile from source with `ledger compile`",
+            path.display()
+        )
+        .into());
+    }
+
+    let mut version_bytes = [0u8; 2];
+    reader.read_exact(&mut version_bytes)?;
+    let version = u16::from_le_bytes(version_bytes);
+    if version != BKI_FORMAT_VERSION {
+        return Err(format!(
+            "{}: incompatible .bki format version {} \
+             (this binary supports version {}); \
+             recompile from source with `ledger compile`",
+            path.display(),
+            version,
+            BKI_FORMAT_VERSION,
+        )
+        .into());
+    }
+
+    // Skip the 2 reserved bytes — ignore their value on read.
+    let mut reserved = [0u8; 2];
+    reader.read_exact(&mut reserved)?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,10 +152,13 @@ impl OutputFormat {
 ///   directives relative to the file's parent directory.
 fn load_journal(path: &PathBuf) -> Result<ledger::Journal, Box<dyn std::error::Error>> {
     if let Some("bki") = path.extension().and_then(|e| e.to_str()) {
-        // Pre-compiled binary format: decompress then deserialise.
+        // Pre-compiled binary format: validate 8-byte header, then decompress
+        // and deserialise.
+        let mut f = File::open(path)?;
+        ledger::bki_read_header(&mut f, path)?;
         // The 100 KiB scratch buffer is required by postcard's `from_io` API;
         // it does not limit the total data read.
-        let input_xz = xz::read::XzDecoder::new(File::open(path)?);
+        let input_xz = xz::read::XzDecoder::new(f);
         let mut buf = vec![0; 102400];
         Ok(postcard::from_io((input_xz, &mut buf))?.0)
     } else {
@@ -226,7 +229,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let mut file = String::new();
             File::open(source)?.read_to_string(&mut file)?;
             let journal = ledger::compile(&file, parser)?;
-            let mut output_xz = xz::write::XzEncoder::new(File::create(output)?, 6);
+            let mut out_file = File::create(output)?;
+            // Write the 8-byte header: magic (4) + version LE (2) + reserved (2).
+            ledger::bki_write_header(&mut out_file)?;
+            let mut output_xz = xz::write::XzEncoder::new(out_file, 6);
             {
                 let mut buf = std::io::BufWriter::new(&mut output_xz);
                 postcard::to_io(&journal, &mut buf)?;

--- a/tests/bki_format.rs
+++ b/tests/bki_format.rs
@@ -1,0 +1,162 @@
+//! Integration tests for the `.bki` binary format header.
+//!
+//! These tests exercise the [`ledger::bki_write_header`] /
+//! [`ledger::bki_read_header`] helpers and verify the full compile → load
+//! round-trip via the library's public API.
+
+use std::{
+    io::{Seek as _, SeekFrom, Write as _},
+    path::Path,
+};
+
+use tempfile::NamedTempFile;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/// Compile a small ledger source string into a temp `.bki` file and return the
+/// file handle (positioned at offset 0 so the caller can verify raw bytes).
+fn compile_to_bki(source: &str) -> NamedTempFile {
+    // Build the journal in memory.
+    let mut parser = ledger::parser::Parser {
+        opener: |_: &str| String::new(),
+        base_path: std::path::PathBuf::new(),
+    };
+    let ast = parser.parse(source).expect("parse failed");
+    let hir: ledger::resolution::HIR = ast.try_into().expect("resolution failed");
+    let journal: ledger::elaboration::Journal = hir.try_into().expect("elaboration failed");
+
+    // Write to a named temp file so we can pass its path to `bki_read_header`.
+    let mut tmp = NamedTempFile::new().expect("tmp file");
+    ledger::bki_write_header(tmp.as_file_mut()).expect("write header");
+    let mut xz_enc = xz::write::XzEncoder::new(tmp.as_file_mut(), 6);
+    {
+        let mut buf = std::io::BufWriter::new(&mut xz_enc);
+        postcard::to_io(&journal, &mut buf).expect("postcard");
+        buf.flush().expect("flush");
+    }
+    xz_enc.finish().expect("xz finish");
+
+    // Seek back to the beginning so the file is ready for reading.
+    tmp.as_file_mut()
+        .seek(SeekFrom::Start(0))
+        .expect("seek to start");
+    tmp
+}
+
+/// Load a journal from a named temp file using the library header reader.
+fn load_bki(path: &Path) -> ledger::Journal {
+    let mut f = std::fs::File::open(path).expect("open bki");
+    ledger::bki_read_header(&mut f, path).expect("read header");
+    let input_xz = xz::read::XzDecoder::new(f);
+    let mut buf = vec![0u8; 102400];
+    postcard::from_io((input_xz, &mut buf))
+        .expect("deserialise")
+        .0
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+/// A full compile → load round-trip: the deserialized journal should contain
+/// the same transactions as the original source.
+#[test]
+fn round_trip_compile_and_load() {
+    let source = "\
+2024-01-15 Groceries
+    Expenses:Food  50 $
+    Assets:Checking
+
+2024-02-01 Rent
+    Expenses:Rent  1200 $
+    Assets:Checking
+";
+
+    let tmp = compile_to_bki(source);
+    let journal = load_bki(tmp.path());
+
+    assert_eq!(
+        journal.transactions.len(),
+        2,
+        "expected 2 transactions after round-trip"
+    );
+    assert_eq!(
+        journal.transactions[0].description, "Groceries",
+        "first transaction description mismatch"
+    );
+    assert_eq!(
+        journal.transactions[1].description, "Rent",
+        "second transaction description mismatch"
+    );
+}
+
+/// Writing garbage bytes to a `.bki`-named file and attempting to load it
+/// should produce an error whose message contains "missing magic header".
+#[test]
+fn bad_magic_returns_error() {
+    let mut tmp = tempfile::Builder::new()
+        .suffix(".bki")
+        .tempfile()
+        .expect("tmp file");
+    tmp.write_all(b"GARBAGE_NOT_BKI_FORMAT")
+        .expect("write garbage");
+    tmp.flush().expect("flush");
+
+    let path = tmp.path().to_owned();
+    let mut f = std::fs::File::open(&path).expect("open");
+    let err = ledger::bki_read_header(&mut f, &path).expect_err("expected an error for bad magic");
+
+    assert!(
+        err.to_string().contains("missing magic header"),
+        "error message should mention 'missing magic header', got: {err}"
+    );
+}
+
+/// An empty file (or file too short for the header) should also be rejected
+/// with the "missing magic header" message.
+#[test]
+fn empty_file_returns_missing_magic_error() {
+    let tmp = tempfile::Builder::new()
+        .suffix(".bki")
+        .tempfile()
+        .expect("tmp file");
+
+    let path = tmp.path().to_owned();
+    let mut f = std::fs::File::open(&path).expect("open");
+    let err = ledger::bki_read_header(&mut f, &path).expect_err("expected an error for empty file");
+
+    assert!(
+        err.to_string().contains("missing magic header"),
+        "error message should mention 'missing magic header', got: {err}"
+    );
+}
+
+/// A file with correct magic but wrong version should produce an error that
+/// mentions the version number it found.
+#[test]
+fn wrong_version_returns_error_with_version_number() {
+    let mut tmp = tempfile::Builder::new()
+        .suffix(".bki")
+        .tempfile()
+        .expect("tmp file");
+
+    // Write correct magic but version = 99.
+    tmp.write_all(b"BKI\0").expect("write magic");
+    tmp.write_all(&99u16.to_le_bytes()).expect("write version");
+    tmp.write_all(&0u16.to_le_bytes()).expect("write reserved");
+    tmp.flush().expect("flush");
+
+    let path = tmp.path().to_owned();
+    let mut f = std::fs::File::open(&path).expect("open");
+    // Seek is not needed — file was just written and we opened a fresh handle.
+    let err =
+        ledger::bki_read_header(&mut f, &path).expect_err("expected an error for wrong version");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("incompatible .bki format version"),
+        "error message should mention 'incompatible .bki format version', got: {msg}"
+    );
+    assert!(
+        msg.contains("99"),
+        "error message should include the bad version number 99, got: {msg}"
+    );
+}


### PR DESCRIPTION
## Summary

- Writes an 8-byte header (`BKI\0` magic + u16 LE version + 2 reserved bytes) before the XZ-compressed body in every `.bki` file produced by `ledger compile`
- Validates the header on load in `load_journal`, returning clear, actionable error messages for bad magic or an incompatible version number
- Extracts `bki_write_header` / `bki_read_header` as public library functions so they are independently testable and reusable

## Header layout

| Offset | Length | Content |
|--------|--------|---------|
| 0 | 4 | Magic: `b"BKI\0"` |
| 4 | 2 | Version: `u16` LE (= 1) |
| 6 | 2 | Reserved: `u16` LE (write 0, ignore on read) |

## Test plan

- [x] `round_trip_compile_and_load` — compile a two-transaction `.ledger` string, write to a temp `.bki`, load back via `bki_read_header` + postcard/XZ, verify journal contains the expected transactions
- [x] `bad_magic_returns_error` — write garbage bytes to a `.bki`-named temp file, confirm error message contains "missing magic header"
- [x] `empty_file_returns_missing_magic_error` — empty file also triggers the missing-magic path
- [x] `wrong_version_returns_error_with_version_number` — correct magic + version 99 → error message mentions "incompatible .bki format version" and "99"
- [x] `cargo fmt && cargo clippy -- -D warnings && cargo test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)