### PR TITLE
chore: rename crate doppio, binary dop, format .dop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ First tagged release.
 
 ### Pipeline
 
-- Four-stage compiler: PEG parser → resolution → elaboration → binary serialisation (postcard + XZ → `.bki`)
+- Four-stage compiler: PEG parser → resolution → elaboration → binary serialisation (postcard + XZ → `.dop`)
 - `compile()` entry point processes a ledger source string end-to-end
 - Historical price directives (`P`) parsed, resolved, and wired through to the elaborated journal
 - `define` directives enable named value aliases with context versioning
@@ -16,13 +16,13 @@ First tagged release.
 - `compile(source, parser)` — full pipeline, returns `elaboration::Journal`
 - `write_ledger(txns, writer)` — serialise a sequence of `resolution::Transaction` to any `Write` sink
 - `eval_transaction(txn, context)` — evaluate a single transaction through elaboration without a full journal
-- `bki_write_header(writer)` / `bki_read_header(reader, path)` — portable `.bki` header I/O with clear version-mismatch errors
+- `dop_write_header(writer)` / `dop_read_header(reader, path)` — portable `.dop` header I/O with clear version-mismatch errors
 - `resolution::Transaction` and `resolution::Posting` builder APIs (`new`, `with_posting`, `with_tag`, `with_comment`, `with_metadata`, `with_amount`, `with_code`, `with_state`)
 - Typed amount shorthand: `From<(Decimal, S)> for ValueExpr`, `From<I: Into<ValueExpr>> for AmountDetails`
 
-### `.bki` binary format
+### `.dop` binary format
 
-- 8-byte header: `BKI\0` magic + u16 version (currently 1) + u16 reserved
+- 8-byte header: `DOP\0` magic + u16 version (currently 1) + u16 reserved
 - Incompatible files produce a clear error rather than a silent mis-parse
 - Body: postcard-serialised `elaboration::Journal` wrapped in XZ compression
 
@@ -34,7 +34,7 @@ First tagged release.
 
 ### CLI
 
-- `compile` — parse and compile a `.ledger` file to a `.bki` binary
+- `compile` — parse and compile a `.ledger` file to a `.dop` binary
 - `balance` — account balances with `--depth`, `--flat`, `--begin`, `--end`, `--cleared`, regex `--pattern`; text, JSON, CSV output
 - `register` — posting register with `--begin`, `--end`, `--cleared`, regex `--pattern`; text, JSON, CSV output
 - `print` — re-emit journal as canonical Ledger source text

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,6 +426,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "doppio"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "clap",
+ "criterion",
+ "glob",
+ "pest",
+ "pest_derive",
+ "postcard",
+ "regex",
+ "rust_decimal",
+ "serde",
+ "serde-pickle",
+ "serde_json",
+ "tempfile",
+ "xz",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,26 +667,6 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
-name = "ledger"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "clap",
- "criterion",
- "glob",
- "pest",
- "pest_derive",
- "postcard",
- "regex",
- "rust_decimal",
- "serde",
- "serde-pickle",
- "serde_json",
- "tempfile",
- "xz",
-]
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
-name = "ledger"
+name = "doppio"
 version = "0.1.0"
 edition = "2024"
 autobenches = false
