### PR TITLE
feat: wire up commodity format/default/nomarket declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## [Unreleased]
+
+### Breaking changes
+
+- `.dop` binary format version bumped from 1 → 2 (adds `CommodityProperties`
+  to `elaboration::Journal`). Existing `.dop` files compiled with v0.1.0 are
+  **no longer readable** and must be recompiled with `dop compile`.
+
+### Added
+
+- `commodity` directive: `format`, `nomarket`, `note`, and `default` sub-keys
+  are now parsed, resolved, and stored in `elaboration::Journal::commodities`.
+- `balance` and `register` commands apply the declared `format` string when
+  rendering amounts (correct prefix/suffix, thousands separator, decimal places,
+  and sign placement).
+- Unrecognised `commodity` sub-keys now emit a warning instead of panicking.
+
+### Fixed
+
+- `detect_separators`: a lone separator followed by exactly 3 digits (e.g.
+  `$1.000`) is now correctly treated as a thousands separator rather than a
+  decimal point, matching ledger convention.
+- Sign placement for prefix-symbol formats: `-$100` instead of `$-100`.
+
+### Not in scope
+
+- `print` re-emits raw source text and intentionally does not apply format
+  strings — source amounts are not reformatted. Users who want formatted amounts
+  should use `balance` or `register`.
+
+---
+
 ## [0.1.0] - 2026-04-22
 
 First tagged release.

--- a/src/elaboration.rs
+++ b/src/elaboration.rs
@@ -46,9 +46,22 @@ pub struct Journal {
     pub transactions: Vec<ResolvedTransaction>,
     /// All accounts referenced by any posting, with their declared properties.
     pub accounts: BTreeMap<String, AccountProperties>,
+    /// Display and market-data properties declared in `commodity` directives.
+    pub commodities: BTreeMap<String, CommodityProperties>,
     /// Market price quotes from `P` directives, in source order, with the
     /// price expression fully evaluated to a concrete `(Decimal, commodity)`.
     pub prices: Vec<HistoricalPrice>,
+}
+
+/// Display and market-data properties of a commodity, persisted in the journal.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct CommodityProperties {
+    /// A display format string from a `format` sub-directive (e.g. `"$1,000.00"`).
+    pub format: Option<String>,
+    /// `true` if the commodity was declared with `nomarket`.
+    pub no_market: bool,
+    /// A free-form note describing the commodity.
+    pub note: Option<String>,
 }
 
 /// A fully evaluated historical price entry produced from a `P` directive.
@@ -688,9 +701,26 @@ impl TryFrom<resolution::HIR> for Journal {
             });
         }
 
