### PR TITLE
fix: prevent and/or from being consumed as commodities in bool_expr chains

### DIFF
--- a/src/elaboration.rs
+++ b/src/elaboration.rs
@@ -1813,6 +1813,42 @@ account Assets:Checking
         assert_eq!(account, "Assets:Checking");
     }
 
+    #[test]
+    fn test_bool_expr_and_chain_fails_when_rhs_false() {
+        // Regression test for issue #78: `and`/`or` in a bool_expr chain were
+        // being silently consumed as a commodity by value_expr's postfix, causing
+        // the chain to be dropped and the assertion to pass incorrectly.
+        //
+        // With $50, `amount > 0 and amount < 0` evaluates as `true AND false = false`,
+        // so the assertion must fail.
+        let input = "\
+account Assets:Savings
+    assert amount > 0 and amount < 0
+
+2024-01-01 Deposit
+    Assets:Savings  $50.00
+    Assets:Checking
+";
+        let (account, _, _) = elaborate_assert_fails(input);
+        assert_eq!(account, "Assets:Savings");
+    }
+
+    #[test]
+    fn test_bool_expr_or_chain_passes_when_either_true() {
+        // `amount > 0 or amount < 0` — true for any nonzero amount.
+        // $50 > 0 is true, so the OR chain should pass.
+        let input = "\
+account Assets:Savings
+    assert amount > 0 or amount < 0
+
+2024-01-01 Deposit
+    Assets:Savings  $50.00
+    Assets:Checking
+";
+        let journal = elaborate_ok(input);
+        assert_eq!(journal.transactions.len(), 1);
+    }
+
     // -----------------------------------------------------------------------
     // Tests for balance assignment commodity inference (issue #71)
     // -----------------------------------------------------------------------

--- a/src/ledger.pest
+++ b/src/ledger.pest
@@ -244,7 +244,9 @@ bool_op = @{ "and" | "or" }
 
 // A value_expr is an expression optionally followed by a commodity annotation.
 // The trailing commodity form "(1 + 2) USD" creates a ValueExpr::Typed node.
-value_expr = ${ expr ~ (ws+ ~ commodity)? }
+// The negative lookahead `!bool_op` prevents `and`/`or` from being consumed as
+// a commodity, which would silently drop the boolean chain in `bool_expr`.
+value_expr = ${ expr ~ (ws+ ~ !bool_op ~ commodity)? }
 
 // An expression is one or more terms joined by infix operators.
 expr = ${ term ~ (ws* ~ infix_op ~ ws* ~ term)* }
@@ -278,9 +280,11 @@ function_call = ${ identifier ~ ws* ~ "(" ~ ws* ~ (expr ~ (ws* ~ "," ~ ws* ~ exp
 //   "$100"      — symbol before number (no space required)
 //   "100 USD"   — identifier commodity after number (space required)
 //   "100"       — bare number (commodity filled in from context later)
+// The negative lookahead `!bool_op` in the number-first alternative prevents
+// `and`/`or` from being consumed as a commodity (e.g., `0 and` in `amount > 0 and`).
 amount = ${
     (commodity ~ ws* ~ number)
-    | (number ~ ws+ ~ commodity)
+    | (number ~ ws+ ~ !bool_op ~ commodity)
     | number
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1041,4 +1041,36 @@ mod directed_tests {
         assert_eq!(a.account, "Liabilities:CreditCard");
         assert!(a.strict, "== should be strict");
     }
+
+    #[test]
+    fn test_bool_expr_and_chain_parses() {
+        // Regression test for issue #78: `and` was being consumed as a commodity
+        // by value_expr, causing the bool chain to be silently dropped.
+        // After the grammar fix, the chain must survive round-trip through the parser.
+        let input = "\
+account Assets:Savings
+    assert amount > 0 and amount < 0
+";
+        let journal = parse_ledger(input).unwrap();
+        assert_eq!(journal.entries.len(), 1);
+        let Entry::Directive(Directive::Account { items, .. }) = &journal.entries[0] else {
+            panic!("expected Account directive");
+        };
+        let assert_item = items
+            .iter()
+            .find(|item| matches!(item, AccountItem::Assert(_)))
+            .expect("assert item not found");
+        let AccountItem::Assert(bool_expr) = assert_item else {
+            unreachable!()
+        };
+        // The chain must be present — if it's None, the grammar still drops `and`.
+        assert!(
+            bool_expr.chain.is_some(),
+            "bool_expr.chain should be Some(And, ...), got None — grammar fix may not be applied"
+        );
+        assert!(
+            matches!(bool_expr.chain.as_ref().unwrap().0, BoolOp::And),
+            "expected BoolOp::And in chain"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- The `amount` grammar rule's `number ~ ws+ ~ commodity` alternative was greedily consuming `and`/`or` as commodity names (e.g., `0 and` parsed as `Amount { value: 0, commodity: "and" }`), silently dropping the boolean chain in `bool_expr`
- This caused `assert amount > 0 and amount < 0` to fall back to `account_item` (parsed as unknown key `"assert"` with value `"amount > 0 and amount < 0"`) instead of matching `account_assert`, so the assertion was never evaluated
- Fix adds a `!bool_op` negative lookahead before `commodity` in the `amount` rule (the root cause) and in `value_expr`'s optional postfix-commodity alternative (defence in depth); `bool_op` was already a top-level rule so both lookaheads are valid

## Test plan

- [ ] `test_bool_expr_and_chain_fails_when_rhs_false`: `assert amount > 0 and amount < 0` with `$50` evaluates `true AND false = false` → assertion fails as expected
- [ ] `test_bool_expr_or_chain_passes_when_either_true`: `assert amount > 0 or amount < 0` with `$50` evaluates `true OR false = true` → passes
- [ ] `test_bool_expr_and_chain_parses` (parser-level): verifies that `bool_expr.chain` is `Some(And, ...)` rather than `None` after parsing
- [ ] All existing tests (92 unit + integration) continue to pass
- [ ] `cargo fmt` and `cargo clippy` clean

Closes #78