### PR TITLE
feat: support glob patterns in include directives

### DIFF
--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -8,7 +8,7 @@ fn bench_parse(c: &mut Criterion) {
     group.measurement_time(Duration::from_secs(15));
     for (name, input) in data::workloads() {
         let mut parser = doppio::parser::Parser {
-            opener: |_: &str| String::new(),
+            opener: |_: &str| Ok(String::new()),
             base_path: PathBuf::new(),
         };
         group.bench_with_input(BenchmarkId::new("parse", name), &input, |b, input| {

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -3,8 +3,8 @@ use std::{path::PathBuf, time::Duration};
 
 mod data;
 
-fn make_parser() -> doppio::parser::Parser<impl Fn(&str) -> Result<String, Box<dyn std::error::Error>>>
-{
+fn make_parser()
+-> doppio::parser::Parser<impl Fn(&str) -> Result<String, Box<dyn std::error::Error>>> {
     doppio::parser::Parser {
         opener: |_: &str| Ok(String::new()),
         base_path: PathBuf::new(),

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -3,9 +3,10 @@ use std::{path::PathBuf, time::Duration};
 
 mod data;
 
-fn make_parser() -> doppio::parser::Parser<impl Fn(&str) -> String> {
+fn make_parser() -> doppio::parser::Parser<impl Fn(&str) -> Result<String, Box<dyn std::error::Error>>>
+{
     doppio::parser::Parser {
-        opener: |_: &str| String::new(),
+        opener: |_: &str| Ok(String::new()),
         base_path: PathBuf::new(),
     }
 }

--- a/benches/queries.rs
+++ b/benches/queries.rs
@@ -4,8 +4,8 @@ use std::{collections::BTreeMap, path::PathBuf, time::Duration};
 
 mod data;
 
-fn make_parser() -> doppio::parser::Parser<impl Fn(&str) -> Result<String, Box<dyn std::error::Error>>>
-{
+fn make_parser()
+-> doppio::parser::Parser<impl Fn(&str) -> Result<String, Box<dyn std::error::Error>>> {
     doppio::parser::Parser {
         opener: |_: &str| Ok(String::new()),
         base_path: PathBuf::new(),

--- a/benches/queries.rs
+++ b/benches/queries.rs
@@ -4,9 +4,10 @@ use std::{collections::BTreeMap, path::PathBuf, time::Duration};
 
 mod data;
 
-fn make_parser() -> doppio::parser::Parser<impl Fn(&str) -> String> {
+fn make_parser() -> doppio::parser::Parser<impl Fn(&str) -> Result<String, Box<dyn std::error::Error>>>
+{
     doppio::parser::Parser {
-        opener: |_: &str| String::new(),
+        opener: |_: &str| Ok(String::new()),
         base_path: PathBuf::new(),
     }
 }

--- a/benches/serial.rs
+++ b/benches/serial.rs
@@ -3,9 +3,10 @@ use std::{io::Write as _, path::PathBuf};
 
 mod data;
 
-fn make_parser() -> doppio::parser::Parser<impl Fn(&str) -> String> {
+fn make_parser() -> doppio::parser::Parser<impl Fn(&str) -> Result<String, Box<dyn std::error::Error>>>
+{
     doppio::parser::Parser {
-        opener: |_: &str| String::new(),
+        opener: |_: &str| Ok(String::new()),
         base_path: PathBuf::new(),
     }
 }

--- a/benches/serial.rs
+++ b/benches/serial.rs
@@ -3,8 +3,8 @@ use std::{io::Write as _, path::PathBuf};
 
 mod data;
 
-fn make_parser() -> doppio::parser::Parser<impl Fn(&str) -> Result<String, Box<dyn std::error::Error>>>
-{
+fn make_parser()
+-> doppio::parser::Parser<impl Fn(&str) -> Result<String, Box<dyn std::error::Error>>> {
     doppio::parser::Parser {
         opener: |_: &str| Ok(String::new()),
         base_path: PathBuf::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,13 @@ pub fn file_opener(pattern: &str) -> Result<String, Box<dyn std::error::Error>> 
 
     let mut buf = String::new();
     for path in &paths {
+        // Ensure each appended file starts on a fresh line. If the previous
+        // file didn't end with a newline, gluing the next file's first line
+        // onto the previous one can change parse meaning (e.g. attach a
+        // posting to the wrong transaction).
+        if !buf.is_empty() && !buf.ends_with('\n') {
+            buf.push('\n');
+        }
         std::fs::File::open(path)
             .map_err(|e| format!("include: cannot open {}: {e}", path.display()))?
             .read_to_string(&mut buf)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,22 +119,61 @@ where
 /// Load and concatenate all files matching a glob pattern.
 ///
 /// This is the default file-opener used by the CLI when processing `include`
-/// directives. Multiple files matched by a single glob (e.g.
-/// `include accounts/*.ledger`) are concatenated in the order that
-/// [`glob::glob`] returns them (lexicographic on most platforms).
+/// directives. It is passed to [`parser::Parser`] as the `opener` field.
 ///
-/// Panics if the pattern is invalid or a matched path cannot be read.
-pub fn file_opener(pattern: &str) -> String {
+/// ## Glob patterns
+///
+/// Any path containing `*`, `?`, or `[` is treated as a glob pattern. Matched
+/// files are read in **lexicographic order** (sorted by path after expansion)
+/// and concatenated into a single string.
+///
+/// A glob pattern that matches **zero** files is an error — it almost always
+/// indicates a misconfigured `include` directive or a missing file tree.
+///
+/// ## Literal paths
+///
+/// A path with no glob metacharacters is treated as a single-file include. If
+/// the file does not exist, an I/O error is returned.
+///
+/// ## Errors
+///
+/// Returns a boxed error if:
+/// - `pattern` is not a valid glob expression,
+/// - the pattern contains glob metacharacters but matches no files,
+/// - a matched path cannot be read (I/O error), or
+/// - a literal path does not exist (I/O error).
+pub fn file_opener(pattern: &str) -> Result<String, Box<dyn std::error::Error>> {
     use std::io::Read as _;
 
-    let mut buf = String::new();
-    for path in glob::glob(pattern).unwrap() {
-        std::fs::File::open(path.unwrap())
-            .unwrap()
-            .read_to_string(&mut buf)
-            .unwrap();
+    // Collect and sort all matching paths. Sorting ensures lexicographic,
+    // deterministic ordering regardless of filesystem traversal order.
+    let mut paths: Vec<_> = glob::glob(pattern)?
+        .collect::<Result<_, _>>()
+        .map_err(|e| format!("glob match error for {pattern:?}: {e}"))?;
+    paths.sort();
+
+    // A glob with metacharacters that resolves to nothing is always an error.
+    // A plain literal path that doesn't exist is caught below by the file open.
+    let is_glob = pattern.contains(['*', '?', '[']);
+    if is_glob && paths.is_empty() {
+        return Err(format!("include glob {pattern:?} matched no files").into());
     }
-    buf
+
+    // Literal path: glob returns empty when the file doesn't exist (glob
+    // silently skips non-existent literal paths). Detect this early.
+    if !is_glob && paths.is_empty() {
+        return Err(format!("include: file not found: {pattern}").into());
+    }
+
+    let mut buf = String::new();
+    for path in &paths {
+        std::fs::File::open(path)
+            .map_err(|e| format!("include: cannot open {}: {e}", path.display()))?
+            .read_to_string(&mut buf)
+            .map_err(|e| format!("include: cannot read {}: {e}", path.display()))?;
+    }
+
+    Ok(buf)
 }
 
 /// Compile Ledger source text into a fully elaborated [`Journal`].
@@ -159,7 +198,7 @@ pub fn compile<F>(
     mut parser: parser::Parser<F>,
 ) -> Result<elaboration::Journal, Box<dyn std::error::Error>>
 where
-    F: Fn(&str) -> String,
+    F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>,
 {
     let output = parser.parse(input)?;
     let hir: resolution::HIR = output.try_into()?;
@@ -321,7 +360,7 @@ mod write_ledger_tests {
     /// Parse a Ledger-format source string and return the resolved transactions.
     fn parse_transactions(source: &str) -> Vec<resolution::Transaction> {
         let mut p = parser::Parser {
-            opener: |_: &str| String::new(),
+            opener: |_: &str| Ok(String::new()),
             base_path: std::path::PathBuf::new(),
         };
         let ast_journal = p.parse(&source.to_string()).expect("parse failed");

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -43,7 +43,9 @@ pub struct LedgerParser;
 /// responsible for expanding and sorting matches; [`crate::file_opener`] does
 /// this correctly and is the default for CLI use.
 pub struct Parser<F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>> {
-    /// Called with an absolute path (or glob pattern) to load included files.
+    /// Called with the joined include path (or glob pattern) to load included
+    /// files. The path may be relative if `base_path` is relative — callers
+    /// who need absolute paths should canonicalise `base_path` before parsing.
     ///
     /// Returns the concatenated file contents on success, or a boxed error
     /// if the path does not exist, the glob matches nothing, or a file cannot

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -33,28 +33,42 @@ pub struct LedgerParser;
 /// A stateful parser that resolves `include` directives.
 ///
 /// The generic parameter `F` is the file-opener: a callable that accepts a
-/// file-system path (potentially a glob pattern) and returns its contents as
-/// a `String`. This design makes the parser testable without touching the
-/// file system — pass `|_| String::new()` for a no-op opener.
-pub struct Parser<F: Fn(&str) -> String> {
+/// file-system path (potentially a glob pattern) and returns the concatenated
+/// contents of all matching files as a `String`, or an error. This design
+/// makes the parser testable without touching the file system — pass
+/// `|_| Ok(String::new())` for a no-op opener.
+///
+/// The opener receives the fully joined path (base directory + include
+/// argument). For glob patterns (containing `*`, `?`, or `[`) the opener is
+/// responsible for expanding and sorting matches; [`crate::file_opener`] does
+/// this correctly and is the default for CLI use.
+pub struct Parser<F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>> {
     /// Called with an absolute path (or glob pattern) to load included files.
-    /// The path passed in may contain glob wildcards when the source uses
-    /// `include path/to/*.ledger`.
+    ///
+    /// Returns the concatenated file contents on success, or a boxed error
+    /// if the path does not exist, the glob matches nothing, or a file cannot
+    /// be read. The error message is surfaced to the caller of
+    /// [`Parser::parse`].
     pub opener: F,
     /// The directory of the file currently being parsed. Used to resolve
     /// relative paths in `include` directives.
     pub base_path: PathBuf,
 }
 
-impl<F: Fn(&str) -> String> Parser<F> {
+impl<F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>> Parser<F> {
     /// Parse `input` (Ledger-format source text) into an [`ast::Journal`].
     ///
     /// `include` directives are expanded inline: the included file's entries
     /// are inserted at the position of the directive in the parent journal.
     /// The `base_path` and `opener` fields are used to locate included files.
     ///
-    /// Returns a `pest` parse error if the source is syntactically invalid.
-    pub fn parse(&mut self, input: &str) -> Result<Journal, pest::error::Error<Rule>> {
+    /// # Errors
+    ///
+    /// Returns a boxed error if:
+    /// - the source text is syntactically invalid (pest parse error), or
+    /// - an `include` directive's opener call fails (e.g. file not found,
+    ///   glob with no matches, I/O error).
+    pub fn parse(&mut self, input: &str) -> Result<Journal, Box<dyn std::error::Error>> {
         let pairs = LedgerParser::parse(Rule::journal, input)?;
         let mut entries = Vec::new();
 
@@ -89,7 +103,7 @@ impl<F: Fn(&str) -> String> Parser<F> {
                     // relative paths (e.g. "include accounts/*.ledger") work
                     // regardless of the process working directory.
                     let include_path = self.base_path.join(pair.into_inner().as_str());
-                    let new_input = (self.opener)(include_path.as_os_str().to_str().unwrap());
+                    let new_input = (self.opener)(include_path.as_os_str().to_str().unwrap())?;
                     // Temporarily update base_path to the included file's directory
                     // so that any further includes within it are resolved correctly.
                     let new_base_path = include_path
@@ -119,10 +133,11 @@ impl<F: Fn(&str) -> String> Parser<F> {
 /// Convenience function: parse Ledger source with no `include` support.
 ///
 /// Useful in tests and benchmarks where a self-contained string is parsed
-/// and no file I/O is needed.
-pub fn parse_ledger(input: &str) -> Result<Journal, pest::error::Error<Rule>> {
+/// and no file I/O is needed. Any `include` directives in the input are
+/// silently resolved to an empty string (no entries are included).
+pub fn parse_ledger(input: &str) -> Result<Journal, Box<dyn std::error::Error>> {
     Parser {
-        opener: |_| String::new(),
+        opener: |_| Ok(String::new()),
         base_path: PathBuf::new(),
     }
     .parse(input)

--- a/tests/dop_format.rs
+++ b/tests/dop_format.rs
@@ -18,7 +18,7 @@ use tempfile::NamedTempFile;
 fn compile_to_dop(source: &str) -> NamedTempFile {
     // Build the journal in memory.
     let mut parser = doppio::parser::Parser {
-        opener: |_: &str| String::new(),
+        opener: |_: &str| Ok(String::new()),
         base_path: std::path::PathBuf::new(),
     };
     let ast = parser.parse(source).expect("parse failed");

--- a/tests/glob_include.rs
+++ b/tests/glob_include.rs
@@ -1,0 +1,196 @@
+//! Integration tests for glob pattern support in `include` directives.
+//!
+//! These tests exercise [`doppio::file_opener`] and the include-handling path
+//! of [`doppio::parser::Parser`] against real files on disk, covering:
+//!
+//! - single-file (literal path) includes — unchanged behaviour
+//! - glob patterns matching multiple files — lexicographic ordering
+//! - recursive glob (`**`) — deep directory traversal
+//! - glob with no matches — must produce an error
+
+use std::io::Write as _;
+
+use tempfile::TempDir;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/// Create a file at `dir/name` with `content` and return its path.
+fn write_file(dir: &std::path::Path, name: &str, content: &str) -> std::path::PathBuf {
+    // Support sub-directories in `name` (e.g. "sub/a.ledger").
+    let path = dir.join(name);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("mkdir");
+    }
+    let mut f = std::fs::File::create(&path).expect("create file");
+    f.write_all(content.as_bytes()).expect("write");
+    path
+}
+
+/// Parse and compile a ledger string that uses `include` directives, with
+/// `base_path` set to `dir`. Returns the elaborated journal.
+fn compile_with_dir(
+    source: &str,
+    dir: &std::path::Path,
+) -> Result<doppio::Journal, Box<dyn std::error::Error>> {
+    let parser = doppio::parser::Parser {
+        opener: doppio::file_opener,
+        base_path: dir.to_path_buf(),
+    };
+    let mut input = source.to_owned();
+    doppio::compile(&mut input, parser)
+}
+
+// ── single-file include ───────────────────────────────────────────────────────
+
+/// A literal path `include` should work exactly as before: one file, one entry.
+#[test]
+fn single_file_include() {
+    let dir = TempDir::new().unwrap();
+
+    write_file(
+        dir.path(),
+        "accounts.ledger",
+        "2024-01-01 Single file
+    Expenses:Food  10 $
+    Assets:Checking
+",
+    );
+
+    let source = "include accounts.ledger\n";
+    let journal = compile_with_dir(source, dir.path()).expect("compile");
+    assert_eq!(journal.transactions.len(), 1);
+    assert_eq!(journal.transactions[0].description, "Single file");
+}
+
+// ── glob: multiple matches, lexicographic order ───────────────────────────────
+
+/// `include *.ledger` should include all matching files in sorted order so the
+/// transaction sequence is deterministic regardless of filesystem ordering.
+#[test]
+fn glob_multiple_files_lexicographic_order() {
+    let dir = TempDir::new().unwrap();
+
+    // Write files in reverse alphabetical order to detect any "first-found" bugs.
+    write_file(
+        dir.path(),
+        "c.ledger",
+        "2024-03-01 Charlie
+    Expenses:Food  30 $
+    Assets:Checking
+",
+    );
+    write_file(
+        dir.path(),
+        "a.ledger",
+        "2024-01-01 Alpha
+    Expenses:Food  10 $
+    Assets:Checking
+",
+    );
+    write_file(
+        dir.path(),
+        "b.ledger",
+        "2024-02-01 Bravo
+    Expenses:Food  20 $
+    Assets:Checking
+",
+    );
+
+    let source = "include *.ledger\n";
+    let journal = compile_with_dir(source, dir.path()).expect("compile");
+
+    // Files are sorted a.ledger → b.ledger → c.ledger, so transactions appear
+    // in that order.
+    assert_eq!(journal.transactions.len(), 3);
+    assert_eq!(journal.transactions[0].description, "Alpha");
+    assert_eq!(journal.transactions[1].description, "Bravo");
+    assert_eq!(journal.transactions[2].description, "Charlie");
+}
+
+// ── glob: no matches is an error ─────────────────────────────────────────────
+
+/// A glob pattern that matches no files must return an error containing the
+/// pattern text, not silently include nothing.
+#[test]
+fn glob_no_matches_is_error() {
+    let dir = TempDir::new().unwrap();
+    // No files in the directory — the glob will match nothing.
+
+    let source = "include *.ledger\n";
+    let result = compile_with_dir(source, dir.path());
+
+    assert!(
+        result.is_err(),
+        "glob with no matches should produce an error"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("matched no files") || msg.contains("*.ledger"),
+        "error message should mention the unmatched glob; got: {msg}"
+    );
+}
+
+// ── literal path not found is an error ───────────────────────────────────────
+
+/// A literal `include` path that does not exist must return an error, not
+/// silently include nothing.
+#[test]
+fn literal_path_not_found_is_error() {
+    let dir = TempDir::new().unwrap();
+    // No file named "missing.ledger" exists.
+
+    let source = "include missing.ledger\n";
+    let result = compile_with_dir(source, dir.path());
+
+    assert!(
+        result.is_err(),
+        "include of a non-existent literal path should produce an error"
+    );
+}
+
+// ── recursive glob (**) ───────────────────────────────────────────────────────
+
+/// `include people/**/*.ledger` should recurse into subdirectories and include
+/// all matching files in lexicographic (path-sorted) order.
+#[test]
+fn recursive_glob_includes_subdirectories() {
+    let dir = TempDir::new().unwrap();
+
+    write_file(
+        dir.path(),
+        "people/alice.ledger",
+        "2024-01-01 Alice salary
+    Income:Salary  -1000 $
+    Assets:Checking
+",
+    );
+    write_file(
+        dir.path(),
+        "people/bob.ledger",
+        "2024-01-02 Bob salary
+    Income:Salary  -2000 $
+    Assets:Checking
+",
+    );
+    write_file(
+        dir.path(),
+        "people/contractors/carol.ledger",
+        "2024-01-03 Carol contract
+    Income:Consulting  -500 $
+    Assets:Checking
+",
+    );
+
+    let source = "include people/**/*.ledger\n";
+    let journal = compile_with_dir(source, dir.path()).expect("compile");
+
+    // Paths sorted: people/alice.ledger, people/bob.ledger, people/contractors/carol.ledger
+    assert_eq!(
+        journal.transactions.len(),
+        3,
+        "expected 3 transactions from recursive glob"
+    );
+    assert_eq!(journal.transactions[0].description, "Alice salary");
+    assert_eq!(journal.transactions[1].description, "Bob salary");
+    assert_eq!(journal.transactions[2].description, "Carol contract");
+}

--- a/tests/glob_include.rs
+++ b/tests/glob_include.rs
@@ -194,3 +194,40 @@ fn recursive_glob_includes_subdirectories() {
     assert_eq!(journal.transactions[1].description, "Bob salary");
     assert_eq!(journal.transactions[2].description, "Carol contract");
 }
+
+// ── concatenation safety ─────────────────────────────────────────────────────
+
+/// Files included via a glob that don't end with a trailing newline must still
+/// parse correctly when concatenated. Without a separator, the next file's
+/// first line would be glued onto the previous file's last line.
+#[test]
+fn glob_files_without_trailing_newline_are_separated() {
+    let dir = TempDir::new().unwrap();
+
+    // No trailing newline on either file.
+    write_file(
+        dir.path(),
+        "a.ledger",
+        "2024-01-01 First
+    Expenses:Food  10 $
+    Assets:Checking",
+    );
+    write_file(
+        dir.path(),
+        "b.ledger",
+        "2024-01-02 Second
+    Expenses:Food  20 $
+    Assets:Checking",
+    );
+
+    let source = "include *.ledger\n";
+    let journal = compile_with_dir(source, dir.path()).expect("compile");
+
+    assert_eq!(
+        journal.transactions.len(),
+        2,
+        "both transactions should parse despite missing trailing newlines"
+    );
+    assert_eq!(journal.transactions[0].description, "First");
+    assert_eq!(journal.transactions[1].description, "Second");
+}


### PR DESCRIPTION
## Summary

Closes #73

Implements glob pattern support for `include` directives per REQ-GAP-004b.

- **Glob expansion**: `include accounts/*.ledger` expands all matching files via the `glob` crate already in the dependency tree.
- **Deterministic ordering**: Matched paths are explicitly sorted after expansion, guaranteeing lexicographic order across all filesystems (POSIX makes no ordering guarantee for directory iteration).
- **Error on zero matches**: A glob pattern containing `*`, `?`, or `[` that matches no files returns a clear error rather than silently including nothing. A literal path that does not exist also errors (previously would silently include nothing).
- **Recursive glob**: `include people/**/*.ledger` works via `glob`'s `**` support.

## Breaking API change (pre-1.0)

`Parser<F>` opener signature and `parse_ledger`/`Parser::parse` return types changed:

| Before | After |
|--------|-------|
| `F: Fn(&str) -> String` | `F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>` |
| `Parser::parse` returns `Result<Journal, pest::error::Error<Rule>>` | returns `Result<Journal, Box<dyn std::error::Error>>` |
| `parse_ledger` returns `Result<Journal, pest::error::Error<Rule>>` | returns `Result<Journal, Box<dyn std::error::Error>>` |

Migration: change opener closures from `|_| String::new()` to `|_| Ok(String::new())`.

`?` and `.unwrap()` callsites need no changes.

## Design decisions

- **`Box<dyn Error>` over a custom error enum**: The opener is a user-supplied callback; a custom enum would require every user-defined error type to be wrapped. `Box<dyn Error>` is the minimal change that threads errors through cleanly without constraining callers.
- **Explicit sort after expansion**: The `glob` crate docs say "paths are visited in an unspecified order". Sorting after collection guarantees deterministic, cross-platform lex ordering.
- **Glob logic in `file_opener`, not `Parser`**: Keeps the parser I/O-agnostic. Library users who implement custom openers can apply their own glob semantics (or none).

## Test plan

- [x] `tests/glob_include.rs`: single-file literal include, multi-file glob in lex order, zero-match glob error, literal-path-not-found error, recursive `**` glob
- [x] All existing inline tests, `tests/dop_format.rs`, and all benchmarks updated to use the new `Ok(String::new())` opener form