### PR TITLE
feat: account-level assert/check directives (closes #74)

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -140,8 +140,86 @@ pub enum AccountItem {
     Alias(String),
     /// A free-form note describing the account.
     Note(String),
+    /// A fatal assertion that every posting to this account must satisfy.
+    ///
+    /// Elaboration halts with [`crate::elaboration::ElaborationError::AccountAssertionFailed`]
+    /// if the expression evaluates to `false` for any posting.
+    Assert(BoolExpr),
+    /// A non-fatal check that every posting to this account should satisfy.
+    ///
+    /// If the expression evaluates to `false`, a warning is printed to stderr
+    /// but elaboration continues.
+    Check(BoolExpr),
     /// An unrecognised sub-directive with an optional value.
     Unknown(String, Option<String>),
+}
+
+/// A boolean expression used in `assert` / `check` account sub-directives.
+///
+/// The grammar supports a simple left-to-right structure:
+/// `lhs [cmp_op rhs] [bool_op continuation]`.
+/// Full precedence parsing of boolean operators is a TODO(#74-followup).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BoolExpr {
+    /// Left-hand side value expression (e.g. `commodity`, `amount`).
+    pub lhs: ValueExpr,
+    /// Optional comparison: operator and right-hand side.
+    pub cmp: Option<(CmpOp, ValueExpr)>,
+    /// Optional logical continuation chained to the right.
+    pub chain: Option<(BoolOp, Box<BoolExpr>)>,
+}
+
+/// Comparison operator used in [`BoolExpr`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CmpOp {
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+}
+
+impl std::fmt::Display for CmpOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CmpOp::Eq => write!(f, "=="),
+            CmpOp::Ne => write!(f, "!="),
+            CmpOp::Lt => write!(f, "<"),
+            CmpOp::Le => write!(f, "<="),
+            CmpOp::Gt => write!(f, ">"),
+            CmpOp::Ge => write!(f, ">="),
+        }
+    }
+}
+
+/// Boolean chaining operator used in [`BoolExpr`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BoolOp {
+    And,
+    Or,
+}
+
+impl std::fmt::Display for BoolOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BoolOp::And => write!(f, "and"),
+            BoolOp::Or => write!(f, "or"),
+        }
+    }
+}
+
+impl std::fmt::Display for BoolExpr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.lhs)?;
+        if let Some((op, rhs)) = &self.cmp {
+            write!(f, " {op} {rhs}")?;
+        }
+        if let Some((op, cont)) = &self.chain {
+            write!(f, " {op} {cont}")?;
+        }
+        Ok(())
+    }
 }
 
 /// A parsed date, with an optional year.