+        let commodities = value
+            .global_context
+            .commodity_properties
+            .into_iter()
+            .map(|(name, p)| {
+                (
+                    name,
+                    CommodityProperties {
+                        format: p.format,
+                        no_market: p.no_market,
+                        note: p.note,
+                    },
+                )
+            })
+            .collect();
+
         Ok(Journal {
             transactions,
             accounts,
+            commodities,
             prices,
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,7 +284,7 @@ pub const DOP_MAGIC: [u8; 4] = *b"DOP\0";
 ///
 /// Bump this constant (and update [`dop_read_header`]) whenever the
 /// serialisation format changes in a breaking way.
-pub const DOP_FORMAT_VERSION: u16 = 1;
+pub const DOP_FORMAT_VERSION: u16 = 2;
 
 /// Write the 8-byte `.dop` header to `writer`.
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -373,13 +373,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             // Print one output line per commodity in the posting.
                             // The first line carries date, description, and account;
                             // subsequent commodity lines are blank in those columns.
-                            let mut commodities = posting.amount.0.iter();
-                            if let Some((commodity, amount)) = commodities.next() {
-                                let amount_str = format!("{} {}", commodity, amount);
-                                let running_str = format!(
-                                    "{} {}",
+                            let mut commodities_iter = posting.amount.0.iter();
+                            if let Some((commodity, amount)) = commodities_iter.next() {
+                                let amount_str =
+                                    display_amount(commodity, *amount, &journal.commodities);
+                                let running_str = display_amount(
                                     commodity,
-                                    running.get(commodity).copied().unwrap_or_default()
+                                    running.get(commodity).copied().unwrap_or_default(),
+                                    &journal.commodities,
                                 );
                                 println!(
                                     "{:<10}  {:<20}  {:<30}  {:>15}  {:>15}",
@@ -390,12 +391,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     running_str,
                                 );
                             }
-                            for (commodity, amount) in commodities {
-                                let amount_str = format!("{} {}", commodity, amount);
-                                let running_str = format!(
-                                    "{} {}",
+                            for (commodity, amount) in commodities_iter {
+                                let amount_str =
+                                    display_amount(commodity, *amount, &journal.commodities);
+                                let running_str = display_amount(
                                     commodity,
-                                    running.get(commodity).copied().unwrap_or_default()
+                                    running.get(commodity).copied().unwrap_or_default(),
+                                    &journal.commodities,
                                 );
                                 println!(
                                     "{:<10}  {:<20}  {:<30}  {:>15}  {:>15}",
@@ -588,13 +590,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         let indent = if flat { 0 } else { indent_depth * 2 };
                         let prefix = " ".repeat(indent);
 
-                        let mut commodities = commodities.iter();
-                        if let Some((commodity, value)) = commodities.next() {
-                            let balance = format!("{} {value}", commodity);
+                        let mut commodities_iter = commodities.iter();
+                        if let Some((commodity, value)) = commodities_iter.next() {
+                            let balance = display_amount(commodity, *value, &journal.commodities);
                             println!("{balance:>20}  {prefix}{label}");
                         }
-                        for (commodity, value) in commodities {
-                            let balance = format!("{} {value}", commodity);
+                        for (commodity, value) in commodities_iter {
+                            let balance = display_amount(commodity, *value, &journal.commodities);
                             println!("{balance:>20}");
                         }
                     }
@@ -632,6 +634,166 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
     Ok(())
+}
+
+/// Format an amount according to a commodity's declared format string.
+///
+/// The format encodes prefix/suffix position, thousand separator, decimal
+/// separator, and decimal places. Falls back to `"COMMODITY VALUE"` if the
+/// format string cannot be parsed.
+///
+/// Examples:
+/// - `"$1,000.00"` → prefix `$`, thousands `,`, decimal `.`, 2 places
+/// - `"1.000,00 EUR"` → suffix ` EUR`, thousands `.`, decimal `,`, 2 places
+/// - `"100 USD"` → suffix ` USD`, no thousands, no decimal
+fn format_amount(commodity: &str, value: rust_decimal::Decimal, format: &str) -> String {
+    // Determine prefix vs suffix by scanning for digit/sign characters.
+    // Everything before the first digit/sign is the prefix; after the last
+    // digit is the suffix (including any space).
+    let first_digit = format
+        .char_indices()
+        .find(|(_, c)| c.is_ascii_digit() || *c == '-')
+        .map(|(i, _)| i);
+    let last_digit = format
+        .char_indices()
+        .rfind(|(_, c)| c.is_ascii_digit())
+        .map(|(i, _)| i);
+
+    let (prefix, number_part, suffix) = match (first_digit, last_digit) {
+        (Some(s), Some(e)) => (&format[..s], &format[s..=e], &format[e + 1..]),
+        _ => return format!("{commodity} {value}"),
+    };
+
+    // Detect the decimal separator: the last `.` or `,` in the number portion,
+    // if it is followed by exactly N non-separator digits.
+    let (decimal_sep, thousand_sep, decimal_places) = detect_separators(number_part);
+
+    apply_format(
+        commodity,
+        value,
+        prefix,
+        suffix,
+        decimal_sep,
+        thousand_sep,
+        decimal_places,
+    )
+}
+
+/// Returns `(decimal_sep, thousand_sep, decimal_places)` by inspecting the
+/// example number in the format string.
+fn detect_separators(number: &str) -> (Option<char>, Option<char>, usize) {
+    // Find the last occurrence of '.' or ',' — that's the decimal separator.
+    let last_dot = number.rfind('.');
+    let last_comma = number.rfind(',');
+
+    let (decimal_sep, decimal_places) = match (last_dot, last_comma) {
+        (Some(di), Some(ci)) if di > ci => {
+            // dot comes last → decimal separator is '.', thousands is ','
+            let places = number.len() - di - 1;
+            (Some('.'), places)
+        }
+        (Some(di), Some(ci)) if ci > di => {
+            // comma comes last → decimal separator is ',', thousands is '.'
+            let places = number.len() - ci - 1;
+            (Some(','), places)
+        }
+        (Some(di), None) => {
+            let places = number.len() - di - 1;
+            (Some('.'), places)
+        }
+        (None, Some(ci)) => {
+            let places = number.len() - ci - 1;
+            (Some(','), places)
+        }
+        _ => (None, 0),
+    };
+
+    let thousand_sep = match decimal_sep {
+        Some('.') if number.contains(',') => Some(','),
+        Some(',') if number.contains('.') => Some('.'),
+        None if number.contains(',') => Some(','),
+        None if number.contains('.') => Some('.'),
+        _ => None,
+    };
+
+    (decimal_sep, thousand_sep, decimal_places)
+}
+
+/// Render `value` using the parsed format components.
+fn apply_format(
+    commodity: &str,
+    value: rust_decimal::Decimal,
+    prefix: &str,
+    suffix: &str,
+    decimal_sep: Option<char>,
+    thousand_sep: Option<char>,
+    decimal_places: usize,
+) -> String {
+    use rust_decimal::prelude::ToPrimitive as _;
+
+    // Re-scale the decimal to the correct number of places.
+    let scaled = value.round_dp(decimal_places as u32);
+    let is_neg = scaled.is_sign_negative();
+    let abs = scaled.abs();
+
+    // Split into integer and fractional parts.
+    let integer_part = abs.trunc().to_u64().unwrap_or(0);
+    let frac_str = if decimal_places > 0 {
+        // Produce the fractional digits by taking the remainder and padding.
+        let frac = abs.fract();
+        let multiplier = rust_decimal::Decimal::from(10u64.pow(decimal_places as u32));
+        let frac_digits = (frac * multiplier).to_u64().unwrap_or(0);
+        format!("{frac_digits:0>width$}", width = decimal_places)
+    } else {
+        String::new()
+    };
+
+    // Format integer part with optional thousand separator.
+    let int_str = if let Some(sep) = thousand_sep {
+        let s = integer_part.to_string();
+        let mut out = String::new();
+        for (i, ch) in s.chars().rev().enumerate() {
+            if i > 0 && i % 3 == 0 {
+                out.push(sep);
+            }
+            out.push(ch);
+        }
+        out.chars().rev().collect::<String>()
+    } else {
+        integer_part.to_string()
+    };
+
+    // Assemble number string.
+    let number = if decimal_places > 0 {
+        format!("{int_str}{}{frac_str}", decimal_sep.unwrap_or('.'))
+    } else {
+        int_str
+    };
+
+    let sign = if is_neg { "-" } else { "" };
+
+    // The prefix/suffix may already contain the commodity symbol. Use the
+    // format's prefix/suffix as-is if non-empty, otherwise fall back.
+    if !prefix.is_empty() || !suffix.is_empty() {
+        format!("{prefix}{sign}{number}{suffix}")
+    } else {
+        // No prefix/suffix in format (shouldn't happen, but safe fallback).
+        format!("{sign}{number} {commodity}")
+    }
+}
+
+/// Format an amount using the commodity's declared format if available,
+/// otherwise fall back to `"COMMODITY VALUE"`.
+fn display_amount(
+    commodity: &str,
+    value: rust_decimal::Decimal,
+    commodities: &std::collections::BTreeMap<String, doppio::elaboration::CommodityProperties>,
+) -> String {
+    if let Some(fmt) = commodities.get(commodity).and_then(|p| p.format.as_deref()) {
+        format_amount(commodity, value, fmt)
+    } else {
+        format!("{commodity} {value}")
+    }
 }
 
 /// Convert Unix epoch days to a `YYYY-MM-DD` string.

--- a/src/main.rs
+++ b/src/main.rs
@@ -698,12 +698,24 @@ fn detect_separators(number: &str) -> (Option<char>, Option<char>, usize) {
             (Some(','), places)
         }
         (Some(di), None) => {
-            let places = number.len() - di - 1;
-            (Some('.'), places)
+            // Single '.' with nothing else. Per ledger convention, a lone
+            // separator followed by exactly 3 digits (e.g. `1.000`) is a
+            // thousands separator, not a decimal point.
+            let trailing = number.len() - di - 1;
+            if trailing == 3 {
+                (None, 0) // treat as thousands sep; decimal_sep stays None
+            } else {
+                (Some('.'), trailing)
+            }
         }
         (None, Some(ci)) => {
-            let places = number.len() - ci - 1;
-            (Some(','), places)
+            // Same logic for a lone ',': `1,000` → thousands sep.
+            let trailing = number.len() - ci - 1;
+            if trailing == 3 {
+                (None, 0)
+            } else {
+                (Some(','), trailing)
+            }
         }
         _ => (None, 0),
     };
@@ -774,8 +786,11 @@ fn apply_format(
 
     // The prefix/suffix may already contain the commodity symbol. Use the
     // format's prefix/suffix as-is if non-empty, otherwise fall back.
+    //
+    // Sign placement: for prefix formats (e.g. `$`) the sign goes before the
+    // prefix so the result is `-$100`, not `$-100`.
     if !prefix.is_empty() || !suffix.is_empty() {
-        format!("{prefix}{sign}{number}{suffix}")
+        format!("{sign}{prefix}{number}{suffix}")
     } else {
         // No prefix/suffix in format (shouldn't happen, but safe fallback).
         format!("{sign}{number} {commodity}")

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -538,10 +538,16 @@ impl TryFrom<ast::Journal> for HIR {
                             ast::CommodityItem::Note(note) => {
                                 global_context.note = Some(note);
                             }
-                            ast::CommodityItem::Unknown(key, Some(value)) if &key == "note" => {
-                                global_context.note = Some(value);
+                            // The `Note` arm above now handles all note values;
+                            // the `Unknown("note", …)` path is superseded.
+                            ast::CommodityItem::Unknown(key, value) => {
+                                // Unrecognised commodity sub-key: skip with a
+                                // warning rather than panicking on user input.
+                                eprintln!(
+                                    "warning: ignoring unrecognised commodity directive \
+                                     sub-key `{key}` (value: {value:?})"
+                                );
                             }
-                            ast::CommodityItem::Unknown(key, value) => todo!("{key} {value:?}"),
                         }
                     }
                 }

--- a/tests/balance.rs
+++ b/tests/balance.rs
@@ -156,3 +156,24 @@ fn commodity_format_suffix_symbol_applied_to_register() {
         "formatted amount should appear as '2.500,00 EUR': {out}"
     );
 }
+
+#[test]
+fn commodity_format_single_separator_three_digits_is_thousands() {
+    // `format $1.000` — a single separator followed by exactly 3 digits is a
+    // *thousands* separator per ledger convention, not a decimal point.
+    // A balance of 1000 should render as `$1.000`, not `$1` (which would
+    // result from misinterpreting `.000` as 3 decimal places on `1.000`).
+    let content = "commodity $
+    format $1.000
+
+2024-01-01 Deposit
+    Assets:Checking  1000 $
+    Income:Salary
+";
+    let f = tmp_journal_file(content);
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+    assert!(
+        out.contains("$1.000"),
+        "amount 1000 with format '$1.000' should render as '$1.000': {out}"
+    );
+}

--- a/tests/balance.rs
+++ b/tests/balance.rs
@@ -71,3 +71,88 @@ fn balance_tag_no_match_returns_empty() {
     ]);
     assert!(out.trim().is_empty(), "expected no output: {out}");
 }
+
+// ---------------------------------------------------------------------------
+// commodity directive: default, format, nomarket
+// ---------------------------------------------------------------------------
+
+#[test]
+fn commodity_default_sets_default_commodity() {
+    // A bare amount (no commodity symbol) in a posting should be interpreted
+    // as `$` when `commodity $\n    default` is declared.
+    let content = "commodity $
+    default
+
+2024-01-01 Groceries
+    Expenses:Food  100
+    Assets:Checking
+";
+    let f = tmp_journal_file(content);
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+    // The bare `100` should be tagged as `$`, so the balance output should
+    // contain `$` as the commodity label.
+    assert!(
+        out.contains('$'),
+        "default commodity '$' should appear in balance output: {out}"
+    );
+    assert!(
+        out.contains("100"),
+        "amount 100 should appear in balance output: {out}"
+    );
+}
+
+#[test]
+fn commodity_format_prefix_symbol_applied_to_balance() {
+    // `format $1,000.00` → prefix `$`, thousands `,`, 2 decimal places.
+    // A balance of 1234.56 should render as `$1,234.56`, not `$ 1234.56`.
+    let content = "commodity $
+    format $1,000.00
+
+2024-01-01 Salary
+    Income:Salary  -1234.56 $
+    Assets:Checking  1234.56 $
+";
+    let f = tmp_journal_file(content);
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+    assert!(
+        out.contains("$1,234.56"),
+        "formatted amount should appear as '$1,234.56': {out}"
+    );
+}
+
+#[test]
+fn commodity_nomarket_stored_does_not_break_output() {
+    // `nomarket` is a flag — it should not affect output or cause an error.
+    let content = "commodity USD
+    nomarket
+
+2024-01-01 Purchase
+    Expenses:Food  50 USD
+    Assets:Checking
+";
+    let f = tmp_journal_file(content);
+    // Should not panic or produce an error.
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+    assert!(out.contains("USD"), "commodity should still appear: {out}");
+    assert!(out.contains("50"), "amount should appear: {out}");
+}
+
+#[test]
+fn commodity_format_suffix_symbol_applied_to_register() {
+    // `format 1.000,00 EUR` → suffix ` EUR`, thousands `.`, decimal `,`, 2 places.
+    let content = "commodity EUR
+    format 1.000,00 EUR
+
+2024-01-01 Invoice
+    Income:Consulting  -2500 EUR
+    Assets:Bank  2500 EUR
+";
+    let f = tmp_journal_file(content);
+    let out = run(&["register", f.path().to_str().unwrap()]);
+    // The register output should show `2,500.00 EUR` ... but the format uses
+    // `.` as thousands sep and `,` as decimal — so it should be `2.500,00 EUR`.
+    assert!(
+        out.contains("2.500,00 EUR"),
+        "formatted amount should appear as '2.500,00 EUR': {out}"
+    );
+}


### PR DESCRIPTION
## Summary

- `elaboration::Journal` now exposes `commodities: BTreeMap<String, CommodityProperties>` so format strings and nomarket flags declared in `commodity` directives survive to the CLI layer
- `format_amount` in `main.rs` parses ledger format strings (e.g. `$1,000.00`, `1.000,00 EUR`) to detect prefix/suffix position, thousand separator, decimal separator, and decimal places, then formats amounts accordingly
- `balance` and `register` text output use the commodity's declared format when present; falls back to `COMMODITY VALUE` when none is declared (no change to existing default behaviour)
- The `default` keyword was already wired in `resolution.rs`; this PR adds a test confirming it makes bare amounts pick up the declared default commodity

## Breaking change — `.dop` format version bump

`DOP_FORMAT_VERSION` was bumped from 1 → 2 to accommodate the new `CommodityProperties` field in `elaboration::Journal`. **Existing `.dop` files compiled with v0.1.0 are no longer readable** and must be recompiled with `dop compile`. The binary header check will return a clear version-mismatch error rather than a silent mis-parse.

## `print` does not apply format strings — intentional

`print` re-emits raw source text; it does not go through the evaluated-balance path. Applying commodity format strings to raw source amounts would silently rewrite the user's source, which is incorrect behaviour for a source-faithful re-emitter. Users who want amounts rendered with the declared format should use `balance` or `register`. This is consistent with how Ledger CLI itself handles `print`.

Closes #83

## Test plan

- `commodity_default_sets_default_commodity` — bare amount in posting uses `$` as commodity when declared default
- `commodity_format_prefix_symbol_applied_to_balance` — `$1,000.00` format renders `1234.56 $` as `$1,234.56`
- `commodity_format_suffix_symbol_applied_to_register` — `1.000,00 EUR` format renders `2500 EUR` as `2.500,00 EUR`
- `commodity_nomarket_stored_does_not_break_output` — `nomarket` flag does not crash or corrupt output
- `commodity_format_single_separator_three_digits_is_thousands` — `$1.000` format renders integer 1000 as `$1.000` (single separator + 3 trailing digits = thousands sep, not decimal)