### PR TITLE
chore: add CHANGELOG and tag v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+## [0.1.0] - 2026-04-22
+
+First tagged release.
+
+### Pipeline
+
+- Four-stage compiler: PEG parser → resolution → elaboration → binary serialisation (postcard + XZ → `.bki`)
+- `compile()` entry point processes a ledger source string end-to-end
+- Historical price directives (`P`) parsed, resolved, and wired through to the elaborated journal
+- `define` directives enable named value aliases with context versioning
+
+### Library API (`src/lib.rs`)
+
+- `compile(source, parser)` — full pipeline, returns `elaboration::Journal`
+- `write_ledger(txns, writer)` — serialise a sequence of `resolution::Transaction` to any `Write` sink
+- `eval_transaction(txn, context)` — evaluate a single transaction through elaboration without a full journal
+- `bki_write_header(writer)` / `bki_read_header(reader, path)` — portable `.bki` header I/O with clear version-mismatch errors
+- `resolution::Transaction` and `resolution::Posting` builder APIs (`new`, `with_posting`, `with_tag`, `with_comment`, `with_metadata`, `with_amount`, `with_code`, `with_state`)
+- Typed amount shorthand: `From<(Decimal, S)> for ValueExpr`, `From<I: Into<ValueExpr>> for AmountDetails`
+
+### `.bki` binary format
+
+- 8-byte header: `BKI\0` magic + u16 version (currently 1) + u16 reserved
+- Incompatible files produce a clear error rather than a silent mis-parse
+- Body: postcard-serialised `elaboration::Journal` wrapped in XZ compression
+
+### Balance assertion enforcement
+
+- Standalone balance-assertion directives (`= amount` / `== amount`) parsed and resolved
+- Assertions enforced during elaboration; `ElaborationError::BalanceAssertionFailed` carries account, date, expected, and actual amounts
+- Posting-level balance assertions also enforced
+
+### CLI
+
+- `compile` — parse and compile a `.ledger` file to a `.bki` binary
+- `balance` — account balances with `--depth`, `--flat`, `--begin`, `--end`, `--cleared`, regex `--pattern`; text, JSON, CSV output
+- `register` — posting register with `--begin`, `--end`, `--cleared`, regex `--pattern`; text, JSON, CSV output
+- `print` — re-emit journal as canonical Ledger source text
+- `stats` — transaction/account/commodity counts and date range
+- `accounts` — list all account names
+
+### Deferred to v0.2
+
+- Query / filter DSL (#23, #45)
+- Framed postcard format with append, range-scan, and snapshot support (#17, #39–#41)
+- `JournalFilter` shared abstraction (#43)
+- `Amount` accessor ergonomics; `pub(crate)` tightening of `HIR` internals (#24)


### PR DESCRIPTION
## Summary

- Adds `CHANGELOG.md` summarising everything built in M1–M3
- After merge, tag `v0.1.0` to mark the first stable release

## What's in the release

- Four-stage pipeline (parse → resolve → elaborate → `.bki`)
- Full programmatic construction API (`resolution::Transaction`/`Posting` builders, `write_ledger`, `eval_transaction`)
- `.bki` version marker header with clear version-mismatch errors
- Balance assertion enforcement
- CLI: `balance`, `register`, `print`, `stats`, `accounts` with full filtering flags

## Deferred to v0.2

Query DSL, framed postcard format, `JournalFilter` abstraction — all tracked in open issues.

Closes #24.