--- a/src/elaboration.rs
+++ b/src/elaboration.rs
@@ -558,8 +558,10 @@ impl TryFrom<resolution::HIR> for Journal {
 
                     // Evaluate account-level assert/check directives for each posting.
                     for (posting_index, posting) in resolved_postings.iter().enumerate() {
-                        if let Some(props) =
-                            value.global_context.account_properties.get(&posting.account)
+                        if let Some(props) = value
+                            .global_context
+                            .account_properties
+                            .get(&posting.account)
                         {
                             // Assertions and checks operate per-commodity. For
                             // multi-commodity postings each commodity is checked
@@ -576,13 +578,11 @@ impl TryFrom<resolution::HIR> for Journal {
                                     )
                                     .map_err(ElaborationError::EvaluationError)?;
                                     if !passed {
-                                        return Err(
-                                            ElaborationError::AccountAssertionFailed {
-                                                account: posting.account.clone(),
-                                                posting_index,
-                                                expression: assert_expr.to_string(),
-                                            },
-                                        );
+                                        return Err(ElaborationError::AccountAssertionFailed {
+                                            account: posting.account.clone(),
+                                            posting_index,
+                                            expression: assert_expr.to_string(),
+                                        });
                                     }
                                 }
                                 for check_expr in &props.checks {
@@ -1640,7 +1640,10 @@ account Income:Salary
 ";
         let (account, _, expression) = elaborate_assert_fails(input);
         assert_eq!(account, "Income:Salary");
-        assert!(expression.contains("amount"), "expression should mention 'amount'");
+        assert!(
+            expression.contains("amount"),
+            "expression should mention 'amount'"
+        );
     }
 
     #[test]

--- a/src/elaboration.rs
+++ b/src/elaboration.rs
@@ -71,6 +71,9 @@ pub struct HistoricalPrice {
 pub struct AccountProperties {
     /// A free-form note describing the account.
     pub note: Option<String>,
+    // Note: assert/check expressions are evaluated during elaboration and are
+    // not persisted to the serialised journal — they are a compile-time check,
+    // not runtime data.
 }
 
 /// Per-account running balance, used during elaboration to evaluate balance
@@ -230,6 +233,16 @@ pub enum ElaborationError {
     TooManyNullPostings,
     /// All postings have explicit amounts but they do not sum to zero.
     TransactionDoesNotBalance(Amount),
+    /// An `assert` expression on an account directive evaluated to `false`
+    /// for a posting to that account.
+    AccountAssertionFailed {
+        /// The account whose assertion fired.
+        account: String,
+        /// Zero-based index of the posting within the transaction.
+        posting_index: usize,
+        /// The source text of the failing expression (for diagnostics).
+        expression: String,
+    },
 }
 
 /// Error produced when evaluating a value expression (e.g., an amount or
@@ -296,6 +309,17 @@ impl Display for ElaborationError {
                      actual {actual_amount} {expected_commodity}"
                 )
             }
+            ElaborationError::AccountAssertionFailed {
+                account,
+                posting_index,
+                expression,
+            } => {
+                write!(
+                    f,
+                    "account assertion failed for posting {posting_index} to {account}: \
+                     assert {expression}"
+                )
+            }
             ElaborationError::TooManyNullPostings => {
                 write!(f, "transaction has more than one null posting")
             }
@@ -317,11 +341,11 @@ impl TryFrom<resolution::HIR> for Journal {
         // Pre-populate the accounts map from directives so that accounts
         // declared with notes but never posted to still appear in the output.
         let mut accounts = BTreeMap::new();
-        for (name, properties) in value.global_context.account_properties {
+        for (name, properties) in &value.global_context.account_properties {
             accounts.insert(
-                name,
+                name.clone(),
                 AccountProperties {
-                    note: properties.note,
+                    note: properties.note.clone(),
                 },
             );
         }
@@ -532,6 +556,57 @@ impl TryFrom<resolution::HIR> for Journal {
                         }
                     }
 
+                    // Evaluate account-level assert/check directives for each posting.
+                    for (posting_index, posting) in resolved_postings.iter().enumerate() {
+                        if let Some(props) =
+                            value.global_context.account_properties.get(&posting.account)
+                        {
+                            // Assertions and checks operate per-commodity. For
+                            // multi-commodity postings each commodity is checked
+                            // independently; in practice postings carry a single
+                            // commodity.
+                            for (commodity, &amount_val) in posting.amount.0.iter() {
+                                for assert_expr in &props.asserts {
+                                    let passed = evaluator::eval_bool_expr(
+                                        assert_expr,
+                                        amount_val,
+                                        commodity,
+                                        entry_context,
+                                        &state,
+                                    )
+                                    .map_err(ElaborationError::EvaluationError)?;
+                                    if !passed {
+                                        return Err(
+                                            ElaborationError::AccountAssertionFailed {
+                                                account: posting.account.clone(),
+                                                posting_index,
+                                                expression: assert_expr.to_string(),
+                                            },
+                                        );
+                                    }
+                                }
+                                for check_expr in &props.checks {
+                                    let passed = evaluator::eval_bool_expr(
+                                        check_expr,
+                                        amount_val,
+                                        commodity,
+                                        entry_context,
+                                        &state,
+                                    )
+                                    .map_err(ElaborationError::EvaluationError)?;
+                                    if !passed {
+                                        eprintln!(
+                                            "warning: check failed for posting {posting_index} \
+                                             to {account}: check {expr}",
+                                            account = posting.account,
+                                            expr = check_expr,
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+
                     // Update running account balances and register new accounts.
                     for posting in resolved_postings.iter() {
                         if !accounts.contains_key(&posting.account) {
@@ -595,7 +670,7 @@ mod evaluator {
     use rust_decimal::Decimal;
 
     use crate::{
-        ast::{self, ValueExpr},
+        ast::{self, BoolExpr, CmpOp, ValueExpr},
         resolution,
     };
 
@@ -631,6 +706,123 @@ mod evaluator {
                 Ok((value, commodity))
             }
             val => Err(ElaborationError::NonAmountWhereAmountExpected(val)),
+        }
+    }
+
+    /// Evaluate a [`BoolExpr`] in the context of a posting.
+    ///
+    /// `posting_amount` and `posting_commodity` are bound as `amount` and
+    /// `commodity` in the expression context, which is how account assertions
+    /// refer to the current posting's values.
+    ///
+    /// Returns `true` if the assertion passes, `false` if it fails, or an
+    /// error if expression evaluation itself fails.
+    pub fn eval_bool_expr(
+        expr: &BoolExpr,
+        posting_amount: Decimal,
+        posting_commodity: &str,
+        eval_context: &resolution::Context,
+        state: &RunningState,
+    ) -> Result<bool, EvaluationError> {
+        // Build a temporary context with `amount` and `commodity` injected.
+        let mut ctx = eval_context.clone();
+        ctx.defines.insert(
+            "amount".into(),
+            ast::ValueExpr::Amount {
+                value: posting_amount,
+                commodity: Some(posting_commodity.to_string()),
+            },
+        );
+        ctx.defines.insert(
+            "commodity".into(),
+            ast::ValueExpr::Str(posting_commodity.to_string()),
+        );
+
+        // Evaluate LHS.
+        let lhs_val = eval(expr.lhs.clone(), &ctx, state)?;
+
+        // If there's no comparison operator, the expression is truthy iff the
+        // LHS evaluates to a non-zero amount (unusual but consistent).
+        let Some((ref cmp_op, ref rhs_expr)) = expr.cmp else {
+            // Plain value — treat non-zero amount as true.
+            return Ok(match lhs_val {
+                ast::ValueExpr::Amount { value, .. } => !value.is_zero(),
+                _ => false,
+            });
+        };
+
+        let rhs_val = eval(rhs_expr.clone(), &ctx, state)?;
+
+        let result = eval_cmp(cmp_op, &lhs_val, &rhs_val)?;
+
+        // If there is a boolean chain, short-circuit accordingly.
+        match &expr.chain {
+            None => Ok(result),
+            Some((ast::BoolOp::And, cont)) => {
+                if !result {
+                    Ok(false)
+                } else {
+                    eval_bool_expr(cont, posting_amount, posting_commodity, eval_context, state)
+                }
+            }
+            Some((ast::BoolOp::Or, cont)) => {
+                if result {
+                    Ok(true)
+                } else {
+                    eval_bool_expr(cont, posting_amount, posting_commodity, eval_context, state)
+                }
+            }
+        }
+    }
+
+    /// Compare two evaluated [`ast::ValueExpr`] values with a [`CmpOp`].
+    ///
+    /// Supported comparisons:
+    /// - `Str == Str` / `Str != Str` — commodity identity checks
+    /// - `Amount cmp Amount` — numeric comparisons (same or compatible commodities)
+    ///
+    /// Returns an error for type mismatches.
+    fn eval_cmp(
+        op: &CmpOp,
+        lhs: &ast::ValueExpr,
+        rhs: &ast::ValueExpr,
+    ) -> Result<bool, EvaluationError> {
+        match (lhs, rhs) {
+            // String equality: used for `commodity == "$"`.
+            (ast::ValueExpr::Str(a), ast::ValueExpr::Str(b)) => Ok(match op {
+                CmpOp::Eq => a == b,
+                CmpOp::Ne => a != b,
+                _ => {
+                    return Err(EvaluationError::BinaryOperationTypeError((
+                        lhs.clone(),
+                        rhs.clone(),
+                        ast::Op::Add, // placeholder op; no ordering on strings
+                    )));
+                }
+            }),
+            // Numeric comparisons: used for `amount > 0`, etc.
+            (
+                ast::ValueExpr::Amount {
+                    value: v1,
+                    commodity: c1,
+                },
+                ast::ValueExpr::Amount {
+                    value: v2,
+                    commodity: c2,
+                },
+            ) if c1 == c2 || c2.is_none() => Ok(match op {
+                CmpOp::Eq => v1 == v2,
+                CmpOp::Ne => v1 != v2,
+                CmpOp::Lt => v1 < v2,
+                CmpOp::Le => v1 <= v2,
+                CmpOp::Gt => v1 > v2,
+                CmpOp::Ge => v1 >= v2,
+            }),
+            _ => Err(EvaluationError::BinaryOperationTypeError((
+                lhs.clone(),
+                rhs.clone(),
+                ast::Op::Add,
+            ))),
         }
     }
 
@@ -1361,5 +1553,158 @@ define myval = $99.00
 ";
         let journal = elaborate(input);
         assert_eq!(journal.transactions.len(), 1);
+    }
+
+    // ── Account-level assert/check tests ─────────────────────────────────────
+
+    /// Helper: attempt elaboration and expect success.
+    fn elaborate_ok(input: &str) -> Journal {
+        elaborate(input)
+    }
+
+    /// Helper: attempt elaboration and expect an `AccountAssertionFailed` error.
+    fn elaborate_assert_fails(input: &str) -> (String, usize, String) {
+        use crate::{parser::parse_ledger, resolution::HIR};
+        let ast = parse_ledger(input).expect("parse failed");
+        let hir = HIR::try_from(ast).expect("resolution failed");
+        match Journal::try_from(hir).expect_err("expected assertion failure") {
+            ElaborationError::AccountAssertionFailed {
+                account,
+                posting_index,
+                expression,
+            } => (account, posting_index, expression),
+            e => panic!("expected AccountAssertionFailed, got {e:?}"),
+        }
+    }
+
+    #[test]
+    fn test_account_assert_commodity_passes() {
+        // Posting to Assets:Checking with "$" commodity — assertion must pass.
+        let input = "\
+account Assets:Checking
+    assert commodity == \"$\"
+
+2024-01-01 Deposit
+    Assets:Checking  $500.00
+    Income:Salary
+";
+        let journal = elaborate_ok(input);
+        assert_eq!(journal.transactions.len(), 1);
+    }
+
+    #[test]
+    fn test_account_assert_commodity_fails() {
+        // Posting with wrong commodity triggers the assertion.
+        let input = "\
+account Assets:Checking
+    assert commodity == \"$\"
+
+2024-01-01 Foreign deposit
+    Assets:Checking  500 EUR
+    Income:Salary
+";
+        let (account, posting_index, expression) = elaborate_assert_fails(input);
+        assert_eq!(account, "Assets:Checking");
+        assert_eq!(posting_index, 0);
+        assert!(
+            expression.contains("commodity"),
+            "expression should mention 'commodity', got: {expression}"
+        );
+    }
+
+    #[test]
+    fn test_account_assert_amount_positive_passes() {
+        // Income account asserts amount < 0 (income postings are negative).
+        let input = "\
+account Income:Salary
+    assert amount < 0
+
+2024-01-01 Paycheck
+    Income:Salary  $-3000.00
+    Assets:Checking
+";
+        let journal = elaborate_ok(input);
+        assert_eq!(journal.transactions.len(), 1);
+    }
+
+    #[test]
+    fn test_account_assert_amount_fails() {
+        // A positive posting to an income account should trip the assertion.
+        let input = "\
+account Income:Salary
+    assert amount < 0
+
+2024-01-01 Bad entry
+    Income:Salary  $100.00
+    Assets:Checking
+";
+        let (account, _, expression) = elaborate_assert_fails(input);
+        assert_eq!(account, "Income:Salary");
+        assert!(expression.contains("amount"), "expression should mention 'amount'");
+    }
+
+    #[test]
+    fn test_multiple_asserts_all_must_pass() {
+        // Two assert lines — both must hold. First passes, second fails.
+        let input = "\
+account Assets:Savings
+    assert commodity == \"$\"
+    assert amount > 0
+
+2024-01-01 Withdrawal
+    Assets:Savings  $-100.00
+    Assets:Checking
+";
+        // commodity == "$" passes, but amount > 0 fails for -100.
+        let (account, _, _) = elaborate_assert_fails(input);
+        assert_eq!(account, "Assets:Savings");
+    }
+
+    #[test]
+    fn test_account_check_failure_does_not_halt() {
+        // `check` produces a warning but elaboration succeeds.
+        let input = "\
+account Expenses:Food
+    check amount > 0
+
+2024-01-01 Refund
+    Expenses:Food  $-10.00
+    Assets:Checking
+";
+        // Should NOT error — check is non-fatal.
+        let journal = elaborate_ok(input);
+        assert_eq!(journal.transactions.len(), 1);
+    }
+
+    #[test]
+    fn test_account_check_passing_no_warning() {
+        // check passes silently.
+        let input = "\
+account Expenses:Food
+    check amount > 0
+
+2024-01-01 Dinner
+    Expenses:Food  $25.00
+    Assets:Checking
+";
+        let journal = elaborate_ok(input);
+        assert_eq!(journal.transactions.len(), 1);
+    }
+
+    #[test]
+    fn test_assert_only_applies_to_declared_account() {
+        // Assertion on Assets:Checking does not affect Expenses:Food postings.
+        let input = "\
+account Assets:Checking
+    assert commodity == \"$\"
+
+2024-01-01 Euro lunch
+    Expenses:Food  50 EUR
+    Assets:Checking  -50 EUR
+";
+        // The Expenses:Food posting has no assertion — no error there.
+        // The Assets:Checking posting uses EUR, which fails the assertion.
+        let (account, _, _) = elaborate_assert_fails(input);
+        assert_eq!(account, "Assets:Checking");
     }
 }

--- a/src/elaboration.rs
+++ b/src/elaboration.rs
@@ -240,7 +240,11 @@ pub enum ElaborationError {
         account: String,
         /// Zero-based index of the posting within the transaction.
         posting_index: usize,
-        /// The source text of the failing expression (for diagnostics).
+        /// A rendered form of the failing expression (for diagnostics).
+        ///
+        /// Produced via the AST's `Display` impl, so formatting may be
+        /// normalized (e.g. whitespace, `$500` rendered as `500 $`) and may
+        /// not byte-match the original source text.
         expression: String,
     },
 }
@@ -741,19 +745,20 @@ mod evaluator {
         // Evaluate LHS.
         let lhs_val = eval(expr.lhs.clone(), &ctx, state)?;
 
-        // If there's no comparison operator, the expression is truthy iff the
-        // LHS evaluates to a non-zero amount (unusual but consistent).
-        let Some((ref cmp_op, ref rhs_expr)) = expr.cmp else {
-            // Plain value — treat non-zero amount as true.
-            return Ok(match lhs_val {
+        // Compute this segment's boolean value. With no comparison operator,
+        // the expression is truthy iff the LHS evaluates to a non-zero amount
+        // (unusual but consistent). Either way, an `expr.chain` continuation
+        // must still be evaluated below.
+        let result = match &expr.cmp {
+            None => match lhs_val {
                 ast::ValueExpr::Amount { value, .. } => !value.is_zero(),
                 _ => false,
-            });
+            },
+            Some((cmp_op, rhs_expr)) => {
+                let rhs_val = eval(rhs_expr.clone(), &ctx, state)?;
+                eval_cmp(cmp_op, &lhs_val, &rhs_val)?
+            }
         };
-
-        let rhs_val = eval(rhs_expr.clone(), &ctx, state)?;
-
-        let result = eval_cmp(cmp_op, &lhs_val, &rhs_val)?;
 
         // If there is a boolean chain, short-circuit accordingly.
         match &expr.chain {
@@ -1679,6 +1684,23 @@ account Assets:Savings
 ";
         let (account, _, _) = elaborate_assert_fails(input);
         assert_eq!(account, "Assets:Savings");
+    }
+
+    #[test]
+    fn test_account_assert_no_whitespace_around_cmp_op() {
+        // `amount>0` with no spaces around the comparison operator must parse
+        // and evaluate correctly. Punctuation operators don't need whitespace
+        // (matching arithmetic operators in `value_expr`).
+        let input = "\
+account Assets:Savings
+    assert amount>0
+
+2024-01-01 Deposit
+    Assets:Savings  $100.00
+    Assets:Checking
+";
+        let journal = elaborate_ok(input);
+        assert_eq!(journal.transactions.len(), 1);
     }
 
     #[test]

--- a/src/elaboration.rs
+++ b/src/elaboration.rs
@@ -810,7 +810,7 @@ mod evaluator {
                     value: v2,
                     commodity: c2,
                 },
-            ) if c1 == c2 || c2.is_none() => Ok(match op {
+            ) if c1 == c2 || c1.is_none() || c2.is_none() => Ok(match op {
                 CmpOp::Eq => v1 == v2,
                 CmpOp::Ne => v1 != v2,
                 CmpOp::Lt => v1 < v2,
@@ -1644,6 +1644,41 @@ account Income:Salary
             expression.contains("amount"),
             "expression should mention 'amount'"
         );
+    }
+
+    #[test]
+    fn test_account_assert_dimensionless_lhs_compares_with_amount() {
+        // `0 < amount` (LHS bare, RHS commodity-bearing) must work the same as
+        // `amount > 0`. The commodity-compatibility check on numeric comparisons
+        // must be symmetric — without that, this would error with
+        // BinaryOperationTypeError instead of evaluating cleanly.
+        let input = "\
+account Assets:Savings
+    assert 0 < amount
+
+2024-01-01 Deposit
+    Assets:Savings  $100.00
+    Assets:Checking
+";
+        // 0 < $100 is true — assertion passes, elaboration succeeds.
+        let journal = elaborate_ok(input);
+        assert_eq!(journal.transactions.len(), 1);
+    }
+
+    #[test]
+    fn test_account_assert_dimensionless_lhs_fails_when_false() {
+        // Same shape as above but the comparison evaluates false — the
+        // assertion should fail (not error with a type mismatch).
+        let input = "\
+account Assets:Savings
+    assert 0 < amount
+
+2024-01-01 Withdrawal
+    Assets:Savings  $-50.00
+    Assets:Checking
+";
+        let (account, _, _) = elaborate_assert_fails(input);
+        assert_eq!(account, "Assets:Savings");
     }
 
     #[test]

--- a/src/ledger.pest
+++ b/src/ledger.pest
@@ -236,7 +236,9 @@ filename = @{ (!NEWLINE ~ ANY)+ }
 // TODO(#74-followup): wire cmp_op/bool_op into the Pratt parser so that
 // complex expressions like "a > 0 and b < 10" parse correctly under full
 // precedence rules.
-bool_expr = ${ value_expr ~ (ws+ ~ cmp_op ~ ws+ ~ value_expr)? ~ (ws+ ~ bool_op ~ ws+ ~ bool_expr)? }
+// `cmp_op` separators are punctuation so they take ws*; `bool_op` is alphabetic
+// (`and`/`or`) and must be space-separated to avoid `xand` parsing as `x and`.
+bool_expr = ${ value_expr ~ (ws* ~ cmp_op ~ ws* ~ value_expr)? ~ (ws+ ~ bool_op ~ ws+ ~ bool_expr)? }
 cmp_op = @{ "==" | "!=" | "<=" | ">=" | "<" | ">" }
 bool_op = @{ "and" | "or" }
 

--- a/src/ledger.pest
+++ b/src/ledger.pest
@@ -194,10 +194,16 @@ commodity_key = @{ "alias" | "format" | "nomarket" | "default" | identifier }
 commodity_val = @{ (!NEWLINE ~ ANY)* }
 
 // An account block: declares an account and its properties (alias, note).
+// account_assert / account_check are tried before account_item so the
+// "assert" / "check" keywords are not swallowed as unknown keys.
 account_directive = ${
     "account" ~ ws+ ~ account ~ (ws* ~ note)? ~ NEWLINE ~
-    ((indent+ ~ note ~ NEWLINE) | account_item)*
+    ((indent+ ~ note ~ NEWLINE) | account_assert | account_check | account_item)*
 }
+
+// assert / check take a full boolean expression rather than a raw string.
+account_assert = ${ indent+ ~ "assert" ~ ws+ ~ bool_expr ~ (NEWLINE | EOI) }
+account_check  = ${ indent+ ~ "check"  ~ ws+ ~ bool_expr ~ (NEWLINE | EOI) }
 
 account_item = ${
     indent+ ~ account_key ~ (ws+ ~ account_val)? ~ (ws* ~ note)? ~ (NEWLINE | EOI)
@@ -222,6 +228,17 @@ filename = @{ (!NEWLINE ~ ANY)+ }
 // is NOT handled here — the grammar produces a flat left-to-right token
 // stream that is then processed by a Pratt parser in parser.rs, which
 // applies the correct precedence (* and / bind tighter than + and -).
+
+// A boolean expression used in account assert/check directives.
+// Grammar: value_expr (cmp_op value_expr)? (bool_op bool_expr)?
+// This is kept intentionally simple: no grouping, left-to-right, since
+// the Pratt parser does not yet handle boolean / comparison operators.
+// TODO(#74-followup): wire cmp_op/bool_op into the Pratt parser so that
+// complex expressions like "a > 0 and b < 10" parse correctly under full
+// precedence rules.
+bool_expr = ${ value_expr ~ (ws+ ~ cmp_op ~ ws+ ~ value_expr)? ~ (ws+ ~ bool_op ~ ws+ ~ bool_expr)? }
+cmp_op = @{ "==" | "!=" | "<=" | ">=" | "<" | ">" }
+bool_op = @{ "and" | "or" }
 
 // A value_expr is an expression optionally followed by a commodity annotation.
 // The trailing commodity form "(1 + 2) USD" creates a ValueExpr::Typed node.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -249,9 +249,9 @@ fn parse_bool_expr(pair: Pair<Rule>) -> BoolExpr {
             "!=" => CmpOp::Ne,
             "<=" => CmpOp::Le,
             ">=" => CmpOp::Ge,
-            "<"  => CmpOp::Lt,
-            ">"  => CmpOp::Gt,
-            _    => unreachable!("unknown cmp_op: {}", op_pair.as_str()),
+            "<" => CmpOp::Lt,
+            ">" => CmpOp::Gt,
+            _ => unreachable!("unknown cmp_op: {}", op_pair.as_str()),
         };
         let rhs = parse_expr(inner.next().expect("cmp_op must be followed by rhs"));
         Some((op, rhs))
@@ -264,8 +264,8 @@ fn parse_bool_expr(pair: Pair<Rule>) -> BoolExpr {
         let op_pair = inner.next().unwrap();
         let op = match op_pair.as_str() {
             "and" => BoolOp::And,
-            "or"  => BoolOp::Or,
-            _     => unreachable!("unknown bool_op: {}", op_pair.as_str()),
+            "or" => BoolOp::Or,
+            _ => unreachable!("unknown bool_op: {}", op_pair.as_str()),
         };
         let cont = parse_bool_expr(inner.next().expect("bool_op must be followed by bool_expr"));
         Some((op, Box::new(cont)))

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -195,6 +195,14 @@ fn parse_account_directive(pair: Pair<Rule>) -> Directive {
             Rule::account_item => {
                 items.push(parse_account_item(p));
             }
+            Rule::account_assert => {
+                let expr = parse_bool_expr(p.into_inner().next().unwrap());
+                items.push(AccountItem::Assert(expr));
+            }
+            Rule::account_check => {
+                let expr = parse_bool_expr(p.into_inner().next().unwrap());
+                items.push(AccountItem::Check(expr));
+            }
             _ => {}
         }
     }
@@ -219,6 +227,53 @@ fn parse_commodity_directive(pair: Pair<Rule>) -> Directive {
     }
 
     Directive::Commodity { name, notes, items }
+}
+
+/// Parse a `bool_expr` grammar node into a [`BoolExpr`] AST node.
+///
+/// The grammar rule is:
+/// ```text
+/// bool_expr = ${ value_expr ~ (cmp_op ~ value_expr)? ~ (bool_op ~ bool_expr)? }
+/// ```
+fn parse_bool_expr(pair: Pair<Rule>) -> BoolExpr {
+    let mut inner = pair.into_inner().peekable();
+
+    // First child is always the LHS value_expr.
+    let lhs = parse_expr(inner.next().expect("bool_expr must have lhs"));
+
+    // Next child (if any) is cmp_op — consume it and the following rhs.
+    let cmp = if inner.peek().map(|p| p.as_rule()) == Some(Rule::cmp_op) {
+        let op_pair = inner.next().unwrap();
+        let op = match op_pair.as_str() {
+            "==" => CmpOp::Eq,
+            "!=" => CmpOp::Ne,
+            "<=" => CmpOp::Le,
+            ">=" => CmpOp::Ge,
+            "<"  => CmpOp::Lt,
+            ">"  => CmpOp::Gt,
+            _    => unreachable!("unknown cmp_op: {}", op_pair.as_str()),
+        };
+        let rhs = parse_expr(inner.next().expect("cmp_op must be followed by rhs"));
+        Some((op, rhs))
+    } else {
+        None
+    };
+
+    // Remaining child (if any) is bool_op + bool_expr continuation.
+    let chain = if inner.peek().map(|p| p.as_rule()) == Some(Rule::bool_op) {
+        let op_pair = inner.next().unwrap();
+        let op = match op_pair.as_str() {
+            "and" => BoolOp::And,
+            "or"  => BoolOp::Or,
+            _     => unreachable!("unknown bool_op: {}", op_pair.as_str()),
+        };
+        let cont = parse_bool_expr(inner.next().expect("bool_op must be followed by bool_expr"));
+        Some((op, Box::new(cont)))
+    } else {
+        None
+    };
+
+    BoolExpr { lhs, cmp, chain }
 }
 
 fn parse_account_item(pair: Pair<Rule>) -> AccountItem {

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -131,6 +131,12 @@ pub struct CommodityProperties {
 pub struct AccountProperties {
     /// A free-form note describing the account.
     pub note: Option<String>,
+    /// Fatal assertions: every posting to this account must satisfy all of
+    /// these expressions. Elaboration halts if any fails.
+    pub asserts: Vec<ast::BoolExpr>,
+    /// Non-fatal checks: if any fail, a warning is printed to stderr but
+    /// elaboration continues.
+    pub checks: Vec<ast::BoolExpr>,
 }
 
 /// A single entry in the resolved journal, paired with its active context.
@@ -560,6 +566,12 @@ impl TryFrom<ast::Journal> for HIR {
                                     });
                             }
                             ast::AccountItem::Note(note) => global_context.note = Some(note),
+                            ast::AccountItem::Assert(expr) => {
+                                global_context.asserts.push(expr);
+                            }
+                            ast::AccountItem::Check(expr) => {
+                                global_context.checks.push(expr);
+                            }
                             ast::AccountItem::Unknown(_, _) => { /* TODO */ }
                         }
                     }


### PR DESCRIPTION
## Summary

- Adds `assert <expr>` and `check <expr>` as nested sub-directives under `account` blocks
- `assert` is fatal: if the expression evaluates to `false` for any posting to that account, elaboration halts with `ElaborationError::AccountAssertionFailed { account, posting_index, expression }`
- `check` is non-fatal: a `warning:` line is printed to stderr and elaboration continues
- Expressions expose `commodity` (string) and `amount` (decimal) as bindings for the current posting, enabling `assert commodity == "$"` and `assert amount > 0`
- Multiple `assert`/`check` lines under one account are all evaluated independently

## What was deferred

**Regex match operator `=~`** (e.g. `tag("IncomeType") =~ /^RBI/`): requires grammar extension for regex literals and a regex-aware evaluator. Left a `TODO(#74-followup)` comment in `src/ledger.pest`. Will need a separate issue.

**Function calls in assert expressions** (e.g. `incomeChecker(amount)`): requires `define` macro support (REQ-GAP-004d). The existing `define` infrastructure in the evaluator can be extended for this; tracked as a follow-up. Function-call syntax parses today but will produce an `EvaluationError::UnknownFunctionArgs` at elaboration time, giving a clear error.

**Full boolean precedence** (e.g. `a > 0 and b < 10`): the grammar's `bool_expr` rule supports chaining via `and`/`or` but uses a flat left-to-right parse rather than a full Pratt precedence pass. Complex nested boolean expressions may not associate as expected. Left a `TODO(#74-followup)` comment in `src/ledger.pest`.

## Implementation notes

- Grammar (`src/ledger.pest`): added `account_assert`, `account_check`, `bool_expr`, `cmp_op`, and `bool_op` rules. `assert`/`check` are tried before `account_item` so the keywords are not consumed as unknown sub-directives.
- AST (`src/ast.rs`): added `AccountItem::Assert(BoolExpr)`, `AccountItem::Check(BoolExpr)`, `BoolExpr`, `CmpOp`, `BoolOp`.
- Parser (`src/parser.rs`): added `parse_bool_expr` and wired it into `parse_account_directive`.
- Resolution (`src/resolution.rs`): `AccountProperties` gains `asserts: Vec<BoolExpr>` and `checks: Vec<BoolExpr>`.
- Elaboration (`src/elaboration.rs`): added `ElaborationError::AccountAssertionFailed`; assertion check loop runs after all postings in a transaction are resolved, before balance updates; `evaluator::eval_bool_expr` injects `amount` and `commodity` as `define` bindings for expression evaluation.

## Test plan

- [x] `test_account_assert_commodity_passes` — `assert commodity == "$"` passes with `$` posting
- [x] `test_account_assert_commodity_fails` — same assertion fails with `EUR` posting
- [x] `test_account_assert_amount_positive_passes` — `assert amount < 0` passes for negative income posting
- [x] `test_account_assert_amount_fails` — same assertion fails for positive posting
- [x] `test_multiple_asserts_all_must_pass` — two assert lines, second fails
- [x] `test_account_check_failure_does_not_halt` — `check` failure continues elaboration
- [x] `test_account_check_passing_no_warning` — passing `check` is silent
- [x] `test_assert_only_applies_to_declared_account` — assertion scoped to declared account only

Closes #74