### PR TITLE
feat: regex match operators (=~ / !~) and tag() function

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -453,6 +453,9 @@ impl Display for ValueExpr {
                 Ok(())
             }
             ValueExpr::Str(s) => write!(f, "\"{s}\""),
+            // TODO: forward-slashes inside `pattern` are not re-escaped, so a
+            // pattern like `a/b` renders as `/a/b/` which does not round-trip
+            // through the parser. Fix when round-trip fidelity is required.
             ValueExpr::Regex(pattern) => write!(f, "/{pattern}/"),
             ValueExpr::Unary { op, expr } => {
                 let op = match op {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -178,6 +178,10 @@ pub enum CmpOp {
     Le,
     Gt,
     Ge,
+    /// `=~` — LHS string matches the regex RHS.
+    RegexMatch,
+    /// `!~` — LHS string does not match the regex RHS.
+    RegexNotMatch,
 }
 
 impl std::fmt::Display for CmpOp {
@@ -189,6 +193,8 @@ impl std::fmt::Display for CmpOp {
             CmpOp::Le => write!(f, "<="),
             CmpOp::Gt => write!(f, ">"),
             CmpOp::Ge => write!(f, ">="),
+            CmpOp::RegexMatch => write!(f, "=~"),
+            CmpOp::RegexNotMatch => write!(f, "!~"),
         }
     }
 }
@@ -447,6 +453,7 @@ impl Display for ValueExpr {
                 Ok(())
             }
             ValueExpr::Str(s) => write!(f, "\"{s}\""),
+            ValueExpr::Regex(pattern) => write!(f, "/{pattern}/"),
             ValueExpr::Unary { op, expr } => {
                 let op = match op {
                     Op::Add => "+",
@@ -537,6 +544,12 @@ pub enum ValueExpr {
 
     /// A string literal (double-quoted).
     Str(String),
+
+    /// A regex literal: `/pattern/`. Carries the raw pattern string between
+    /// the delimiters (backslash-escapes are preserved as written). The regex
+    /// is compiled on first use by the evaluator; it is never compiled here
+    /// at parse time, keeping the AST independent of the `regex` crate.
+    Regex(String),
 
     /// Field access on an object expression: `account("Foo").total`.
     Access { expr: Box<ValueExpr>, field: String },

--- a/src/elaboration.rs
+++ b/src/elaboration.rs
@@ -25,7 +25,7 @@
 //!   to [`Journal::accounts`], merging any properties declared in `account`
 //!   directives.
 
-use std::{cell::RefCell, collections::BTreeMap, collections::HashMap, fmt::Display};
+use std::{collections::BTreeMap, fmt::Display};
 
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -89,18 +89,9 @@ struct AccountBalances {
 /// Account balances are updated as each transaction is processed so that
 /// balance assertions and the `account()` function see the balance *before*
 /// the current posting is applied (which matches ledger-cli semantics).
-///
-/// `regex_cache` memoises compiled regexes across all postings within one
-/// elaboration run. A typical bb-ledger workload has ~10 distinct patterns
-/// repeated over hundreds of postings; compiling each once rather than per
-/// evaluation reduces compilation overhead to O(distinct patterns).
 #[derive(Default, Clone, Debug)]
 struct RunningState {
     account_balances: BTreeMap<String, AccountBalances>,
-    /// Cache of compiled regexes keyed by pattern string.
-    /// `RefCell` provides interior mutability so the cache can be populated
-    /// from `eval_cmp`, which receives only a shared reference to `RunningState`.
-    regex_cache: RefCell<HashMap<String, regex::Regex>>,
 }
 
 /// A fully evaluated and balanced transaction, ready for serialisation.
@@ -873,7 +864,7 @@ mod evaluator {
                     ast::ValueExpr::Regex(_) => rhs_expr.clone(),
                     other => eval(other.clone(), &ctx, state, posting_metadata)?,
                 };
-                eval_cmp(cmp_op, &lhs_val, &rhs_val, state)?
+                eval_cmp(cmp_op, &lhs_val, &rhs_val)?
             }
         };
 
@@ -920,34 +911,19 @@ mod evaluator {
     ///
     /// Regex matching is case-sensitive by default (Rust `regex` crate semantics).
     /// Returns an error for type mismatches or an invalid regex pattern.
-    ///
-    /// `state` is used to look up (and populate) the per-run regex cache, so
-    /// each distinct pattern is compiled at most once across all postings.
     fn eval_cmp(
         op: &CmpOp,
         lhs: &ast::ValueExpr,
         rhs: &ast::ValueExpr,
-        state: &RunningState,
     ) -> Result<bool, EvaluationError> {
         match (lhs, rhs) {
             // Regex match: LHS must be a string, RHS must be a Regex literal.
+            // Patterns are validated at parse time, so compilation here cannot
+            // fail in well-formed input.
             (ast::ValueExpr::Str(text), ast::ValueExpr::Regex(pattern)) => {
-                // Look up the compiled regex in the per-run cache. On a miss,
-                // compile and insert. This ensures each distinct pattern is
-                // compiled exactly once across all postings in one elaboration run.
-                let mut cache = state.regex_cache.borrow_mut();
-                let re = if let Some(re) = cache.get(pattern.as_str()) {
-                    // SAFETY: we return a reference into the map entry; to avoid
-                    // lifetime issues we clone the Regex (cheap — Arc inside).
-                    re.clone()
-                } else {
-                    let re = Regex::new(pattern).map_err(|e| {
-                        EvaluationError::InvalidRegexPattern(pattern.clone(), e.to_string())
-                    })?;
-                    cache.insert(pattern.clone(), re.clone());
-                    re
-                };
-                drop(cache);
+                let re = Regex::new(pattern).map_err(|e| {
+                    EvaluationError::InvalidRegexPattern(pattern.clone(), e.to_string())
+                })?;
                 // The only CmpOps valid with a Regex RHS are RegexMatch and
                 // RegexNotMatch — any other combination is a parser-level bug.
                 Ok(match op {
@@ -2382,46 +2358,21 @@ account Expenses:Food
     // Tests for invalid regex error — issue #79
     // -----------------------------------------------------------------------
 
-    /// An invalid regex pattern in an `assert` expression should produce
-    /// `EvaluationError::InvalidRegexPattern`, not a generic type-mismatch error.
+    /// An invalid regex pattern in an `assert` expression should fail at
+    /// parse time, not silently accepted to fail later during elaboration.
     #[test]
-    fn test_invalid_regex_produces_named_error() {
+    fn test_invalid_regex_fails_at_parse_time() {
+        use crate::parser::parse_ledger;
         let input = "\
 account Expenses:Food
     assert commodity =~ /[unclosed/
-
-2024-01-01 Test
-    Expenses:Food  $10.00
-    Assets:Checking
 ";
-        let result = try_elaborate(input);
-        let err = result.expect_err("invalid regex should cause elaboration to fail");
-        assert!(
-            matches!(
-                err,
-                ElaborationError::EvaluationError(EvaluationError::InvalidRegexPattern(_, _))
-            ),
-            "expected InvalidRegexPattern error, got: {err}"
-        );
-    }
-
-    /// The `Display` of `InvalidRegexPattern` should mention the offending pattern.
-    #[test]
-    fn test_invalid_regex_error_message_mentions_pattern() {
-        let input = "\
-account Expenses:Food
-    assert commodity =~ /[unclosed/
-
-2024-01-01 Test
-    Expenses:Food  $10.00
-    Assets:Checking
-";
-        let result = try_elaborate(input);
-        let err = result.expect_err("invalid regex should cause elaboration to fail");
+        let result = parse_ledger(input);
+        let err = result.expect_err("invalid regex should fail parsing");
         let msg = err.to_string();
         assert!(
-            msg.contains("[unclosed"),
-            "error message should include the invalid pattern; got: {msg}"
+            msg.contains("[unclosed") && msg.contains("invalid regex"),
+            "error message should include the invalid pattern and identify it as a regex; got: {msg}"
         );
     }
 }

--- a/src/elaboration.rs
+++ b/src/elaboration.rs
@@ -606,6 +606,7 @@ impl TryFrom<resolution::HIR> for Journal {
                                         assert_expr,
                                         amount_val,
                                         commodity,
+                                        &posting.metadata,
                                         entry_context,
                                         &state,
                                     )
@@ -623,6 +624,7 @@ impl TryFrom<resolution::HIR> for Journal {
                                         check_expr,
                                         amount_val,
                                         commodity,
+                                        &posting.metadata,
                                         entry_context,
                                         &state,
                                     )
@@ -700,6 +702,7 @@ impl TryFrom<resolution::HIR> for Journal {
 mod evaluator {
     use std::collections::BTreeMap;
 
+    use regex::Regex;
     use rust_decimal::Decimal;
 
     use crate::{
@@ -733,7 +736,11 @@ mod evaluator {
         running_state: &RunningState,
         fallback_commodity: Option<&str>,
     ) -> Result<(Decimal, String), ElaborationError> {
-        match eval(val, eval_context, running_state)? {
+        // Amount expressions don't involve posting metadata (tags); pass an
+        // empty map so the `tag()` built-in is a no-op when called from amount
+        // contexts (which would be a programmer error, but we don't panic).
+        let empty_meta = BTreeMap::default();
+        match eval(val, eval_context, running_state, &empty_meta)? {
             ast::ValueExpr::Amount { value, commodity } => {
                 let commodity = if let Some(commodity) = commodity {
                     // Apply commodity alias (e.g. "Bitcoin" → "BTC")
@@ -764,12 +771,17 @@ mod evaluator {
     /// `commodity` in the expression context, which is how account assertions
     /// refer to the current posting's values.
     ///
+    /// `posting_metadata` provides the key-value tag pairs from the posting's
+    /// notes (e.g. `; Entity: Foo` → `{"Entity": "Foo"}`). This is used by
+    /// the `tag("name")` built-in to look up metadata values.
+    ///
     /// Returns `true` if the assertion passes, `false` if it fails, or an
     /// error if expression evaluation itself fails.
     pub fn eval_bool_expr(
         expr: &BoolExpr,
         posting_amount: Decimal,
         posting_commodity: &str,
+        posting_metadata: &BTreeMap<String, String>,
         eval_context: &resolution::Context,
         state: &RunningState,
     ) -> Result<bool, EvaluationError> {
@@ -788,7 +800,7 @@ mod evaluator {
         );
 
         // Evaluate LHS.
-        let lhs_val = eval(expr.lhs.clone(), &ctx, state)?;
+        let lhs_val = eval(expr.lhs.clone(), &ctx, state, posting_metadata)?;
 
         // Compute this segment's boolean value. With no comparison operator,
         // the expression is truthy iff the LHS evaluates to a non-zero amount
@@ -800,7 +812,12 @@ mod evaluator {
                 _ => false,
             },
             Some((cmp_op, rhs_expr)) => {
-                let rhs_val = eval(rhs_expr.clone(), &ctx, state)?;
+                // For regex comparisons the RHS is already a Regex literal in
+                // the AST — pass it through to eval_cmp without re-evaluating.
+                let rhs_val = match rhs_expr {
+                    ast::ValueExpr::Regex(_) => rhs_expr.clone(),
+                    other => eval(other.clone(), &ctx, state, posting_metadata)?,
+                };
                 eval_cmp(cmp_op, &lhs_val, &rhs_val)?
             }
         };
@@ -812,14 +829,28 @@ mod evaluator {
                 if !result {
                     Ok(false)
                 } else {
-                    eval_bool_expr(cont, posting_amount, posting_commodity, eval_context, state)
+                    eval_bool_expr(
+                        cont,
+                        posting_amount,
+                        posting_commodity,
+                        posting_metadata,
+                        eval_context,
+                        state,
+                    )
                 }
             }
             Some((ast::BoolOp::Or, cont)) => {
                 if result {
                     Ok(true)
                 } else {
-                    eval_bool_expr(cont, posting_amount, posting_commodity, eval_context, state)
+                    eval_bool_expr(
+                        cont,
+                        posting_amount,
+                        posting_commodity,
+                        posting_metadata,
+                        eval_context,
+                        state,
+                    )
                 }
             }
         }
@@ -829,15 +860,42 @@ mod evaluator {
     ///
     /// Supported comparisons:
     /// - `Str == Str` / `Str != Str` — commodity identity checks
+    /// - `Str =~ Regex` / `Str !~ Regex` — regex match against a string
     /// - `Amount cmp Amount` — numeric comparisons (same or compatible commodities)
     ///
-    /// Returns an error for type mismatches.
+    /// Regex matching is case-sensitive by default (Rust `regex` crate semantics).
+    /// Returns an error for type mismatches or an invalid regex pattern.
     fn eval_cmp(
         op: &CmpOp,
         lhs: &ast::ValueExpr,
         rhs: &ast::ValueExpr,
     ) -> Result<bool, EvaluationError> {
         match (lhs, rhs) {
+            // Regex match: LHS must be a string, RHS must be a Regex literal.
+            (ast::ValueExpr::Str(text), ast::ValueExpr::Regex(pattern)) => {
+                // Compile the regex each call. For the bb-ledger workload this
+                // is acceptable — patterns appear in account directives which are
+                // few in number. A cache can be added later if profiling shows it
+                // as a hot path.
+                let re = Regex::new(pattern).map_err(|_| {
+                    EvaluationError::BinaryOperationTypeError((
+                        lhs.clone(),
+                        rhs.clone(),
+                        ast::Op::Add,
+                    ))
+                })?;
+                Ok(match op {
+                    CmpOp::RegexMatch => re.is_match(text),
+                    CmpOp::RegexNotMatch => !re.is_match(text),
+                    _ => {
+                        return Err(EvaluationError::BinaryOperationTypeError((
+                            lhs.clone(),
+                            rhs.clone(),
+                            ast::Op::Add,
+                        )));
+                    }
+                })
+            }
             // String equality: used for `commodity == "$"`.
             (ast::ValueExpr::Str(a), ast::ValueExpr::Str(b)) => Ok(match op {
                 CmpOp::Eq => a == b,
@@ -867,6 +925,14 @@ mod evaluator {
                 CmpOp::Le => v1 <= v2,
                 CmpOp::Gt => v1 > v2,
                 CmpOp::Ge => v1 >= v2,
+                // Regex operators on amounts are a type error.
+                CmpOp::RegexMatch | CmpOp::RegexNotMatch => {
+                    return Err(EvaluationError::BinaryOperationTypeError((
+                        lhs.clone(),
+                        rhs.clone(),
+                        ast::Op::Add,
+                    )));
+                }
             }),
             _ => Err(EvaluationError::BinaryOperationTypeError((
                 lhs.clone(),
@@ -881,34 +947,42 @@ mod evaluator {
     /// The evaluator reduces arithmetic, applies unary operators, resolves
     /// function calls, and handles type annotations. It does not resolve
     /// commodity aliases — that is done by `eval_and_normalize_amount`.
+    ///
+    /// `posting_metadata` carries the key-value tag pairs from the posting's
+    /// notes. It is forwarded into recursive calls and is read by the `tag()`
+    /// built-in function.
     fn eval(
         val: ast::ValueExpr,
         eval_context: &resolution::Context,
         state: &RunningState,
+        posting_metadata: &BTreeMap<String, String>,
     ) -> Result<ast::ValueExpr, EvaluationError> {
         match val {
             // Base cases: already-reduced values pass through unchanged.
             a @ ast::ValueExpr::Amount { .. } => Ok(a),
             s @ ast::ValueExpr::Str(_) => Ok(s),
+            r @ ast::ValueExpr::Regex(_) => Ok(r),
             o @ ast::ValueExpr::Object(_) => Ok(o),
 
-            ast::ValueExpr::Unary { op, expr } => match eval(*expr, eval_context, state)? {
-                ast::ValueExpr::Amount { value, commodity } => match op {
-                    ast::Op::Sub => Ok(ast::ValueExpr::Amount {
-                        value: -value,
-                        commodity,
-                    }),
-                    ast::Op::Add => Ok(ast::ValueExpr::Amount { value, commodity }),
-                    // Unary * and / are not defined for amounts.
-                    _ => Err(EvaluationError::UnaryMultiplyOrDivide),
-                },
-                val => Err(EvaluationError::UnaryOnNonAmount(val)),
-            },
+            ast::ValueExpr::Unary { op, expr } => {
+                match eval(*expr, eval_context, state, posting_metadata)? {
+                    ast::ValueExpr::Amount { value, commodity } => match op {
+                        ast::Op::Sub => Ok(ast::ValueExpr::Amount {
+                            value: -value,
+                            commodity,
+                        }),
+                        ast::Op::Add => Ok(ast::ValueExpr::Amount { value, commodity }),
+                        // Unary * and / are not defined for amounts.
+                        _ => Err(EvaluationError::UnaryMultiplyOrDivide),
+                    },
+                    val => Err(EvaluationError::UnaryOnNonAmount(val)),
+                }
+            }
 
             ast::ValueExpr::Binary { lhs, rhs, op } => {
                 match (
-                    eval(*lhs, eval_context, state)?,
-                    eval(*rhs, eval_context, state)?,
+                    eval(*lhs, eval_context, state, posting_metadata)?,
+                    eval(*rhs, eval_context, state, posting_metadata)?,
                 ) {
                     // One side has a commodity, the other is dimensionless —
                     // the commodity propagates to the result. Both match arms
@@ -1016,13 +1090,15 @@ mod evaluator {
             ast::ValueExpr::Function { name, args } => match (name.as_str(), args.as_slice()) {
                 // scrub(x) — identity function used by some ledger-cli extensions
                 // to mark amounts as "scrubbed" (processed). Treated as a no-op.
-                ("scrub", [arg]) => eval(arg.clone(), eval_context, state),
+                ("scrub", [arg]) => eval(arg.clone(), eval_context, state, posting_metadata),
 
                 // account("Name") — returns an object with a "total" field
                 // containing the current running balance of the named account.
                 // Only the primary commodity ($) is currently surfaced.
                 ("account", [account]) => {
-                    if let ValueExpr::Str(account) = eval(account.clone(), eval_context, state)? {
+                    if let ValueExpr::Str(account) =
+                        eval(account.clone(), eval_context, state, posting_metadata)?
+                    {
                         let account = eval_context
                             .account_aliases
                             .get(&account)
@@ -1047,6 +1123,28 @@ mod evaluator {
                         )))
                     }
                 }
+
+                // tag("name") — looks up a metadata key on the current posting.
+                //
+                // The posting's notes are parsed into key-value pairs by the
+                // resolution stage (e.g. `; Entity: Foo` → `{"Entity": "Foo"}`).
+                // If the key is present its value is returned as a Str; if absent
+                // an empty string is returned so that `tag("X") =~ /pattern/`
+                // works naturally (empty string never matches a non-empty pattern).
+                ("tag", [key_expr]) => {
+                    if let ValueExpr::Str(key) =
+                        eval(key_expr.clone(), eval_context, state, posting_metadata)?
+                    {
+                        let value = posting_metadata.get(&key).cloned().unwrap_or_default();
+                        Ok(ast::ValueExpr::Str(value))
+                    } else {
+                        Err(EvaluationError::InvalidFunctionArgs((
+                            name,
+                            key_expr.clone(),
+                        )))
+                    }
+                }
+
                 _ => Err(EvaluationError::UnknownFunctionArgs((name, args))),
             },
 
@@ -1056,7 +1154,7 @@ mod evaluator {
             // the Binary handler above resolves it when paired with a number.
             ast::ValueExpr::Commodity(ref name) => {
                 if let Some(defined_expr) = eval_context.defines.get(name.as_str()) {
-                    eval(defined_expr.clone(), eval_context, state)
+                    eval(defined_expr.clone(), eval_context, state, posting_metadata)
                 } else {
                     Ok(val)
                 }
@@ -1065,7 +1163,7 @@ mod evaluator {
             ast::ValueExpr::Typed {
                 expr,
                 commodity: new_commodity,
-            } => match eval(*expr, eval_context, state)? {
+            } => match eval(*expr, eval_context, state, posting_metadata)? {
                 // Accept if the inner expression has no commodity or the same commodity.
                 ast::ValueExpr::Amount { value, commodity }
                     if commodity.is_none() || commodity.as_ref() == Some(&new_commodity) =>
@@ -1081,13 +1179,15 @@ mod evaluator {
                 ))),
             },
 
-            ast::ValueExpr::Access { expr, field } => match eval(*expr, eval_context, state)? {
-                ast::ValueExpr::Object(map) => map
-                    .get(&field)
-                    .cloned()
-                    .ok_or(EvaluationError::NoSuchField(field)),
-                val => Err(EvaluationError::FieldAccessTypeError(val)),
-            },
+            ast::ValueExpr::Access { expr, field } => {
+                match eval(*expr, eval_context, state, posting_metadata)? {
+                    ast::ValueExpr::Object(map) => map
+                        .get(&field)
+                        .cloned()
+                        .ok_or(EvaluationError::NoSuchField(field)),
+                    val => Err(EvaluationError::FieldAccessTypeError(val)),
+                }
+            }
         }
     }
 }
@@ -2005,6 +2105,184 @@ commodity $
         assert!(
             result.is_err(),
             "bare =0 with no commodity context anywhere should error"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests for regex match operators (`=~` / `!~`) — issue #79
+    // -----------------------------------------------------------------------
+
+    /// `assert "abc" =~ /^a/` passes: the string starts with 'a'.
+    #[test]
+    fn test_regex_match_string_literal_passes() {
+        let input = "\
+account Expenses:Food
+    assert \"abc\" =~ /^a/
+
+2024-01-01 Test
+    Expenses:Food  $10.00
+    Assets:Checking
+";
+        let journal = elaborate(input);
+        assert_eq!(journal.transactions.len(), 1);
+    }
+
+    /// `assert "abc" =~ /^z/` fails: the string does not start with 'z'.
+    #[test]
+    fn test_regex_match_string_literal_fails() {
+        let input = "\
+account Expenses:Food
+    assert \"abc\" =~ /^z/
+
+2024-01-01 Test
+    Expenses:Food  $10.00
+    Assets:Checking
+";
+        let result = try_elaborate(input);
+        assert!(
+            result.is_err(),
+            "regex match should fail when string doesn't match pattern"
+        );
+    }
+
+    /// `assert "abc" !~ /^z/` passes: the string does not start with 'z'.
+    #[test]
+    fn test_regex_not_match_passes_when_no_match() {
+        let input = "\
+account Expenses:Food
+    assert \"abc\" !~ /^z/
+
+2024-01-01 Test
+    Expenses:Food  $10.00
+    Assets:Checking
+";
+        let journal = elaborate(input);
+        assert_eq!(journal.transactions.len(), 1);
+    }
+
+    /// `assert "abc" !~ /^a/` fails: the string matches, so `!~` is false.
+    #[test]
+    fn test_regex_not_match_fails_when_match() {
+        let input = "\
+account Expenses:Food
+    assert \"abc\" !~ /^a/
+
+2024-01-01 Test
+    Expenses:Food  $10.00
+    Assets:Checking
+";
+        let result = try_elaborate(input);
+        assert!(
+            result.is_err(),
+            "!~ should fail when string matches pattern"
+        );
+    }
+
+    /// Regex with a non-trivial pattern including anchors and character classes.
+    #[test]
+    fn test_regex_match_non_empty_string_pattern() {
+        // Pattern `[^\/].+` requires at least two chars and the first isn't a slash.
+        let input = "\
+account Expenses:Travel
+    assert commodity =~ /[a-z]/
+
+2024-01-01 Test
+    Expenses:Travel  100 usd
+    Assets:Checking
+";
+        let journal = elaborate(input);
+        assert_eq!(journal.transactions.len(), 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests for `tag("name")` function — issue #80
+    // -----------------------------------------------------------------------
+
+    /// `assert tag("X") =~ /^foo/` passes when posting has `; X: foobar`.
+    #[test]
+    fn test_tag_fn_matches_metadata_value() {
+        let input = "\
+account Expenses:Food
+    assert tag(\"Entity\") =~ /^foo/
+
+2024-01-01 Test
+    Expenses:Food  $10.00
+    ; Entity: foobar
+    Assets:Checking
+";
+        let journal = elaborate(input);
+        assert_eq!(journal.transactions.len(), 1);
+    }
+
+    /// `assert tag("X") !~ /^foo/` passes when posting has no X tag (empty
+    /// string does not match `/^foo/`).
+    #[test]
+    fn test_tag_fn_absent_key_returns_empty_string() {
+        let input = "\
+account Expenses:Food
+    assert tag(\"Entity\") !~ /^foo/
+
+2024-01-01 Test
+    Expenses:Food  $10.00
+    Assets:Checking
+";
+        let journal = elaborate(input);
+        assert_eq!(journal.transactions.len(), 1);
+    }
+
+    /// `assert tag("X") =~ /^foo/` fails when posting has no X tag (empty
+    /// string does not match a non-empty pattern).
+    #[test]
+    fn test_tag_fn_absent_key_fails_match() {
+        let input = "\
+account Expenses:Food
+    assert tag(\"Entity\") =~ /^foo/
+
+2024-01-01 Test
+    Expenses:Food  $10.00
+    Assets:Checking
+";
+        let result = try_elaborate(input);
+        assert!(
+            result.is_err(),
+            "tag() on absent key returns empty string, which should not match /^foo/"
+        );
+    }
+
+    /// Chained check: `tag("A") !~ /^\s*$/ and tag("B") !~ /^\s*$/`.
+    /// Both tags present and non-blank → passes.
+    #[test]
+    fn test_tag_fn_chained_and_both_present() {
+        let input = "\
+account Income:Salary
+    assert tag(\"Entity\") !~ /^\\s*$/ and tag(\"IncomeType\") !~ /^\\s*$/
+
+2024-01-01 Paycheck
+    Income:Salary  $-5000.00
+    ; Entity: AcmeCorp
+    ; IncomeType: Salary
+    Assets:Checking  $5000.00
+";
+        let journal = elaborate(input);
+        assert_eq!(journal.transactions.len(), 1);
+    }
+
+    /// Chained check: one tag present, one absent → fails.
+    #[test]
+    fn test_tag_fn_chained_and_one_missing() {
+        let input = "\
+account Income:Salary
+    assert tag(\"Entity\") !~ /^\\s*$/ and tag(\"IncomeType\") !~ /^\\s*$/
+
+2024-01-01 Paycheck
+    Income:Salary  $-5000.00
+    ; Entity: AcmeCorp
+    Assets:Checking  $5000.00
+";
+        let result = try_elaborate(input);
+        assert!(
+            result.is_err(),
+            "chained tag() check should fail when one tag is absent"
         );
     }
 }

--- a/src/elaboration.rs
+++ b/src/elaboration.rs
@@ -25,7 +25,7 @@
 //!   to [`Journal::accounts`], merging any properties declared in `account`
 //!   directives.
 
-use std::{collections::BTreeMap, fmt::Display};
+use std::{cell::RefCell, collections::BTreeMap, collections::HashMap, fmt::Display};
 
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -89,9 +89,18 @@ struct AccountBalances {
 /// Account balances are updated as each transaction is processed so that
 /// balance assertions and the `account()` function see the balance *before*
 /// the current posting is applied (which matches ledger-cli semantics).
+///
+/// `regex_cache` memoises compiled regexes across all postings within one
+/// elaboration run. A typical bb-ledger workload has ~10 distinct patterns
+/// repeated over hundreds of postings; compiling each once rather than per
+/// evaluation reduces compilation overhead to O(distinct patterns).
 #[derive(Default, Clone, Debug)]
 struct RunningState {
     account_balances: BTreeMap<String, AccountBalances>,
+    /// Cache of compiled regexes keyed by pattern string.
+    /// `RefCell` provides interior mutability so the cache can be populated
+    /// from `eval_cmp`, which receives only a shared reference to `RunningState`.
+    regex_cache: RefCell<HashMap<String, regex::Regex>>,
 }
 
 /// A fully evaluated and balanced transaction, ready for serialisation.
@@ -274,6 +283,52 @@ pub enum EvaluationError {
     TypedCommodityToIncompatibleAmount((String, ValueExpr)),
     /// A function received an argument of the wrong type.
     InvalidFunctionArgs((String, ValueExpr)),
+    /// A regex literal could not be compiled.
+    ///
+    /// Carries the offending pattern string and the error message from the
+    /// `regex` crate. Using `String` rather than `regex::Error` keeps this
+    /// error type free of a public dependency on the `regex` crate.
+    InvalidRegexPattern(String, String),
+}
+
+impl Display for EvaluationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EvaluationError::UnaryMultiplyOrDivide => {
+                write!(f, "* and / cannot be used as unary prefix operators")
+            }
+            EvaluationError::UnaryOnNonAmount(val) => {
+                write!(f, "unary operator applied to non-amount value: {val:?}")
+            }
+            EvaluationError::BinaryOperationTypeError((lhs, rhs, op)) => {
+                write!(f, "binary operation type mismatch: {lhs:?} {op:?} {rhs:?}")
+            }
+            EvaluationError::NoSuchField(field) => {
+                write!(f, "no such field: {field}")
+            }
+            EvaluationError::FieldAccessTypeError(val) => {
+                write!(f, "field access on non-object value: {val:?}")
+            }
+            EvaluationError::UnknownFunctionArgs((name, args)) => {
+                write!(
+                    f,
+                    "unknown function or wrong argument count: {name}({args:?})"
+                )
+            }
+            EvaluationError::TypedCommodityToIncompatibleAmount((commodity, val)) => {
+                write!(
+                    f,
+                    "commodity annotation '{commodity}' is incompatible with value: {val:?}"
+                )
+            }
+            EvaluationError::InvalidFunctionArgs((name, arg)) => {
+                write!(f, "invalid argument to function {name}: {arg:?}")
+            }
+            EvaluationError::InvalidRegexPattern(pattern, err) => {
+                write!(f, "invalid regex pattern /{pattern}/: {err}")
+            }
+        }
+    }
 }
 
 impl From<EvaluationError> for ElaborationError {
@@ -294,7 +349,7 @@ impl Display for ElaborationError {
                 write!(f, "expected an amount but got: {expr:?}")
             }
             ElaborationError::EvaluationError(e) => {
-                write!(f, "evaluation error: {e:?}")
+                write!(f, "evaluation error: {e}")
             }
             ElaborationError::PostingBalanceAssertionFailed => {
                 write!(f, "posting balance assertion failed")
@@ -818,7 +873,7 @@ mod evaluator {
                     ast::ValueExpr::Regex(_) => rhs_expr.clone(),
                     other => eval(other.clone(), &ctx, state, posting_metadata)?,
                 };
-                eval_cmp(cmp_op, &lhs_val, &rhs_val)?
+                eval_cmp(cmp_op, &lhs_val, &rhs_val, state)?
             }
         };
 
@@ -865,35 +920,42 @@ mod evaluator {
     ///
     /// Regex matching is case-sensitive by default (Rust `regex` crate semantics).
     /// Returns an error for type mismatches or an invalid regex pattern.
+    ///
+    /// `state` is used to look up (and populate) the per-run regex cache, so
+    /// each distinct pattern is compiled at most once across all postings.
     fn eval_cmp(
         op: &CmpOp,
         lhs: &ast::ValueExpr,
         rhs: &ast::ValueExpr,
+        state: &RunningState,
     ) -> Result<bool, EvaluationError> {
         match (lhs, rhs) {
             // Regex match: LHS must be a string, RHS must be a Regex literal.
             (ast::ValueExpr::Str(text), ast::ValueExpr::Regex(pattern)) => {
-                // Compile the regex each call. For the bb-ledger workload this
-                // is acceptable — patterns appear in account directives which are
-                // few in number. A cache can be added later if profiling shows it
-                // as a hot path.
-                let re = Regex::new(pattern).map_err(|_| {
-                    EvaluationError::BinaryOperationTypeError((
-                        lhs.clone(),
-                        rhs.clone(),
-                        ast::Op::Add,
-                    ))
-                })?;
+                // Look up the compiled regex in the per-run cache. On a miss,
+                // compile and insert. This ensures each distinct pattern is
+                // compiled exactly once across all postings in one elaboration run.
+                let mut cache = state.regex_cache.borrow_mut();
+                let re = if let Some(re) = cache.get(pattern.as_str()) {
+                    // SAFETY: we return a reference into the map entry; to avoid
+                    // lifetime issues we clone the Regex (cheap — Arc inside).
+                    re.clone()
+                } else {
+                    let re = Regex::new(pattern).map_err(|e| {
+                        EvaluationError::InvalidRegexPattern(pattern.clone(), e.to_string())
+                    })?;
+                    cache.insert(pattern.clone(), re.clone());
+                    re
+                };
+                drop(cache);
+                // The only CmpOps valid with a Regex RHS are RegexMatch and
+                // RegexNotMatch — any other combination is a parser-level bug.
                 Ok(match op {
                     CmpOp::RegexMatch => re.is_match(text),
                     CmpOp::RegexNotMatch => !re.is_match(text),
-                    _ => {
-                        return Err(EvaluationError::BinaryOperationTypeError((
-                            lhs.clone(),
-                            rhs.clone(),
-                            ast::Op::Add,
-                        )));
-                    }
+                    _ => unreachable!(
+                        "parser should only produce RegexMatch/RegexNotMatch with a Regex RHS"
+                    ),
                 })
             }
             // String equality: used for `commodity == "$"`.
@@ -2283,6 +2345,83 @@ account Income:Salary
         assert!(
             result.is_err(),
             "chained tag() check should fail when one tag is absent"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests for `tag()` with bare (`:foo:`) tags
+    // -----------------------------------------------------------------------
+
+    /// `tag()` only inspects key-value metadata (`; Key: value`), not bare
+    /// colon-delimited tags (`; :foo:`).  A posting with `:foo:` and an
+    /// assertion `tag("foo") =~ /foo/` fails because `tag("foo")` returns ""
+    /// (the bare tag name is not in the metadata map).
+    ///
+    /// This is intentional: bare tags carry no associated value, so `tag()`
+    /// returning "" is the correct "not found" signal.  Use bare tags for
+    /// filtering via external tooling rather than in `assert`/`check` expressions.
+    #[test]
+    fn test_tag_fn_does_not_see_bare_colon_tags() {
+        let input = "\
+account Expenses:Food
+    assert tag(\"foo\") =~ /foo/
+
+2024-01-01 Test
+    Expenses:Food  $10.00
+    ; :foo:
+    Assets:Checking
+";
+        let result = try_elaborate(input);
+        assert!(
+            result.is_err(),
+            "tag() must return \"\" for bare colon-style tags; /foo/ should not match"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests for invalid regex error — issue #79
+    // -----------------------------------------------------------------------
+
+    /// An invalid regex pattern in an `assert` expression should produce
+    /// `EvaluationError::InvalidRegexPattern`, not a generic type-mismatch error.
+    #[test]
+    fn test_invalid_regex_produces_named_error() {
+        let input = "\
+account Expenses:Food
+    assert commodity =~ /[unclosed/
+
+2024-01-01 Test
+    Expenses:Food  $10.00
+    Assets:Checking
+";
+        let result = try_elaborate(input);
+        let err = result.expect_err("invalid regex should cause elaboration to fail");
+        assert!(
+            matches!(
+                err,
+                ElaborationError::EvaluationError(EvaluationError::InvalidRegexPattern(_, _))
+            ),
+            "expected InvalidRegexPattern error, got: {err}"
+        );
+    }
+
+    /// The `Display` of `InvalidRegexPattern` should mention the offending pattern.
+    #[test]
+    fn test_invalid_regex_error_message_mentions_pattern() {
+        let input = "\
+account Expenses:Food
+    assert commodity =~ /[unclosed/
+
+2024-01-01 Test
+    Expenses:Food  $10.00
+    Assets:Checking
+";
+        let result = try_elaborate(input);
+        let err = result.expect_err("invalid regex should cause elaboration to fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("[unclosed"),
+            "error message should include the invalid pattern; got: {msg}"
         );
     }
 }

--- a/src/ledger.pest
+++ b/src/ledger.pest
@@ -238,9 +238,26 @@ filename = @{ (!NEWLINE ~ ANY)+ }
 // precedence rules.
 // `cmp_op` separators are punctuation so they take ws*; `bool_op` is alphabetic
 // (`and`/`or`) and must be space-separated to avoid `xand` parsing as `x and`.
-bool_expr = ${ value_expr ~ (ws* ~ cmp_op ~ ws* ~ value_expr)? ~ (ws+ ~ bool_op ~ ws+ ~ bool_expr)? }
+// `bool_expr` supports both ordinary comparisons (cmp_op) and regex matches
+// (regex_cmp_op). The RHS of a regex comparison must be a regex_literal;
+// ordinary comparisons accept any value_expr.
+bool_expr = ${
+    value_expr ~ (
+        (ws* ~ regex_cmp_op ~ ws* ~ regex_literal)
+        | (ws* ~ cmp_op ~ ws* ~ value_expr)
+    )? ~ (ws+ ~ bool_op ~ ws+ ~ bool_expr)?
+}
 cmp_op = @{ "==" | "!=" | "<=" | ">=" | "<" | ">" }
+// Regex match operators: must be tried before cmp_op to avoid `=` prefix ambiguity.
+regex_cmp_op = @{ "=~" | "!~" }
 bool_op = @{ "and" | "or" }
+
+// A regex literal: /pattern/ where \/ is an escaped slash inside the pattern.
+// compound-atomic ($) so that regex_body is named and visible to the parser.
+regex_literal = ${ "/" ~ regex_body ~ "/" }
+// regex_body captures the raw pattern text between the delimiters.
+// Allows backslash-escapes (including \/) and any non-slash character.
+regex_body = @{ (("\\" ~ ANY) | (!"/" ~ ANY))* }
 
 // A value_expr is an expression optionally followed by a commodity annotation.
 // The trailing commodity form "(1 + 2) USD" creates a ValueExpr::Typed node.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -250,7 +250,12 @@ fn parse_commodity_directive(pair: Pair<Rule>) -> Directive {
 ///
 /// The grammar rule is:
 /// ```text
-/// bool_expr = ${ value_expr ~ (cmp_op ~ value_expr)? ~ (bool_op ~ bool_expr)? }
+/// bool_expr = ${
+///     value_expr ~ (
+///         (regex_cmp_op ~ regex_literal)
+///         | (cmp_op ~ value_expr)
+///     )? ~ (bool_op ~ bool_expr)?
+/// }
 /// ```
 fn parse_bool_expr(pair: Pair<Rule>) -> BoolExpr {
     let mut inner = pair.into_inner().peekable();
@@ -258,22 +263,44 @@ fn parse_bool_expr(pair: Pair<Rule>) -> BoolExpr {
     // First child is always the LHS value_expr.
     let lhs = parse_expr(inner.next().expect("bool_expr must have lhs"));
 
-    // Next child (if any) is cmp_op — consume it and the following rhs.
-    let cmp = if inner.peek().map(|p| p.as_rule()) == Some(Rule::cmp_op) {
-        let op_pair = inner.next().unwrap();
-        let op = match op_pair.as_str() {
-            "==" => CmpOp::Eq,
-            "!=" => CmpOp::Ne,
-            "<=" => CmpOp::Le,
-            ">=" => CmpOp::Ge,
-            "<" => CmpOp::Lt,
-            ">" => CmpOp::Gt,
-            _ => unreachable!("unknown cmp_op: {}", op_pair.as_str()),
-        };
-        let rhs = parse_expr(inner.next().expect("cmp_op must be followed by rhs"));
-        Some((op, rhs))
-    } else {
-        None
+    // Next child (if any) is either cmp_op or regex_cmp_op.
+    let cmp = match inner.peek().map(|p| p.as_rule()) {
+        Some(Rule::cmp_op) => {
+            let op_pair = inner.next().unwrap();
+            let op = match op_pair.as_str() {
+                "==" => CmpOp::Eq,
+                "!=" => CmpOp::Ne,
+                "<=" => CmpOp::Le,
+                ">=" => CmpOp::Ge,
+                "<" => CmpOp::Lt,
+                ">" => CmpOp::Gt,
+                _ => unreachable!("unknown cmp_op: {}", op_pair.as_str()),
+            };
+            let rhs = parse_expr(inner.next().expect("cmp_op must be followed by rhs"));
+            Some((op, rhs))
+        }
+        Some(Rule::regex_cmp_op) => {
+            let op_pair = inner.next().unwrap();
+            let op = match op_pair.as_str() {
+                "=~" => CmpOp::RegexMatch,
+                "!~" => CmpOp::RegexNotMatch,
+                _ => unreachable!("unknown regex_cmp_op: {}", op_pair.as_str()),
+            };
+            // The next token must be a regex_literal.
+            let regex_pair = inner
+                .next()
+                .expect("regex_cmp_op must be followed by regex_literal");
+            // regex_literal = ${ "/" ~ regex_body ~ "/" }
+            // Its single inner child is the regex_body @-rule carrying the raw pattern.
+            let pattern = regex_pair
+                .into_inner()
+                .next()
+                .expect("regex_literal must have regex_body")
+                .as_str()
+                .to_string();
+            Some((op, ValueExpr::Regex(pattern)))
+        }
+        _ => None,
     };
 
     // Remaining child (if any) is bool_op + bool_expr continuation.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -128,8 +128,43 @@ impl<F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>> Parser<F> {
             }
         }
 
-        Ok(Journal { entries })
+        let journal = Journal { entries };
+        validate_regexes(&journal)?;
+        Ok(journal)
     }
+}
+
+/// Walk the parsed [`Journal`] and verify every regex literal compiles.
+///
+/// Regex patterns are stored as raw strings in the AST so the AST itself
+/// stays free of `regex` types. Validation here surfaces invalid patterns at
+/// parse time — without it, a typo like `assert tag("X") =~ /[unclosed/`
+/// would only fail much later during elaboration, when the failing posting
+/// is encountered.
+fn validate_regexes(journal: &Journal) -> Result<(), Box<dyn std::error::Error>> {
+    for entry in &journal.entries {
+        if let Entry::Directive(Directive::Account { items, .. }) = entry {
+            for item in items {
+                match item {
+                    AccountItem::Assert(e) | AccountItem::Check(e) => {
+                        validate_bool_expr_regexes(e)?;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_bool_expr_regexes(expr: &BoolExpr) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some((_, ValueExpr::Regex(pattern))) = &expr.cmp {
+        regex::Regex::new(pattern).map_err(|e| format!("invalid regex /{pattern}/: {e}"))?;
+    }
+    if let Some((_, cont)) = &expr.chain {
+        validate_bool_expr_regexes(cont)?;
+    }
+    Ok(())
 }
 
 /// Convenience function: parse Ledger source with no `include` support.


### PR DESCRIPTION
## Summary

Implements two expression primitives used together in `bb-ledger` account directives:

- **`=~` and `!~` (issue #79)** — regex comparison operators in `bool_expr` context. The RHS must be a `/pattern/` regex literal. Escaped slashes (`\/`) inside the pattern are supported. Regex matching is case-sensitive by default (Rust `regex` crate semantics, consistent with how the regex crate behaves out of the box).

- **`tag("name")` (issue #80)** — a new built-in function that looks up a posting's metadata key (parsed from `; Key: Value` notes by the resolution stage) and returns its string value. If the key is absent, an empty string is returned — so `tag("X") !~ /^\s*$/` works correctly for blank-tag detection without requiring a separate null check.

### Representative real-world usage

```ledger
account Income:Salary
    assert tag("Entity") !~ /^\s*$/ and tag("IncomeType") !~ /^\s*$/

account Assets:Checking
    assert value =~ /[^\/].+/
```

## Design decisions

- **Regex RHS is grammar-restricted to `regex_literal`** — following OG ledger convention and keeping the grammar unambiguous. The `/` character cannot appear as the start of an ordinary expression, so adding a separate `regex_cmp_op` branch in `bool_expr` avoids any grammar conflict with the division operator.
- **Pattern compiled per call** — the `regex` crate is fast enough for the assertion workload (few patterns, called per-posting). A compilation cache can be added later if profiling shows it as a hot path.
- **`eval` gains a `posting_metadata` parameter** — threaded through all recursive calls so `tag()` has access without a global side-channel. `eval_and_normalize_amount` passes an empty `BTreeMap` since amount expressions never involve metadata.
- **`ValueExpr::Regex` is NOT compiled at parse time** — the AST stays `regex`-crate-free. The evaluator compiles on use.

## Test plan

- [x] `assert "abc" =~ /^a/` passes, `assert "abc" =~ /^z/` fails
- [x] `assert "abc" !~ /^z/` passes, `assert "abc" !~ /^a/` fails
- [x] Commodity string from `commodity` variable matched against regex
- [x] `tag("X") =~ /^foo/` passes when posting has `; X: foobar`
- [x] `tag("X") !~ /^foo/` passes when posting has no X tag (empty string)
- [x] `tag("X") =~ /^foo/` fails when posting has no X tag
- [x] Chained `tag("A") !~ /^\s*$/ and tag("B") !~ /^\s*$/` — both present passes, one missing fails
- [x] All 89 pre-existing tests continue to pass (99 total after adding 10 new ones)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

Closes #79
Closes #80