+
+[[bin]]
+name = "dop"
+path = "src/main.rs"
 
 [dependencies]
 chrono = { version = "0.4.42", default-features = false, features = ["serde"] }

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -7,7 +7,7 @@ fn bench_parse(c: &mut Criterion) {
     let mut group = c.benchmark_group("parse");
     group.measurement_time(Duration::from_secs(15));
     for (name, input) in data::workloads() {
-        let mut parser = ledger::parser::Parser {
+        let mut parser = doppio::parser::Parser {
             opener: |_: &str| String::new(),
             base_path: PathBuf::new(),
         };

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -3,8 +3,8 @@ use std::{path::PathBuf, time::Duration};
 
 mod data;
 
-fn make_parser() -> ledger::parser::Parser<impl Fn(&str) -> String> {
-    ledger::parser::Parser {
+fn make_parser() -> doppio::parser::Parser<impl Fn(&str) -> String> {
+    doppio::parser::Parser {
         opener: |_: &str| String::new(),
         base_path: PathBuf::new(),
     }
@@ -17,7 +17,7 @@ fn bench_resolution(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("resolution", name), &input, |b, input| {
             b.iter_batched(
                 || make_parser().parse(input).unwrap(),
-                |ast| -> ledger::resolution::HIR { ast.try_into().unwrap() },
+                |ast| -> doppio::resolution::HIR { ast.try_into().unwrap() },
                 criterion::BatchSize::PerIteration,
             )
         });
@@ -33,10 +33,10 @@ fn bench_elaboration(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     let ast = make_parser().parse(input).unwrap();
-                    let hir: ledger::resolution::HIR = ast.try_into().unwrap();
+                    let hir: doppio::resolution::HIR = ast.try_into().unwrap();
                     hir
                 },
-                |hir| -> ledger::elaboration::Journal { hir.try_into().unwrap() },
+                |hir| -> doppio::elaboration::Journal { hir.try_into().unwrap() },
                 criterion::BatchSize::PerIteration,
             )
         });
@@ -49,7 +49,7 @@ fn bench_compile(c: &mut Criterion) {
     group.measurement_time(Duration::from_secs(20));
     for (name, input) in data::workloads() {
         group.bench_with_input(BenchmarkId::new("compile", name), &input, |b, input| {
-            b.iter(|| ledger::compile(input, make_parser()).unwrap())
+            b.iter(|| doppio::compile(input, make_parser()).unwrap())
         });
     }
     group.finish();

--- a/benches/queries.rs
+++ b/benches/queries.rs
@@ -4,8 +4,8 @@ use std::{collections::BTreeMap, path::PathBuf, time::Duration};
 
 mod data;
 
-fn make_parser() -> ledger::parser::Parser<impl Fn(&str) -> String> {
-    ledger::parser::Parser {
+fn make_parser() -> doppio::parser::Parser<impl Fn(&str) -> String> {
+    doppio::parser::Parser {
         opener: |_: &str| String::new(),
         base_path: PathBuf::new(),
     }
@@ -15,7 +15,7 @@ fn bench_balance(c: &mut Criterion) {
     let mut group = c.benchmark_group("balance");
     group.measurement_time(Duration::from_secs(12));
     for (name, input) in data::workloads() {
-        let journal = ledger::compile(&input, make_parser()).unwrap();
+        let journal = doppio::compile(&input, make_parser()).unwrap();
         group.bench_with_input(BenchmarkId::new("balance", name), &journal, |b, journal| {
             b.iter(|| {
                 let mut balances: BTreeMap<&str, BTreeMap<&str, Decimal>> = BTreeMap::new();
@@ -40,7 +40,7 @@ fn bench_balance(c: &mut Criterion) {
 fn bench_register(c: &mut Criterion) {
     let mut group = c.benchmark_group("register");
     for (name, input) in data::workloads() {
-        let journal = ledger::compile(&input, make_parser()).unwrap();
+        let journal = doppio::compile(&input, make_parser()).unwrap();
         // Filter to a pattern that matches ~20% of postings
         let pattern = "expenses";
         group.bench_with_input(

--- a/benches/serial.rs
+++ b/benches/serial.rs
@@ -3,8 +3,8 @@ use std::{io::Write as _, path::PathBuf};
 
 mod data;
 
-fn make_parser() -> ledger::parser::Parser<impl Fn(&str) -> String> {
-    ledger::parser::Parser {
+fn make_parser() -> doppio::parser::Parser<impl Fn(&str) -> String> {
+    doppio::parser::Parser {
         opener: |_: &str| String::new(),
         base_path: PathBuf::new(),
     }
@@ -13,7 +13,7 @@ fn make_parser() -> ledger::parser::Parser<impl Fn(&str) -> String> {
 fn bench_serialize(c: &mut Criterion) {
     let mut group = c.benchmark_group("serialize");
     for (name, input) in data::workloads() {
-        let journal = ledger::compile(&input, make_parser()).unwrap();
+        let journal = doppio::compile(&input, make_parser()).unwrap();
         group.bench_with_input(
             BenchmarkId::new("serialize", name),
             &journal,
@@ -32,10 +32,10 @@ fn bench_serialize(c: &mut Criterion) {
 fn bench_deserialize(c: &mut Criterion) {
     let mut group = c.benchmark_group("deserialize");
     for (name, input) in data::workloads() {
-        let journal = ledger::compile(&input, make_parser()).unwrap();
+        let journal = doppio::compile(&input, make_parser()).unwrap();
         let bytes = postcard::to_allocvec(&journal).unwrap();
         group.bench_with_input(BenchmarkId::new("deserialize", name), &bytes, |b, bytes| {
-            b.iter(|| postcard::from_bytes::<ledger::Journal>(bytes).unwrap())
+            b.iter(|| postcard::from_bytes::<doppio::Journal>(bytes).unwrap())
         });
     }
     group.finish();

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,4 +1,4 @@
-# ledger-rs Requirements
+# doppio Requirements
 
 **Last updated**: 2026-04-21
 
@@ -6,7 +6,7 @@
 
 ## How to use this document
 
-This document answers **what ledger-rs needs to do and why** — grounded in downstream consumer analysis, open issues, and design decisions. GitHub issues answer **what specific work is being done and whether it's done**.
+This document answers **what doppio needs to do and why** — grounded in downstream consumer analysis, open issues, and design decisions. GitHub issues answer **what specific work is being done and whether it's done**.
 
 - **Before starting any issue** that touches the library API or CLI behavior: read the relevant section here for context and constraints.
 - **For API design decisions**: the canonical API surface (§1, §3) is authoritative — e.g., callers construct `resolution::Transaction`, not `ast::Transaction`.
@@ -17,17 +17,17 @@ This document answers **what ledger-rs needs to do and why** — grounded in dow
 
 ## Executive Summary
 
-ledger-rs is a multi-stage Rust compiler and CLI for the Ledger plain-text accounting format. After Milestones 2 and 3, the library will expose ergonomic APIs for programmatic ledger construction and evaluation, and the CLI will support complete balance sheet filtering and reporting. The system will enforce balance assertions during elaboration and provide structured query output (JSON, CSV) alongside the default text format.
+doppio is a multi-stage Rust compiler and CLI for the Ledger plain-text accounting format. After Milestones 2 and 3, the library will expose ergonomic APIs for programmatic ledger construction and evaluation, and the CLI will support complete balance sheet filtering and reporting. The system will enforce balance assertions during elaboration and provide structured query output (JSON, CSV) alongside the default text format.
 
 **Primary users**:
-1. **Library users**: Developers embedding ledger-rs to build accounting applications, tax tools, or import scripts
+1. **Library users**: Developers embedding doppio to build accounting applications, tax tools, or import scripts
 2. **CLI users**: Accountants and individuals querying ledger files via command line
 3. **Integration users**: Systems importing ledger data from bank APIs or other sources, then writing validated ledgers
 
 **Confirmed downstream consumers**:
 - `alevy/better-bytes-ledger-import` — imports Mercury bank transactions, Gusto payroll CSVs, and recognizes grant revenue. Constructs `resolution::Transaction` / `resolution::Posting` values; reads `elaboration::Journal` for deduplication.
 - `alevy/bookie` — imports SimpleFIN bank transactions using `ast::Transaction` / `ast::Posting` for construction (not the resolution layer); reads `elaboration::Journal` for deduplication. Uses `ast::ValueExpr::parse()` for YAML-configured amount expressions.
-- `betterbytes-org/ledger` *(future migration target)* — the actual Better Bytes accounting books, currently using OG ledger-cli. Requires `!include` globs, account/tag/commodity directives, and an invoice generation workflow (Python + Typst + ledger-cli subprocess calls) to be ported to ledger-rs. See §5.1.3.
+- `betterbytes-org/ledger` *(future migration target)* — the actual Better Bytes accounting books, currently using OG ledger-cli. Requires `!include` globs, account/tag/commodity directives, and an invoice generation workflow (Python + Typst + ledger-cli subprocess calls) to be ported to doppio. See §5.1.3.
 
 ---
 
@@ -140,9 +140,9 @@ let txn = resolution::Transaction::new(date, "Payee")
   - Account name and date
 - **Status**: Not yet implemented
 
-**REQ-M3-005**: **No balance assertions in compiled `.bki` files**
+**REQ-M3-005**: **No balance assertions in compiled `.dop` files**
 - Balance assertions are checked at elaboration time but not persisted in the serialized `elaboration::Journal`
-- Deserialized `.bki` files cannot replay assertions
+- Deserialized `.dop` files cannot replay assertions
 - **Rationale**: Assertions are validation artifacts, not data to carry forward
 - **Status**: Implied by architecture; not yet tested
 
@@ -224,15 +224,15 @@ let txn = resolution::Transaction::new(date, "Payee")
 - Target: 100k+ transactions should parse in < 5 seconds on commodity hardware
 - **Evidence**: Benchmarks exist in `benches/parse.rs`, `benches/pipeline.rs`; compiled binary should be optimized with `--release`
 
-**REQ-NF-002**: **Compiled `.bki` files deserialize rapidly**
+**REQ-NF-002**: **Compiled `.dop` files deserialize rapidly**
 - Deserialization should be order-of-magnitude faster than parsing source
 - **Target**: 100k transactions in < 100ms
 - **Status**: XZ decompression + postcard deserialization; performance TBD
 
 **REQ-NF-003**: **Minimal memory footprint for queries**
 - Balance and register commands should not require re-compiling the journal
-- Load from `.bki` once, execute multiple queries without re-parsing
-- **Evidence**: CLI design accepts both `.ledger` and `.bki`
+- Load from `.dop` once, execute multiple queries without re-parsing
+- **Evidence**: CLI design accepts both `.ledger` and `.dop`
 
 ---
 
@@ -277,7 +277,7 @@ let txn = resolution::Transaction::new(date, "Payee")
 **REQ-NF-010**: **Round-trip fidelity for source files**
 - Ledger files loaded, compiled, printed should maintain semantic equivalence
 - Comments, tags, and metadata preserved
-- **Status**: Partially; comments preserved in resolution (issue #5), but `.bki` deserialization cannot restore source form
+- **Status**: Partially; comments preserved in resolution (issue #5), but `.dop` deserialization cannot restore source form
 
 ---
 
@@ -303,7 +303,7 @@ let txn = resolution::Transaction::new(date, "Payee")
 
 ### 5.1 Downstream Consumer Needs (Analysis of bookie & better-bytes-ledger-import)
 
-Both `alevy/bookie` and `alevy/better-bytes-ledger-import` were read via GitHub API in April 2026. Both use ledger-rs as a local path dependency. The analysis below documents what each downstream currently does, assesses whether that reflects genuine requirements or an accidental API choice, and recommends the canonical API each should target.
+Both `alevy/bookie` and `alevy/better-bytes-ledger-import` were read via GitHub API in April 2026. Both use doppio as a local path dependency. The analysis below documents what each downstream currently does, assesses whether that reflects genuine requirements or an accidental API choice, and recommends the canonical API each should target.
 
 **Canonical construction API: `resolution::Transaction`**
 
@@ -394,13 +394,13 @@ posting.amount.0.get("$")  // Amount(pub BTreeMap<Commodity, Decimal>)
 
 #### 5.1.3 betterbytes-org/ledger (future migration target)
 
-`betterbytes-org/ledger` is the actual accounting books for Better Bytes, currently written in OG ledger-cli. It is a **future** downstream user — not yet using ledger-rs — but it represents the most demanding real-world ledger-cli usage in this project family and is the primary litmus test for what features ledger-rs must support to be a viable replacement.
+`betterbytes-org/ledger` is the actual accounting books for Better Bytes, currently written in OG ledger-cli. It is a **future** downstream user — not yet using doppio — but it represents the most demanding real-world ledger-cli usage in this project family and is the primary litmus test for what features doppio must support to be a viable replacement.
 
 **Ledger file structure**: A hierarchical include tree (`books.ledger` → `config/config-npo.ledger` → individual config files → `org/main-org.ledger` → `programs/*.ledger`) plus glob includes (`!include ../people/*.ledger`). Each file is a focused unit (accounts by type, per-grant declarations, per-person accounts).
 
 **Features currently used in ledger-cli** (required for migration):
 
-| Feature | Example | ledger-rs status |
+| Feature | Example | doppio status |
 |---------|---------|-----------------|
 | `!include <path>` | `!include config/config-npo.ledger` | Supported |
 | `!include <glob>` | `!include ../people/*.ledger` | **Not supported** |
@@ -434,9 +434,9 @@ ledger csv -E -s --invert --no-rounding "Income:Grants:UW:HARVEST"
 # Step 5: Write Typst data files + invoke typst compile to produce PDF
 ```
 
-**What ledger-rs needs to replace `ledger.py`**:
+**What doppio needs to replace `ledger.py`**:
 
-The invoice workflow maps cleanly to ledger-rs primitives, some of which are M2/M3 scope and some deferred:
+The invoice workflow maps cleanly to doppio primitives, some of which are M2/M3 scope and some deferred:
 
 | Step | Requirement | Milestone |
 |------|------------|-----------|
@@ -446,23 +446,23 @@ The invoice workflow maps cleanly to ledger-rs primitives, some of which are M2/
 | Sum amounts per account | Iterate `journal.transactions`, filter postings, accumulate | M2 (manual today, query API in Phase 4) |
 | Write revenue recognition transaction | `resolution::Transaction` + `write_ledger()` (#30) | **M2** |
 | Output cumulative income | Same query as above with inverted filter | M2 / Phase 4 |
-| PDF generation via Typst | Out of scope for ledger-rs; external tool invocation | Never — always external |
+| PDF generation via Typst | Out of scope for doppio; external tool invocation | Never — always external |
 
 The revenue recognition transaction construction (`Step 3`) is **already implemented** in `better-bytes-ledger-import/src/revenue.rs` as a library function. It can be lifted almost verbatim once `write_ledger()` (#30) exists.
 
 **Critical insight**: The `--limit "meta('program') == '...'"` metadata expression filter (issue #45) is what makes the invoice script work correctly in multi-grant ledgers. Without it, the query would have to use account regex alone (`/^Expenses:Grants:UW:HARVEST:/`), which is sufficient for single-grant filtering but fragile at scale. This confirms issue #45 (expression-based query DSL) is a **high-value Phase 4 target**, not a nice-to-have.
 
-**Features better in ledger-rs than ledger-cli** (improvement opportunities):
+**Features better in doppio than ledger-cli** (improvement opportunities):
 
-1. **`!include` with glob**: ledger-cli's glob include (`../people/*.ledger`) is order-dependent and non-deterministic across filesystems. ledger-rs can sort glob results deterministically and report errors when the glob matches nothing.
+1. **`!include` with glob**: ledger-cli's glob include (`../people/*.ledger`) is order-dependent and non-deterministic across filesystems. doppio can sort glob results deterministically and report errors when the glob matches nothing.
 
-2. **Account `assert`/`check`**: ledger-cli runs these at transaction entry time with an opaque expression language. ledger-rs can provide:
+2. **Account `assert`/`check`**: ledger-cli runs these at transaction entry time with an opaque expression language. doppio can provide:
    - Clear error messages with account name, failing expression, transaction location
    - Type-safe assertion DSL (commodity check, tag regex) vs. free-form Lisp-like expressions
 
-3. **Balance assertions** (`=$0` at end of payroll transactions): Already parsed/resolved by ledger-rs PR #55; enforcement (#37) will make this more robust than ledger-cli's sometimes-silent handling.
+3. **Balance assertions** (`=$0` at end of payroll transactions): Already parsed/resolved by doppio PR #55; enforcement (#37) will make this more robust than ledger-cli's sometimes-silent handling.
 
-4. **`define` macros**: ledger-cli macros are global and can shadow built-ins silently. ledger-rs can scope them to their include context and produce better error messages.
+4. **`define` macros**: ledger-cli macros are global and can shadow built-ins silently. doppio can scope them to their include context and produce better error messages.
 
 ---
 
@@ -509,7 +509,7 @@ The revenue recognition transaction construction (`Step 3`) is **already impleme
 
 **REQ-GAP-004d** ⏳ Phase 4 — **`commodity`, `define`, and `tag` directives**
 - `betterbytes-org/ledger` uses: commodity format/default declarations, `define` macros (used in account assertions), and `tag` directives with value validation.
-- **Current state**: None of these are supported in ledger-rs.
+- **Current state**: None of these are supported in doppio.
 
 **REQ-GAP-005** 🔧 #37 — **Commodity conversion / FX handling in balance assertions**
 - Mixed-commodity accounts (USD + EUR) raise questions about assertion semantics. Clarify in #37 design phase.
@@ -519,10 +519,10 @@ The revenue recognition transaction construction (`Step 3`) is **already impleme
 ### 5.2 Serialization & Persistence
 
 **REQ-GAP-006** ⏳ Phase 4 (#39–#42) — **Snapshot and restore workflow**
-- Compile journal to `.bki`, ship it, deserialize for queries. Implementation tracked in #39–#42.
-- Gap: no `--snapshot` subcommand; no documented guidance on when to recompile vs. reuse `.bki`.
+- Compile journal to `.dop`, ship it, deserialize for queries. Implementation tracked in #39–#42.
+- Gap: no `--snapshot` subcommand; no documented guidance on when to recompile vs. reuse `.dop`.
 
-**REQ-GAP-007** ⏳ Phase 4 — **Incremental `.bki` updates**
+**REQ-GAP-007** ⏳ Phase 4 — **Incremental `.dop` updates**
 - Appending new transactions to a large ledger requires full recompilation. Delta-encoding or append-only mode not yet designed.
 
 ---
@@ -562,7 +562,7 @@ The revenue recognition transaction construction (`Step 3`) is **already impleme
 
 ### 6.2 Design Decisions Establishing Boundaries
 
-**No retaining original source in `.bki`** — Serialized journals cannot round-trip to source form. This is intentional: `.bki` is optimized for queries, not authoring.
+**No retaining original source in `.dop`** — Serialized journals cannot round-trip to source form. This is intentional: `.dop` is optimized for queries, not authoring.
 
 **No in-place mutation of deserialized journals** — `elaboration::Journal` is immutable. Modifications require re-elaboration from source.
 
@@ -654,7 +654,7 @@ The revenue recognition transaction construction (`Step 3`) is **already impleme
 **Overall**:
 - [ ] CLI `--help` text is complete and accurate
 - [ ] All new flags have short + long forms (where sensible)
-- [ ] Performance targets met: balance/register on 100k txn < 1 sec from `.bki`
+- [ ] Performance targets met: balance/register on 100k txn < 1 sec from `.dop`
 
 ---
 
@@ -706,7 +706,7 @@ The revenue recognition transaction construction (`Step 3`) is **already impleme
 **For library users**:
 - Quickstart: "Building transactions programmatically" with builder examples
 - API reference: Generated from doc comments; `cargo doc --no-deps`
-- Round-trip workflow: "Compiling ledgers to `.bki` and querying"
+- Round-trip workflow: "Compiling ledgers to `.dop` and querying"
 
 **For CLI users**:
 - Updated `--help` text for each subcommand
@@ -788,7 +788,7 @@ The revenue recognition transaction construction (`Step 3`) is **already impleme
 | **Context** | Immutable snapshot of active aliases and default commodity at a point in the journal |
 | **Elaboration** | Third stage: evaluating expressions, balancing txns, enforcing assertions, producing final journal |
 | **HIR** | Higher-level Intermediate Representation; output of resolution stage |
-| **.bki** | Binary ledger-rs format; postcard-serialized, XZ-compressed |
+| **.dop** | Binary doppio format; postcard-serialized, XZ-compressed |
 | **Null posting** | A posting with no explicit amount; inferred as negation of sum of other postings |
 | **Resolution** | Second stage: normalizing dates, indexing aliases, extracting metadata |
 | **ValueExpr** | Unevaluated expression tree (numbers, operators, functions, field access) |

--- a/examples/list_accounts.rs
+++ b/examples/list_accounts.rs
@@ -12,7 +12,7 @@ use std::{collections::BTreeMap, fs::File, io::Read as _, path::PathBuf};
 
 use rust_decimal::Decimal;
 
-fn load_journal(path: &PathBuf) -> Result<ledger::Journal, Box<dyn std::error::Error>> {
+fn load_journal(path: &PathBuf) -> Result<doppio::Journal, Box<dyn std::error::Error>> {
     if let Some("bki") = path.extension().and_then(|e| e.to_str()) {
         // Pre-compiled binary format: XZ-decompress then postcard-deserialise.
         // The 100 KiB scratch buffer is required by postcard's `from_io` API.
@@ -21,13 +21,13 @@ fn load_journal(path: &PathBuf) -> Result<ledger::Journal, Box<dyn std::error::E
         Ok(postcard::from_io((input_xz, &mut buf))?.0)
     } else {
         let base_path = path.parent().unwrap_or_else(|| std::path::Path::new("."));
-        let parser = ledger::parser::Parser {
-            opener: ledger::file_opener,
+        let parser = doppio::parser::Parser {
+            opener: doppio::file_opener,
             base_path: base_path.to_path_buf(),
         };
         let mut source = String::new();
         File::open(path)?.read_to_string(&mut source)?;
-        Ok(ledger::compile(&source, parser)?)
+        Ok(doppio::compile(&source, parser)?)
     }
 }
 

--- a/examples/load_and_print.rs
+++ b/examples/load_and_print.rs
@@ -8,7 +8,7 @@ fn main() {
         .read_to_string(&mut file)
         .unwrap();
     let mut file = file.as_str();
-    let output = ledger::parser::parse_ledger(&mut file).unwrap();
+    let output = doppio::parser::parse_ledger(&mut file).unwrap();
 
     println!("{:?}", output);
 }

--- a/examples/parse_and_print.rs
+++ b/examples/parse_and_print.rs
@@ -1,6 +1,6 @@
 fn main() {
     let mut input = LEDGER;
-    let output = ledger::parser::parse_ledger(&mut input).unwrap();
+    let output = doppio::parser::parse_ledger(&mut input).unwrap();
     println!("{:?}", output);
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -480,7 +480,7 @@ impl ValueExpr {
     ///
     /// # Example
     /// ```
-    /// # use ledger::ast::ValueExpr;
+    /// # use doppio::ast::ValueExpr;
     /// let expr = ValueExpr::parse("100 USD").unwrap();
     /// ```
     pub fn parse(input: &str) -> Result<ValueExpr, pest::error::Error<parser::Rule>> {

--- a/src/bin/timings.rs
+++ b/src/bin/timings.rs
@@ -25,8 +25,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // disk latency on the first run (cold page cache).
     let t0 = Instant::now();
     let base_path = source.parent().unwrap().to_path_buf();
-    let mut parser = ledger::parser::Parser {
-        opener: ledger::file_opener,
+    let mut parser = doppio::parser::Parser {
+        opener: doppio::file_opener,
         base_path,
     };
     let mut file = String::new();
@@ -42,13 +42,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --- resolution ---
     // Date normalisation, alias indexing, metadata extraction.
     let t2 = Instant::now();
-    let hir: ledger::resolution::HIR = ast.try_into()?;
+    let hir: doppio::resolution::HIR = ast.try_into()?;
     eprintln!("resolution:  {:>8.3}s", t2.elapsed().as_secs_f64());
 
     // --- elaboration ---
     // Expression evaluation, transaction balancing, account registration.
     let t3 = Instant::now();
-    let journal: ledger::elaboration::Journal = hir.try_into()?;
+    let journal: doppio::elaboration::Journal = hir.try_into()?;
     eprintln!("elaboration: {:>8.3}s", t3.elapsed().as_secs_f64());
 
     // --- serialize ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,20 +1,20 @@
-//! ledger-rs — a compiler and query library for the Ledger plain-text
+//! doppio — a compiler and query library for the Ledger plain-text
 //! accounting format.
 //!
-//! # `.bki` binary format
+//! # `.dop` binary format
 //!
-//! The `ledger compile` command serialises an elaborated journal to a `.bki`
+//! The `dop compile` command serialises an elaborated journal to a `.dop`
 //! file. The file begins with an 8-byte header followed by the postcard +
 //! XZ-compressed journal body:
 //!
 //! ```text
 //! Offset  Length  Content
-//! 0       4       Magic: b"BKI\0"
+//! 0       4       Magic: b"DOP\0"
 //! 4       2       Version: u16 LE (currently 1)
 //! 6       2       Reserved: u16 LE (write 0, ignore on read)
 //! ```
 //!
-//! Use [`bki_write_header`] / [`bki_read_header`] for portable, tested I/O of
+//! Use [`dop_write_header`] / [`dop_read_header`] for portable, tested I/O of
 //! this header.
 //!
 //! # Pipeline
@@ -26,12 +26,12 @@
 //!   → [parser]      ast::Journal        (PEG grammar + Pratt expressions)
 //!   → [resolution]  resolution::HIR     (dates, aliases, metadata)
 //!   → [elaboration] elaboration::Journal (evaluation, balancing)
-//!   → serialisation                     (postcard + XZ → .bki)
+//!   → serialisation                     (postcard + XZ → .dop)
 //! ```
 //!
 //! The top-level entry point is [`compile`], which runs all three in-memory
 //! stages and returns the elaborated [`Journal`]. For CLI usage see the
-//! `ledger` binary in `src/main.rs`.
+//! `dop` binary in `src/main.rs`.
 //!
 //! # Modules
 //!
@@ -48,7 +48,7 @@
 //! values back to canonical Ledger source text:
 //!
 //! ```rust
-//! # use ledger::resolution::{Transaction, Posting};
+//! # use doppio::resolution::{Transaction, Posting};
 //! # use chrono::NaiveDate;
 //! let txns = vec![
 //!     Transaction::new(NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(), "Groceries")
@@ -58,7 +58,7 @@
 //!         .with_posting(Posting::new("Assets:Checking")),
 //! ];
 //! let mut out = Vec::new();
-//! ledger::write_ledger(txns, &mut out).unwrap();
+//! doppio::write_ledger(txns, &mut out).unwrap();
 //! ```
 
 pub mod ast;
@@ -84,7 +84,7 @@ pub use elaboration::Journal;
 /// # Example
 ///
 /// ```rust
-/// # use ledger::resolution::{Transaction, Posting};
+/// # use doppio::resolution::{Transaction, Posting};
 /// # use chrono::NaiveDate;
 /// let txns = vec![
 ///     Transaction::new(NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(), "Groceries")
@@ -94,7 +94,7 @@ pub use elaboration::Journal;
 ///         .with_posting(Posting::new("Assets:Checking")),
 /// ];
 /// let mut out = Vec::new();
-/// ledger::write_ledger(txns, &mut out).unwrap();
+/// doppio::write_ledger(txns, &mut out).unwrap();
 /// let text = String::from_utf8(out).unwrap();
 /// assert!(text.starts_with("2024-01-15 Groceries"));
 /// ```
@@ -189,7 +189,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// use ledger::resolution::{Context, Transaction, Posting};
+/// use doppio::resolution::{Context, Transaction, Posting};
 /// use chrono::NaiveDate;
 /// use rust_decimal::Decimal;
 ///
@@ -202,7 +202,7 @@ where
 /// )
 /// .with_posting(Posting::new("Assets:Checking"));
 ///
-/// let resolved = ledger::eval_transaction(txn, &Context::default()).unwrap();
+/// let resolved = doppio::eval_transaction(txn, &Context::default()).unwrap();
 /// assert_eq!(resolved.description, "Groceries");
 /// assert_eq!(resolved.postings.len(), 2);
 /// ```
@@ -228,33 +228,33 @@ pub fn eval_transaction(
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
-// .bki header helpers
+// .dop header helpers
 // ──────────────────────────────────────────────────────────────────────────────
 
-/// Four-byte magic that identifies every `.bki` file.
-pub const BKI_MAGIC: [u8; 4] = *b"BKI\0";
+/// Four-byte magic that identifies every `.dop` file.
+pub const DOP_MAGIC: [u8; 4] = *b"DOP\0";
 
-/// Format version embedded in every `.bki` header.
+/// Format version embedded in every `.dop` header.
 ///
-/// Bump this constant (and update [`bki_read_header`]) whenever the
+/// Bump this constant (and update [`dop_read_header`]) whenever the
 /// serialisation format changes in a breaking way.
-pub const BKI_FORMAT_VERSION: u16 = 1;
+pub const DOP_FORMAT_VERSION: u16 = 1;
 
-/// Write the 8-byte `.bki` header to `writer`.
+/// Write the 8-byte `.dop` header to `writer`.
 ///
 /// Layout: magic (4 bytes) + version LE u16 (2 bytes) + reserved u16 (2 bytes).
 ///
 /// # Errors
 ///
 /// Propagates any [`std::io::Error`] from `writer`.
-pub fn bki_write_header<W: std::io::Write>(writer: &mut W) -> std::io::Result<()> {
-    writer.write_all(&BKI_MAGIC)?;
-    writer.write_all(&BKI_FORMAT_VERSION.to_le_bytes())?;
+pub fn dop_write_header<W: std::io::Write>(writer: &mut W) -> std::io::Result<()> {
+    writer.write_all(&DOP_MAGIC)?;
+    writer.write_all(&DOP_FORMAT_VERSION.to_le_bytes())?;
     writer.write_all(&0u16.to_le_bytes())?;
     Ok(())
 }
 
-/// Read and validate the 8-byte `.bki` header from `reader`.
+/// Read and validate the 8-byte `.dop` header from `reader`.
 ///
 /// `path` is used only for error messages; it should be the path of the file
 /// being opened so diagnostics point to the right location.
@@ -263,8 +263,8 @@ pub fn bki_write_header<W: std::io::Write>(writer: &mut W) -> std::io::Result<()
 ///
 /// Returns a boxed error with a user-actionable message if:
 /// - the magic bytes are missing or incorrect,
-/// - the format version is not [`BKI_FORMAT_VERSION`].
-pub fn bki_read_header<R: std::io::Read>(
+/// - the format version is not [`DOP_FORMAT_VERSION`].
+pub fn dop_read_header<R: std::io::Read>(
     reader: &mut R,
     path: &std::path::Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -272,15 +272,15 @@ pub fn bki_read_header<R: std::io::Read>(
     // A short read here means the file is too small to be valid.
     reader.read_exact(&mut magic).map_err(|_| {
         format!(
-            "{}: not a valid .bki file (missing magic header); \
-             recompile from source with `ledger compile`",
+            "{}: not a valid .dop file (missing magic header); \
+             recompile from source with `dop compile`",
             path.display()
         )
     })?;
-    if magic != BKI_MAGIC {
+    if magic != DOP_MAGIC {
         return Err(format!(
-            "{}: not a valid .bki file (missing magic header); \
-             recompile from source with `ledger compile`",
+            "{}: not a valid .dop file (missing magic header); \
+             recompile from source with `dop compile`",
             path.display()
         )
         .into());
@@ -289,14 +289,14 @@ pub fn bki_read_header<R: std::io::Read>(
     let mut version_bytes = [0u8; 2];
     reader.read_exact(&mut version_bytes)?;
     let version = u16::from_le_bytes(version_bytes);
-    if version != BKI_FORMAT_VERSION {
+    if version != DOP_FORMAT_VERSION {
         return Err(format!(
-            "{}: incompatible .bki format version {} \
+            "{}: incompatible .dop format version {} \
              (this binary supports version {}); \
-             recompile from source with `ledger compile`",
+             recompile from source with `dop compile`",
             path.display(),
             version,
-            BKI_FORMAT_VERSION,
+            DOP_FORMAT_VERSION,
         )
         .into());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,14 +17,14 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Parse and compile a ledger source file into a binary `.bki` archive.
+    /// Parse and compile a ledger source file into a binary `.dop` archive.
     ///
     /// The output is a postcard-serialised, XZ-compressed snapshot of the
-    /// elaborated journal. Loading a `.bki` file is much faster than
+    /// elaborated journal. Loading a `.dop` file is much faster than
     /// re-parsing the source, making it suitable for large ledgers that are
     /// queried repeatedly.
     Compile {
-        /// Path for the output `.bki` file.
+        /// Path for the output `.dop` file.
         #[arg(short, long)]
         output: PathBuf,
         /// Path to the root `.ledger` source file (may use `include`).
@@ -33,7 +33,7 @@ enum Commands {
 
     /// Print the running balance for every account, optionally filtered by account name.
     ///
-    /// Accepts either a raw `.ledger` source file or a pre-compiled `.bki`
+    /// Accepts either a raw `.ledger` source file or a pre-compiled `.dop`
     /// file. Output is formatted with the commodity and value right-aligned,
     /// followed by the account name.
     ///
@@ -93,7 +93,7 @@ enum Commands {
     ///
     /// Parses and resolves the source file, then prints each transaction in
     /// canonical Ledger format. Only `.ledger` source files are accepted;
-    /// pre-compiled `.bki` files do not preserve the original transaction
+    /// pre-compiled `.dop` files do not preserve the original transaction
     /// structure needed for faithful re-emission.
     Print {
         /// Path to the root `.ledger` source file.
@@ -143,19 +143,19 @@ impl OutputFormat {
     }
 }
 
-/// Load a [`ledger::Journal`] from either a compiled `.bki` file or a raw
+/// Load a [`doppio::Journal`] from either a compiled `.dop` file or a raw
 /// `.ledger` source file.
 ///
 /// The file type is detected by extension:
-/// - `.bki` — decompress with XZ and deserialise with postcard.
+/// - `.dop` — decompress with XZ and deserialise with postcard.
 /// - anything else — parse as Ledger source text, resolving `include`
 ///   directives relative to the file's parent directory.
-fn load_journal(path: &PathBuf) -> Result<ledger::Journal, Box<dyn std::error::Error>> {
-    if let Some("bki") = path.extension().and_then(|e| e.to_str()) {
+fn load_journal(path: &PathBuf) -> Result<doppio::Journal, Box<dyn std::error::Error>> {
+    if let Some("dop") = path.extension().and_then(|e| e.to_str()) {
         // Pre-compiled binary format: validate 8-byte header, then decompress
         // and deserialise.
         let mut f = File::open(path)?;
-        ledger::bki_read_header(&mut f, path)?;
+        doppio::dop_read_header(&mut f, path)?;
         // The 100 KiB scratch buffer is required by postcard's `from_io` API;
         // it does not limit the total data read.
         let input_xz = xz::read::XzDecoder::new(f);
@@ -163,13 +163,13 @@ fn load_journal(path: &PathBuf) -> Result<ledger::Journal, Box<dyn std::error::E
         Ok(postcard::from_io((input_xz, &mut buf))?.0)
     } else {
         let base_path = path.parent().unwrap().to_path_buf();
-        let parser = ledger::parser::Parser {
-            opener: ledger::file_opener,
+        let parser = doppio::parser::Parser {
+            opener: doppio::file_opener,
             base_path,
         };
         let mut file = String::new();
         File::open(path)?.read_to_string(&mut file)?;
-        Ok(ledger::compile(&file, parser)?)
+        Ok(doppio::compile(&file, parser)?)
     }
 }
 
@@ -222,16 +222,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     match cli.command {
         Commands::Compile { output, source } => {
             let base_path = source.parent().unwrap().to_path_buf();
-            let parser = ledger::parser::Parser {
-                opener: ledger::file_opener,
+            let parser = doppio::parser::Parser {
+                opener: doppio::file_opener,
                 base_path,
             };
             let mut file = String::new();
             File::open(source)?.read_to_string(&mut file)?;
-            let journal = ledger::compile(&file, parser)?;
+            let journal = doppio::compile(&file, parser)?;
             let mut out_file = File::create(output)?;
             // Write the 8-byte header: magic (4) + version LE (2) + reserved (2).
-            ledger::bki_write_header(&mut out_file)?;
+            doppio::dop_write_header(&mut out_file)?;
             let mut output_xz = xz::write::XzEncoder::new(out_file, 6);
             {
                 let mut buf = std::io::BufWriter::new(&mut output_xz);
@@ -281,7 +281,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .iter()
                 .filter(|txn| {
                     if cleared
-                        && !matches!(txn.state, ledger::elaboration::TransactionState::Cleared)
+                        && !matches!(txn.state, doppio::elaboration::TransactionState::Cleared)
                     {
                         return false;
                     }
@@ -410,21 +410,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
         Commands::Print { source } => {
-            if let Some("bki") = source.extension().and_then(|e| e.to_str()) {
+            if let Some("dop") = source.extension().and_then(|e| e.to_str()) {
                 return Err("print only works with .ledger source files; \
-                     .bki binary archives do not preserve the original transaction structure"
+                     .dop binary archives do not preserve the original transaction structure"
                     .into());
             }
             let base_path = source.parent().unwrap().to_path_buf();
-            let mut parser = ledger::parser::Parser {
-                opener: ledger::file_opener,
+            let mut parser = doppio::parser::Parser {
+                opener: doppio::file_opener,
                 base_path,
             };
             let mut file = String::new();
             File::open(&source)?.read_to_string(&mut file)?;
-            let ast_journal: ledger::ast::Journal = parser.parse(&file)?;
-            let hir: ledger::resolution::HIR = ast_journal.try_into()?;
-            ledger::write_ledger(hir.transactions(), &mut std::io::stdout())?;
+            let ast_journal: doppio::ast::Journal = parser.parse(&file)?;
+            let hir: doppio::resolution::HIR = ast_journal.try_into()?;
+            doppio::write_ledger(hir.transactions(), &mut std::io::stdout())?;
         }
         Commands::Accounts { source, pattern } => {
             let journal = load_journal(&source)?;
@@ -520,7 +520,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 BTreeMap::new();
 
             for txn in journal.transactions.iter() {
-                if cleared && !matches!(txn.state, ledger::elaboration::TransactionState::Cleared) {
+                if cleared && !matches!(txn.state, doppio::elaboration::TransactionState::Cleared) {
                     continue;
                 }
 

--- a/tests/dop_format.rs
+++ b/tests/dop_format.rs
@@ -1,7 +1,7 @@
-//! Integration tests for the `.bki` binary format header.
+//! Integration tests for the `.dop` binary format header.
 //!
-//! These tests exercise the [`ledger::bki_write_header`] /
-//! [`ledger::bki_read_header`] helpers and verify the full compile → load
+//! These tests exercise the [`doppio::dop_write_header`] /
+//! [`doppio::dop_read_header`] helpers and verify the full compile → load
 //! round-trip via the library's public API.
 
 use std::{
@@ -13,21 +13,21 @@ use tempfile::NamedTempFile;
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
-/// Compile a small ledger source string into a temp `.bki` file and return the
+/// Compile a small ledger source string into a temp `.dop` file and return the
 /// file handle (positioned at offset 0 so the caller can verify raw bytes).
-fn compile_to_bki(source: &str) -> NamedTempFile {
+fn compile_to_dop(source: &str) -> NamedTempFile {
     // Build the journal in memory.
-    let mut parser = ledger::parser::Parser {
+    let mut parser = doppio::parser::Parser {
         opener: |_: &str| String::new(),
         base_path: std::path::PathBuf::new(),
     };
     let ast = parser.parse(source).expect("parse failed");
-    let hir: ledger::resolution::HIR = ast.try_into().expect("resolution failed");
-    let journal: ledger::elaboration::Journal = hir.try_into().expect("elaboration failed");
+    let hir: doppio::resolution::HIR = ast.try_into().expect("resolution failed");
+    let journal: doppio::elaboration::Journal = hir.try_into().expect("elaboration failed");
 
-    // Write to a named temp file so we can pass its path to `bki_read_header`.
+    // Write to a named temp file so we can pass its path to `dop_read_header`.
     let mut tmp = NamedTempFile::new().expect("tmp file");
-    ledger::bki_write_header(tmp.as_file_mut()).expect("write header");
+    doppio::dop_write_header(tmp.as_file_mut()).expect("write header");
     let mut xz_enc = xz::write::XzEncoder::new(tmp.as_file_mut(), 6);
     {
         let mut buf = std::io::BufWriter::new(&mut xz_enc);
@@ -44,9 +44,9 @@ fn compile_to_bki(source: &str) -> NamedTempFile {
 }
 
 /// Load a journal from a named temp file using the library header reader.
-fn load_bki(path: &Path) -> ledger::Journal {
-    let mut f = std::fs::File::open(path).expect("open bki");
-    ledger::bki_read_header(&mut f, path).expect("read header");
+fn load_dop(path: &Path) -> doppio::Journal {
+    let mut f = std::fs::File::open(path).expect("open dop");
+    doppio::dop_read_header(&mut f, path).expect("read header");
     let input_xz = xz::read::XzDecoder::new(f);
     let mut buf = vec![0u8; 102400];
     postcard::from_io((input_xz, &mut buf))
@@ -70,8 +70,8 @@ fn round_trip_compile_and_load() {
     Assets:Checking
 ";
 
-    let tmp = compile_to_bki(source);
-    let journal = load_bki(tmp.path());
+    let tmp = compile_to_dop(source);
+    let journal = load_dop(tmp.path());
 
     assert_eq!(
         journal.transactions.len(),
@@ -88,21 +88,21 @@ fn round_trip_compile_and_load() {
     );
 }
 
-/// Writing garbage bytes to a `.bki`-named file and attempting to load it
+/// Writing garbage bytes to a `.dop`-named file and attempting to load it
 /// should produce an error whose message contains "missing magic header".
 #[test]
 fn bad_magic_returns_error() {
     let mut tmp = tempfile::Builder::new()
-        .suffix(".bki")
+        .suffix(".dop")
         .tempfile()
         .expect("tmp file");
-    tmp.write_all(b"GARBAGE_NOT_BKI_FORMAT")
+    tmp.write_all(b"GARBAGE_NOT_DOP_FORMAT")
         .expect("write garbage");
     tmp.flush().expect("flush");
 
     let path = tmp.path().to_owned();
     let mut f = std::fs::File::open(&path).expect("open");
-    let err = ledger::bki_read_header(&mut f, &path).expect_err("expected an error for bad magic");
+    let err = doppio::dop_read_header(&mut f, &path).expect_err("expected an error for bad magic");
 
     assert!(
         err.to_string().contains("missing magic header"),
@@ -115,13 +115,13 @@ fn bad_magic_returns_error() {
 #[test]
 fn empty_file_returns_missing_magic_error() {
     let tmp = tempfile::Builder::new()
-        .suffix(".bki")
+        .suffix(".dop")
         .tempfile()
         .expect("tmp file");
 
     let path = tmp.path().to_owned();
     let mut f = std::fs::File::open(&path).expect("open");
-    let err = ledger::bki_read_header(&mut f, &path).expect_err("expected an error for empty file");
+    let err = doppio::dop_read_header(&mut f, &path).expect_err("expected an error for empty file");
 
     assert!(
         err.to_string().contains("missing magic header"),
@@ -134,12 +134,12 @@ fn empty_file_returns_missing_magic_error() {
 #[test]
 fn wrong_version_returns_error_with_version_number() {
     let mut tmp = tempfile::Builder::new()
-        .suffix(".bki")
+        .suffix(".dop")
         .tempfile()
         .expect("tmp file");
 
     // Write correct magic but version = 99.
-    tmp.write_all(b"BKI\0").expect("write magic");
+    tmp.write_all(b"DOP\0").expect("write magic");
     tmp.write_all(&99u16.to_le_bytes()).expect("write version");
     tmp.write_all(&0u16.to_le_bytes()).expect("write reserved");
     tmp.flush().expect("flush");
@@ -148,12 +148,12 @@ fn wrong_version_returns_error_with_version_number() {
     let mut f = std::fs::File::open(&path).expect("open");
     // Seek is not needed — file was just written and we opened a fresh handle.
     let err =
-        ledger::bki_read_header(&mut f, &path).expect_err("expected an error for wrong version");
+        doppio::dop_read_header(&mut f, &path).expect_err("expected an error for wrong version");
 
     let msg = err.to_string();
     assert!(
-        msg.contains("incompatible .bki format version"),
-        "error message should mention 'incompatible .bki format version', got: {msg}"
+        msg.contains("incompatible .dop format version"),
+        "error message should mention 'incompatible .dop format version', got: {msg}"
     );
     assert!(
         msg.contains("99"),

--- a/tests/register.rs
+++ b/tests/register.rs
@@ -13,17 +13,17 @@ fn tmp_ledger(content: &str) -> tempfile::NamedTempFile {
     f
 }
 
-/// Run the `ledger` binary with the given arguments and return stdout as a
+/// Run the `dop` binary with the given arguments and return stdout as a
 /// `String`. Panics if the process exits non-zero.
 fn run(args: &[&str]) -> String {
-    let bin = env!("CARGO_BIN_EXE_ledger");
+    let bin = env!("CARGO_BIN_EXE_dop");
     let out = Command::new(bin)
         .args(args)
         .output()
-        .expect("failed to run ledger binary");
+        .expect("failed to run dop binary");
     if !out.status.success() {
         panic!(
-            "ledger exited with {}\nstderr: {}",
+            "dop exited with {}\nstderr: {}",
             out.status,
             String::from_utf8_lossy(&out.stderr)
         );


### PR DESCRIPTION
## Summary

- Renames the crate from `ledger` to `doppio` and the CLI binary from `ledger` to `dop`
- Renames the compiled binary format from `.bki` to `.dop` (magic bytes `DOP\0`, constants `DOP_MAGIC` / `DOP_FORMAT_VERSION`, functions `dop_write_header` / `dop_read_header`)
- Updates all source files: `src/lib.rs`, `src/main.rs`, `src/ast.rs`, `src/bin/timings.rs`, `benches/`, `examples/`, `tests/`, `CHANGELOG.md`, `docs/requirements.md`
- Renames `tests/bki_format.rs` → `tests/dop_format.rs`

## Test plan

- [x] `cargo build` — clean, zero warnings
- [x] `cargo fmt` — no changes needed
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — 72 unit tests + 4 dop_format integration tests + 11 register integration tests + 4 doctests all pass