### PR TITLE
feat: tag directive value validation

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -104,15 +104,35 @@ pub enum Directive {
         /// The full account name it expands to.
         account: String,
     },
-    /// A `define name = expr` named value alias.
+    /// A `define name[(params)] = body` named alias.
     ///
-    /// After this directive, any occurrence of `name` in a value expression
-    /// is substituted with the stored `expr` during elaboration.
+    /// When `params` is empty this is a simple value alias: any occurrence of
+    /// `name` in a value expression is substituted with the stored body during
+    /// elaboration.
+    ///
+    /// When `params` is non-empty this is a parameterized macro: a call-site
+    /// `name(arg1, arg2)` is evaluated by binding each `params[i]` to `args[i]`
+    /// in the evaluation context and then evaluating the body.
     Define {
         /// The alias name (a plain identifier).
         name: String,
-        /// The value expression the name expands to.
-        expr: ValueExpr,
+        /// Ordered parameter names. Empty for non-parameterized defines.
+        params: Vec<String>,
+        /// The body expression — either a value expression or a boolean expression.
+        body: DefineBody,
+    },
+    /// A `tag` block declaring validation rules for a metadata tag.
+    ///
+    /// Transactions and postings may carry `; TagName: value` metadata.
+    /// The `tag` directive attaches assertions and checks that are evaluated
+    /// whenever such a `TagName: value` pair is encountered during elaboration.
+    Tag {
+        /// The tag name (e.g. `"Statement"`, `"IncomeType"`).
+        name: String,
+        /// Fatal assertions: elaboration halts if any fails.
+        asserts: Vec<BoolExpr>,
+        /// Non-fatal checks: a warning is printed to stderr but elaboration continues.
+        checks: Vec<BoolExpr>,
     },
 }
 
@@ -225,6 +245,28 @@ impl std::fmt::Display for BoolExpr {
             write!(f, " {op} {cont}")?;
         }
         Ok(())
+    }
+}
+
+/// The body of a `define` directive.
+///
+/// A define body is either a value expression (for plain amount aliases and
+/// arithmetic macros) or a boolean expression (for predicate macros used in
+/// `assert`/`check` directives).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DefineBody {
+    /// A value expression, e.g. `define monthly = $1500`.
+    Value(ValueExpr),
+    /// A boolean expression, e.g. `define positive(x) = x > 0`.
+    Bool(BoolExpr),
+}
+
+impl std::fmt::Display for DefineBody {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DefineBody::Value(e) => write!(f, "{e}"),
+            DefineBody::Bool(e) => write!(f, "{e}"),
+        }
     }
 }
 

--- a/src/elaboration.rs
+++ b/src/elaboration.rs
@@ -318,6 +318,9 @@ pub enum EvaluationError {
         /// Number of arguments provided at the call site.
         got: usize,
     },
+    /// Expression evaluation exceeded the recursion limit. The most common
+    /// cause is mutually-recursive defines, e.g. `define a = b; define b = a`.
+    RecursionLimitExceeded,
 }
 
 impl Display for EvaluationError {
@@ -370,6 +373,12 @@ impl Display for EvaluationError {
                 write!(
                     f,
                     "define '{name}' expects {expected} argument(s), got {got}"
+                )
+            }
+            EvaluationError::RecursionLimitExceeded => {
+                write!(
+                    f,
+                    "expression evaluation exceeded recursion limit (likely a cyclic `define`)"
                 )
             }
         }
@@ -1409,12 +1418,45 @@ mod evaluator {
     /// `posting_metadata` carries the key-value tag pairs from the posting's
     /// notes. It is forwarded into recursive calls and is read by the `tag()`
     /// built-in function.
+    /// Maximum recursion depth for [`eval`]. Protects against cyclic
+    /// `define`s (e.g. `define a = b; define b = a`), which would otherwise
+    /// recurse until the OS aborts the process with a stack overflow.
+    /// 64 is well above any sane real-world expression depth and well below
+    /// debug-build stack limits (debug frames are large).
+    const MAX_EVAL_DEPTH: usize = 64;
+
+    thread_local! {
+        static EVAL_DEPTH: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    }
+
+    /// RAII guard that increments the eval recursion counter on construction
+    /// and decrements on drop, regardless of how the calling function exits.
+    struct EvalDepthGuard;
+    impl EvalDepthGuard {
+        fn enter() -> Result<Self, EvaluationError> {
+            EVAL_DEPTH.with(|d| {
+                let depth = d.get();
+                if depth >= MAX_EVAL_DEPTH {
+                    return Err(EvaluationError::RecursionLimitExceeded);
+                }
+                d.set(depth + 1);
+                Ok(EvalDepthGuard)
+            })
+        }
+    }
+    impl Drop for EvalDepthGuard {
+        fn drop(&mut self) {
+            EVAL_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
+        }
+    }
+
     fn eval(
         val: ast::ValueExpr,
         eval_context: &resolution::Context,
         state: &RunningState,
         posting_metadata: &BTreeMap<String, String>,
     ) -> Result<ast::ValueExpr, EvaluationError> {
+        let _guard = EvalDepthGuard::enter()?;
         match val {
             // Base cases: already-reduced values pass through unchanged.
             a @ ast::ValueExpr::Amount { .. } => Ok(a),
@@ -3185,6 +3227,52 @@ define monthly = $1500.00
             .find(|p| p.account == "Expenses:Rent")
             .unwrap();
         assert_eq!(rent.amount.0.get("$").copied(), Some(dec!(1500.00)));
+    }
+
+    /// Mutually-recursive defines must produce a `RecursionLimitExceeded`
+    /// error rather than crash the process with a stack overflow.
+    #[test]
+    fn test_mutually_recursive_defines_caught() {
+        let input = "\
+define a = b
+define b = a
+
+2024-01-01 Test
+    Expenses:Food  a
+    Assets:Cash
+";
+        let result = try_elaborate(input);
+        assert!(
+            matches!(
+                result,
+                Err(ElaborationError::EvaluationError(
+                    EvaluationError::RecursionLimitExceeded
+                ))
+            ),
+            "cyclic defines should produce RecursionLimitExceeded; got: {result:?}"
+        );
+    }
+
+    /// Self-referential define caught the same way.
+    #[test]
+    fn test_self_referential_define_caught() {
+        let input = "\
+define x = x
+
+2024-01-01 Test
+    Expenses:Food  x
+    Assets:Cash
+";
+        let result = try_elaborate(input);
+        assert!(
+            matches!(
+                result,
+                Err(ElaborationError::EvaluationError(
+                    EvaluationError::RecursionLimitExceeded
+                ))
+            ),
+            "self-referential define should produce RecursionLimitExceeded; got: {result:?}"
+        );
     }
 
     /// A parameterized value-body define can be used in a posting amount.

--- a/src/elaboration.rs
+++ b/src/elaboration.rs
@@ -260,6 +260,16 @@ pub enum ElaborationError {
         /// not byte-match the original source text.
         expression: String,
     },
+    /// A `tag` directive `assert` expression evaluated to `false` for a
+    /// `; TagName: value` metadata pair on a transaction or posting.
+    TagAssertionFailed {
+        /// The tag name whose assertion fired (e.g. `"Statement"`).
+        tag_name: String,
+        /// The metadata value that failed the assertion (e.g. `"foo/bar"`).
+        tag_value: String,
+        /// A rendered form of the failing expression (for diagnostics).
+        expression: String,
+    },
 }
 
 /// Error produced when evaluating a value expression (e.g., an amount or
@@ -293,6 +303,21 @@ pub enum EvaluationError {
     /// `regex` crate. Using `String` rather than `regex::Error` keeps this
     /// error type free of a public dependency on the `regex` crate.
     InvalidRegexPattern(String, String),
+    /// A define with a boolean body was called from a value expression context.
+    ///
+    /// Boolean defines (e.g. `define pos(x) = x > 0`) may only be used where a
+    /// `bool_expr` is expected (e.g. inside an `assert` directive), not as part
+    /// of an arithmetic expression.
+    BoolDefineInValueContext(String),
+    /// A parameterized define was called with the wrong number of arguments.
+    DefineArgCountMismatch {
+        /// The define name.
+        name: String,
+        /// Number of parameters the define declares.
+        expected: usize,
+        /// Number of arguments provided at the call site.
+        got: usize,
+    },
 }
 
 impl Display for EvaluationError {
@@ -330,6 +355,22 @@ impl Display for EvaluationError {
             }
             EvaluationError::InvalidRegexPattern(pattern, err) => {
                 write!(f, "invalid regex pattern /{pattern}/: {err}")
+            }
+            EvaluationError::BoolDefineInValueContext(name) => {
+                write!(
+                    f,
+                    "define '{name}' has a boolean body and cannot be used in a value expression"
+                )
+            }
+            EvaluationError::DefineArgCountMismatch {
+                name,
+                expected,
+                got,
+            } => {
+                write!(
+                    f,
+                    "define '{name}' expects {expected} argument(s), got {got}"
+                )
             }
         }
     }
@@ -388,6 +429,16 @@ impl Display for ElaborationError {
             }
             ElaborationError::TransactionDoesNotBalance(_) => {
                 write!(f, "transaction does not balance")
+            }
+            ElaborationError::TagAssertionFailed {
+                tag_name,
+                tag_value,
+                expression,
+            } => {
+                write!(
+                    f,
+                    "tag assertion failed for {tag_name}: \"{tag_value}\": assert {expression}"
+                )
             }
         }
     }
@@ -701,6 +752,31 @@ impl TryFrom<resolution::HIR> for Journal {
                         }
                     }
 
+                    // Evaluate tag-level assert/check directives.
+                    //
+                    // Only metadata-style tags (`; TagName: value`) are validated.
+                    // Bare colon-tags (e.g. `; :payroll:`) carry no value and are
+                    // skipped. Validation applies to both transaction-level metadata
+                    // and posting-level metadata for parity with account assertions.
+
+                    // Validate transaction-level metadata tags.
+                    eval_tag_metadata(
+                        &transaction.metadata,
+                        &value.global_context.tag_properties,
+                        entry_context,
+                        &state,
+                    )?;
+
+                    // Validate posting-level metadata tags.
+                    for posting in resolved_postings.iter() {
+                        eval_tag_metadata(
+                            &posting.metadata,
+                            &value.global_context.tag_properties,
+                            entry_context,
+                            &state,
+                        )?;
+                    }
+
                     // Update running account balances and register new accounts.
                     for posting in resolved_postings.iter() {
                         if !accounts.contains_key(&posting.account) {
@@ -772,6 +848,50 @@ impl TryFrom<resolution::HIR> for Journal {
             prices,
         })
     }
+}
+
+/// Evaluate tag-level assert/check directives for a set of metadata key-value pairs.
+///
+/// For each `(tag_name, tag_value)` pair in `metadata`, looks up `tag_name` in
+/// `tag_properties`. If validation rules are found, runs each assert and check
+/// with `value` bound to `tag_value` in the expression context.
+///
+/// - Failed asserts return `Err(ElaborationError::TagAssertionFailed)`.
+/// - Failed checks print a warning to stderr but return `Ok(())`.
+fn eval_tag_metadata(
+    metadata: &BTreeMap<String, String>,
+    tag_properties: &BTreeMap<String, resolution::TagProperties>,
+    eval_context: &resolution::Context,
+    state: &RunningState,
+) -> Result<(), ElaborationError> {
+    for (tag_name, tag_value) in metadata {
+        if let Some(props) = tag_properties.get(tag_name) {
+            for assert_expr in &props.asserts {
+                let passed =
+                    evaluator::eval_bool_expr_for_tag(assert_expr, tag_value, eval_context, state)
+                        .map_err(ElaborationError::EvaluationError)?;
+                if !passed {
+                    return Err(ElaborationError::TagAssertionFailed {
+                        tag_name: tag_name.clone(),
+                        tag_value: tag_value.clone(),
+                        expression: assert_expr.to_string(),
+                    });
+                }
+            }
+            for check_expr in &props.checks {
+                let passed =
+                    evaluator::eval_bool_expr_for_tag(check_expr, tag_value, eval_context, state)
+                        .map_err(ElaborationError::EvaluationError)?;
+                if !passed {
+                    eprintln!(
+                        "warning: tag check failed for {tag_name}: \"{tag_value}\": \
+                         check {check_expr}",
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Expression evaluator: reduces [`ast::ValueExpr`] trees to concrete values.
@@ -861,19 +981,97 @@ mod evaluator {
         eval_context: &resolution::Context,
         state: &RunningState,
     ) -> Result<bool, EvaluationError> {
-        // Build a temporary context with `amount` and `commodity` injected.
+        // Build a temporary context with `amount` and `commodity` injected as
+        // zero-parameter defines so the evaluator can resolve them.
         let mut ctx = eval_context.clone();
         ctx.defines.insert(
             "amount".into(),
-            ast::ValueExpr::Amount {
-                value: posting_amount,
-                commodity: Some(posting_commodity.to_string()),
+            resolution::Define {
+                params: vec![],
+                body: ast::DefineBody::Value(ast::ValueExpr::Amount {
+                    value: posting_amount,
+                    commodity: Some(posting_commodity.to_string()),
+                }),
             },
         );
         ctx.defines.insert(
             "commodity".into(),
-            ast::ValueExpr::Str(posting_commodity.to_string()),
+            resolution::Define {
+                params: vec![],
+                body: ast::DefineBody::Value(ast::ValueExpr::Str(posting_commodity.to_string())),
+            },
         );
+
+        // Check whether the LHS is a call to a bool-body define. If it is and
+        // there is no comparison operator, we expand the define body as a full
+        // bool expression rather than treating the call result as a numeric value.
+        if expr.cmp.is_none() {
+            if let ast::ValueExpr::Function { ref name, ref args } = expr.lhs {
+                if let Some(define) = ctx.defines.get(name.as_str()) {
+                    if let ast::DefineBody::Bool(ref body) = define.body.clone() {
+                        if define.params.len() != args.len() {
+                            return Err(EvaluationError::DefineArgCountMismatch {
+                                name: name.clone(),
+                                expected: define.params.len(),
+                                got: args.len(),
+                            });
+                        }
+                        // Bind arguments into a new context and evaluate the bool body.
+                        let mut call_ctx = ctx.clone();
+                        for (param, arg_expr) in define.params.iter().zip(args.iter()) {
+                            let arg_val = eval(arg_expr.clone(), &ctx, state, posting_metadata)?;
+                            call_ctx.defines.insert(
+                                param.clone(),
+                                resolution::Define {
+                                    params: vec![],
+                                    body: ast::DefineBody::Value(arg_val),
+                                },
+                            );
+                        }
+                        // Evaluate the define's bool body, then apply any chain.
+                        let segment_result = eval_bool_expr_with_context(
+                            body,
+                            posting_amount,
+                            posting_commodity,
+                            posting_metadata,
+                            &call_ctx,
+                            state,
+                        )?;
+                        return match &expr.chain {
+                            None => Ok(segment_result),
+                            Some((ast::BoolOp::And, cont)) => {
+                                if !segment_result {
+                                    Ok(false)
+                                } else {
+                                    eval_bool_expr(
+                                        cont,
+                                        posting_amount,
+                                        posting_commodity,
+                                        posting_metadata,
+                                        eval_context,
+                                        state,
+                                    )
+                                }
+                            }
+                            Some((ast::BoolOp::Or, cont)) => {
+                                if segment_result {
+                                    Ok(true)
+                                } else {
+                                    eval_bool_expr(
+                                        cont,
+                                        posting_amount,
+                                        posting_commodity,
+                                        posting_metadata,
+                                        eval_context,
+                                        state,
+                                    )
+                                }
+                            }
+                        };
+                    }
+                }
+            }
+        }
 
         // Evaluate LHS.
         let lhs_val = eval(expr.lhs.clone(), &ctx, state, posting_metadata)?;
@@ -927,6 +1125,200 @@ mod evaluator {
                         eval_context,
                         state,
                     )
+                }
+            }
+        }
+    }
+
+    /// Evaluate a [`BoolExpr`] using a pre-built context that already has
+    /// parameter bindings in place.
+    ///
+    /// This is the inner workhorse used when expanding a bool-body define call:
+    /// the caller has already bound the define's parameters as zero-param value
+    /// defines in `eval_context`, so we evaluate the body without re-injecting
+    /// `amount`/`commodity` (they are already in the context or in `eval_context`).
+    fn eval_bool_expr_with_context(
+        expr: &BoolExpr,
+        posting_amount: Decimal,
+        posting_commodity: &str,
+        posting_metadata: &BTreeMap<String, String>,
+        eval_context: &resolution::Context,
+        state: &RunningState,
+    ) -> Result<bool, EvaluationError> {
+        // Check for a bool-body define call in the LHS (recursive define calls).
+        if expr.cmp.is_none() {
+            if let ast::ValueExpr::Function { ref name, ref args } = expr.lhs {
+                if let Some(define) = eval_context.defines.get(name.as_str()) {
+                    if let ast::DefineBody::Bool(ref body) = define.body.clone() {
+                        if define.params.len() != args.len() {
+                            return Err(EvaluationError::DefineArgCountMismatch {
+                                name: name.clone(),
+                                expected: define.params.len(),
+                                got: args.len(),
+                            });
+                        }
+                        let mut call_ctx = eval_context.clone();
+                        for (param, arg_expr) in define.params.iter().zip(args.iter()) {
+                            let arg_val =
+                                eval(arg_expr.clone(), eval_context, state, posting_metadata)?;
+                            call_ctx.defines.insert(
+                                param.clone(),
+                                resolution::Define {
+                                    params: vec![],
+                                    body: ast::DefineBody::Value(arg_val),
+                                },
+                            );
+                        }
+                        let segment_result = eval_bool_expr_with_context(
+                            body,
+                            posting_amount,
+                            posting_commodity,
+                            posting_metadata,
+                            &call_ctx,
+                            state,
+                        )?;
+                        return match &expr.chain {
+                            None => Ok(segment_result),
+                            Some((ast::BoolOp::And, cont)) => {
+                                if !segment_result {
+                                    Ok(false)
+                                } else {
+                                    eval_bool_expr_with_context(
+                                        cont,
+                                        posting_amount,
+                                        posting_commodity,
+                                        posting_metadata,
+                                        eval_context,
+                                        state,
+                                    )
+                                }
+                            }
+                            Some((ast::BoolOp::Or, cont)) => {
+                                if segment_result {
+                                    Ok(true)
+                                } else {
+                                    eval_bool_expr_with_context(
+                                        cont,
+                                        posting_amount,
+                                        posting_commodity,
+                                        posting_metadata,
+                                        eval_context,
+                                        state,
+                                    )
+                                }
+                            }
+                        };
+                    }
+                }
+            }
+        }
+
+        let lhs_val = eval(expr.lhs.clone(), eval_context, state, posting_metadata)?;
+        let result = match &expr.cmp {
+            None => match lhs_val {
+                ast::ValueExpr::Amount { value, .. } => !value.is_zero(),
+                _ => false,
+            },
+            Some((cmp_op, rhs_expr)) => {
+                let rhs_val = match rhs_expr {
+                    ast::ValueExpr::Regex(_) => rhs_expr.clone(),
+                    other => eval(other.clone(), eval_context, state, posting_metadata)?,
+                };
+                eval_cmp(cmp_op, &lhs_val, &rhs_val)?
+            }
+        };
+
+        match &expr.chain {
+            None => Ok(result),
+            Some((ast::BoolOp::And, cont)) => {
+                if !result {
+                    Ok(false)
+                } else {
+                    eval_bool_expr_with_context(
+                        cont,
+                        posting_amount,
+                        posting_commodity,
+                        posting_metadata,
+                        eval_context,
+                        state,
+                    )
+                }
+            }
+            Some((ast::BoolOp::Or, cont)) => {
+                if result {
+                    Ok(true)
+                } else {
+                    eval_bool_expr_with_context(
+                        cont,
+                        posting_amount,
+                        posting_commodity,
+                        posting_metadata,
+                        eval_context,
+                        state,
+                    )
+                }
+            }
+        }
+    }
+
+    /// Evaluate a [`BoolExpr`] in the context of a tag metadata value.
+    ///
+    /// `tag_value` is bound as `value` (a `Str`) in the expression context.
+    /// This is the mechanism used by `tag` directive `assert`/`check` bodies
+    /// to refer to the metadata value, e.g. `value =~ /^foo/`.
+    ///
+    /// Tag assertions have no associated posting amount or commodity, so those
+    /// bindings are not injected. The `tag()` built-in is available but looks
+    /// up from an empty metadata map (tag assertions are about the tag value
+    /// itself, not about other metadata on the same entry).
+    pub fn eval_bool_expr_for_tag(
+        expr: &BoolExpr,
+        tag_value: &str,
+        eval_context: &resolution::Context,
+        state: &RunningState,
+    ) -> Result<bool, EvaluationError> {
+        let empty_meta = BTreeMap::default();
+
+        // Inject `value` as a Str binding so the expression can reference it.
+        let mut ctx = eval_context.clone();
+        ctx.defines.insert(
+            "value".into(),
+            resolution::Define {
+                params: vec![],
+                body: ast::DefineBody::Value(ast::ValueExpr::Str(tag_value.to_string())),
+            },
+        );
+
+        let lhs_val = eval(expr.lhs.clone(), &ctx, state, &empty_meta)?;
+
+        let result = match &expr.cmp {
+            None => match lhs_val {
+                ast::ValueExpr::Amount { value, .. } => !value.is_zero(),
+                _ => false,
+            },
+            Some((cmp_op, rhs_expr)) => {
+                let rhs_val = match rhs_expr {
+                    ast::ValueExpr::Regex(_) => rhs_expr.clone(),
+                    other => eval(other.clone(), &ctx, state, &empty_meta)?,
+                };
+                eval_cmp(cmp_op, &lhs_val, &rhs_val)?
+            }
+        };
+
+        match &expr.chain {
+            None => Ok(result),
+            Some((ast::BoolOp::And, cont)) => {
+                if !result {
+                    Ok(false)
+                } else {
+                    eval_bool_expr_for_tag(cont, tag_value, eval_context, state)
+                }
+            }
+            Some((ast::BoolOp::Or, cont)) => {
+                if result {
+                    Ok(true)
+                } else {
+                    eval_bool_expr_for_tag(cont, tag_value, eval_context, state)
                 }
             }
         }
@@ -1155,74 +1547,124 @@ mod evaluator {
                 }
             }
 
-            ast::ValueExpr::Function { name, args } => match (name.as_str(), args.as_slice()) {
-                // scrub(x) — identity function used by some ledger-cli extensions
-                // to mark amounts as "scrubbed" (processed). Treated as a no-op.
-                ("scrub", [arg]) => eval(arg.clone(), eval_context, state, posting_metadata),
-
-                // account("Name") — returns an object with a "total" field
-                // containing the current running balance of the named account.
-                // Only the primary commodity ($) is currently surfaced.
-                ("account", [account]) => {
-                    if let ValueExpr::Str(account) =
-                        eval(account.clone(), eval_context, state, posting_metadata)?
-                    {
-                        let account = eval_context
-                            .account_aliases
-                            .get(&account)
-                            .unwrap_or(&account);
-                        let balance = state
-                            .account_balances
-                            .get(account)
-                            .and_then(|ab| ab.commodity.get("$"))
-                            .cloned()
-                            .unwrap_or_default();
-                        Ok(ast::ValueExpr::Object(BTreeMap::from([(
-                            "total".into(),
-                            ast::ValueExpr::Amount {
-                                value: balance,
-                                commodity: Some("$".into()),
-                            },
-                        )])))
-                    } else {
-                        Err(EvaluationError::InvalidFunctionArgs((
-                            name,
-                            account.clone(),
-                        )))
+            ast::ValueExpr::Function { name, args } => {
+                // Check user-defined parameterized macros before built-ins.
+                if let Some(define) = eval_context.defines.get(name.as_str()) {
+                    if define.params.len() != args.len() {
+                        return Err(EvaluationError::DefineArgCountMismatch {
+                            name: name.clone(),
+                            expected: define.params.len(),
+                            got: args.len(),
+                        });
                     }
+                    return match &define.body {
+                        ast::DefineBody::Bool(_) => {
+                            Err(EvaluationError::BoolDefineInValueContext(name.clone()))
+                        }
+                        ast::DefineBody::Value(body_expr) => {
+                            // Evaluate arguments in the caller's context, then
+                            // bind them by name in a temporary child context.
+                            let mut ctx = eval_context.clone();
+                            for (param, arg_expr) in define.params.iter().zip(args.iter()) {
+                                let arg_val =
+                                    eval(arg_expr.clone(), eval_context, state, posting_metadata)?;
+                                ctx.defines.insert(
+                                    param.clone(),
+                                    resolution::Define {
+                                        params: vec![],
+                                        body: ast::DefineBody::Value(arg_val),
+                                    },
+                                );
+                            }
+                            eval(body_expr.clone(), &ctx, state, posting_metadata)
+                        }
+                    };
                 }
 
-                // tag("name") — looks up a metadata key on the current posting.
-                //
-                // The posting's notes are parsed into key-value pairs by the
-                // resolution stage (e.g. `; Entity: Foo` → `{"Entity": "Foo"}`).
-                // If the key is present its value is returned as a Str; if absent
-                // an empty string is returned so that `tag("X") =~ /pattern/`
-                // works naturally (empty string never matches a non-empty pattern).
-                ("tag", [key_expr]) => {
-                    if let ValueExpr::Str(key) =
-                        eval(key_expr.clone(), eval_context, state, posting_metadata)?
-                    {
-                        let value = posting_metadata.get(&key).cloned().unwrap_or_default();
-                        Ok(ast::ValueExpr::Str(value))
-                    } else {
-                        Err(EvaluationError::InvalidFunctionArgs((
-                            name,
-                            key_expr.clone(),
-                        )))
-                    }
-                }
+                match (name.as_str(), args.as_slice()) {
+                    // scrub(x) — identity function used by some ledger-cli extensions
+                    // to mark amounts as "scrubbed" (processed). Treated as a no-op.
+                    ("scrub", [arg]) => eval(arg.clone(), eval_context, state, posting_metadata),
 
-                _ => Err(EvaluationError::UnknownFunctionArgs((name, args))),
-            },
+                    // account("Name") — returns an object with a "total" field
+                    // containing the current running balance of the named account.
+                    // Only the primary commodity ($) is currently surfaced.
+                    ("account", [account]) => {
+                        if let ValueExpr::Str(account) =
+                            eval(account.clone(), eval_context, state, posting_metadata)?
+                        {
+                            let account = eval_context
+                                .account_aliases
+                                .get(&account)
+                                .unwrap_or(&account);
+                            let balance = state
+                                .account_balances
+                                .get(account)
+                                .and_then(|ab| ab.commodity.get("$"))
+                                .cloned()
+                                .unwrap_or_default();
+                            Ok(ast::ValueExpr::Object(BTreeMap::from([(
+                                "total".into(),
+                                ast::ValueExpr::Amount {
+                                    value: balance,
+                                    commodity: Some("$".into()),
+                                },
+                            )])))
+                        } else {
+                            Err(EvaluationError::InvalidFunctionArgs((
+                                name,
+                                account.clone(),
+                            )))
+                        }
+                    }
+
+                    // tag("name") — looks up a metadata key on the current posting.
+                    //
+                    // The posting's notes are parsed into key-value pairs by the
+                    // resolution stage (e.g. `; Entity: Foo` → `{"Entity": "Foo"}`).
+                    // If the key is present its value is returned as a Str; if absent
+                    // an empty string is returned so that `tag("X") =~ /pattern/`
+                    // works naturally (empty string never matches a non-empty pattern).
+                    ("tag", [key_expr]) => {
+                        if let ValueExpr::Str(key) =
+                            eval(key_expr.clone(), eval_context, state, posting_metadata)?
+                        {
+                            let value = posting_metadata.get(&key).cloned().unwrap_or_default();
+                            Ok(ast::ValueExpr::Str(value))
+                        } else {
+                            Err(EvaluationError::InvalidFunctionArgs((
+                                name,
+                                key_expr.clone(),
+                            )))
+                        }
+                    }
+
+                    _ => Err(EvaluationError::UnknownFunctionArgs((name, args))),
+                }
+            }
 
             // A bare commodity symbol or identifier. If the name matches a
             // `define` alias in the active context, substitute and re-evaluate
             // the stored expression. Otherwise return the Commodity as-is;
             // the Binary handler above resolves it when paired with a number.
             ast::ValueExpr::Commodity(ref name) => {
-                if let Some(defined_expr) = eval_context.defines.get(name.as_str()) {
-                    eval(defined_expr.clone(), eval_context, state, posting_metadata)
+                if let Some(define) = eval_context.defines.get(name.as_str()) {
+                    // Zero-parameter defines act as simple aliases: expand the body.
+                    // Parameterized defines require a call site (handled in the
+                    // Function arm above); a bare reference is not valid.
+                    if define.params.is_empty() {
+                        match &define.body {
+                            ast::DefineBody::Value(expr) => {
+                                eval(expr.clone(), eval_context, state, posting_metadata)
+                            }
+                            // A boolean-body define referenced as a plain identifier is
+                            // not meaningful in a value-expression context; treat it as
+                            // an unresolved commodity (same as if it were undefined).
+                            ast::DefineBody::Bool(_) => Ok(val),
+                        }
+                    } else {
+                        Ok(val)
+                    }
                 } else {
                     Ok(val)
                 }
@@ -2440,5 +2882,329 @@ account Expenses:Food
             msg.contains("[unclosed") && msg.contains("invalid regex"),
             "error message should include the invalid pattern and identify it as a regex; got: {msg}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests for tag directive validation — issue #82
+    // -----------------------------------------------------------------------
+
+    /// `tag X\n    assert value =~ /^foo/` with `; X: foobar` passes.
+    #[test]
+    fn test_tag_assert_passes_when_value_matches() {
+        let input = "\
+tag Statement
+    assert value =~ /^foo/
+
+2024-01-01 Test
+    ; Statement: foobar
+    Expenses:Food  $10.00
+    Assets:Checking
+";
+        let journal = elaborate(input);
+        assert_eq!(journal.transactions.len(), 1);
+    }
+
+    /// `tag X\n    assert value =~ /^foo/` with `; X: barfoo` fails with
+    /// `TagAssertionFailed`.
+    #[test]
+    fn test_tag_assert_fails_when_value_does_not_match() {
+        let input = "\
+tag Statement
+    assert value =~ /^foo/
+
+2024-01-01 Test
+    ; Statement: barfoo
+    Expenses:Food  $10.00
+    Assets:Checking
+";
+        let result = try_elaborate(input);
+        assert!(
+            matches!(result, Err(ElaborationError::TagAssertionFailed { .. })),
+            "expected TagAssertionFailed, got: {result:?}"
+        );
+        if let Err(ElaborationError::TagAssertionFailed {
+            tag_name,
+            tag_value,
+            ..
+        }) = result
+        {
+            assert_eq!(tag_name, "Statement");
+            assert_eq!(tag_value, "barfoo");
+        }
+    }
+
+    /// `tag X\n    check value =~ /^foo/` with `; X: barfoo` warns but
+    /// elaboration succeeds.
+    #[test]
+    fn test_tag_check_warns_does_not_halt() {
+        let input = "\
+tag Statement
+    check value =~ /^foo/
+
+2024-01-01 Test
+    ; Statement: barfoo
+    Expenses:Food  $10.00
+    Assets:Checking
+";
+        // Should succeed (check does not halt elaboration).
+        let journal = elaborate(input);
+        assert_eq!(journal.transactions.len(), 1);
+    }
+
+    /// Multiple asserts under one tag: all must pass.
+    #[test]
+    fn test_tag_multiple_asserts_all_must_pass() {
+        let input = "\
+tag IncomeType
+    assert value =~ /^(Donations|RBI|UBTI)$/
+
+2024-01-01 Income
+    ; IncomeType: RBI
+    Income:Donations  $100.00
+    Assets:Checking
+";
+        let journal = elaborate(input);
+        assert_eq!(journal.transactions.len(), 1);
+    }
+
+    /// An invalid value fails all asserts.
+    #[test]
+    fn test_tag_assert_invalid_value_fails() {
+        let input = "\
+tag IncomeType
+    assert value =~ /^(Donations|RBI|UBTI)$/
+
+2024-01-01 Income
+    ; IncomeType: Salary
+    Income:Salary  $100.00
+    Assets:Checking
+";
+        let result = try_elaborate(input);
+        assert!(
+            matches!(result, Err(ElaborationError::TagAssertionFailed { .. })),
+            "expected TagAssertionFailed for unrecognised IncomeType"
+        );
+    }
+
+    /// A tag declared but not referenced in any transaction produces no errors.
+    #[test]
+    fn test_tag_declared_but_unused_no_error() {
+        let input = "\
+tag Receipt
+    assert value =~ /foo/
+
+2024-01-01 Test
+    Expenses:Food  $10.00
+    Assets:Checking
+";
+        let journal = elaborate(input);
+        assert_eq!(journal.transactions.len(), 1);
+    }
+
+    /// Posting-level metadata is also validated (not just transaction-level).
+    #[test]
+    fn test_tag_assert_on_posting_level_metadata() {
+        let input = "\
+tag Statement
+    assert value =~ /^foo/
+
+2024-01-01 Test
+    Expenses:Food  $10.00
+    ; Statement: barfoo
+    Assets:Checking
+";
+        let result = try_elaborate(input);
+        assert!(
+            matches!(result, Err(ElaborationError::TagAssertionFailed { .. })),
+            "posting-level tag metadata should also be validated"
+        );
+    }
+
+    /// Posting-level metadata with a passing value succeeds.
+    #[test]
+    fn test_tag_assert_on_posting_level_metadata_passes() {
+        let input = "\
+tag Statement
+    assert value =~ /^foo/
+
+2024-01-01 Test
+    Expenses:Food  $10.00
+    ; Statement: foobar
+    Assets:Checking
+";
+        let journal = elaborate(input);
+        assert_eq!(journal.transactions.len(), 1);
+    }
+
+    /// Bare colon-tags (e.g. `; :payroll:`) have no value and are NOT validated
+    /// by `tag` directive rules — they are skipped entirely.
+    #[test]
+    fn test_tag_directive_does_not_validate_bare_colon_tags() {
+        let input = "\
+tag payroll
+    assert value =~ /^.+$/
+
+2024-01-01 Payroll
+    ; :payroll:
+    Income:Salary  $5000.00
+    Assets:Checking
+";
+        // Bare colon-tags don't have a value, so they never reach the tag
+        // directive validator. Elaboration should succeed.
+        let journal = elaborate(input);
+        assert_eq!(journal.transactions.len(), 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests for parameterized defines (issue #81)
+    // -----------------------------------------------------------------------
+
+    /// `define isPositive(x) = x > 0` in an account assert — passing case.
+    #[test]
+    fn test_parameterized_define_bool_passing() {
+        let input = "\
+define isPositive(x) = x > 0
+
+account Expenses:Food
+    assert isPositive(amount)
+
+2024-01-01 Lunch
+    Expenses:Food  $10.00
+    Assets:Cash
+";
+        elaborate(input);
+    }
+
+    /// `define isNegative(x) = x < 0` in an account assert — positive amount
+    /// should trigger the assertion.
+    #[test]
+    fn test_parameterized_define_bool_failing() {
+        let input = "\
+define isNegative(x) = x < 0
+
+account Expenses:Food
+    assert isNegative(amount)
+
+2024-01-01 Lunch
+    Expenses:Food  $10.00
+    Assets:Cash
+";
+        let ast = crate::parser::parse_ledger(input).expect("parse failed");
+        let hir = crate::resolution::HIR::try_from(ast).expect("resolution failed");
+        let result = Journal::try_from(hir);
+        assert!(
+            matches!(result, Err(ElaborationError::AccountAssertionFailed { .. })),
+            "positive amount should fail isNegative assertion; got: {result:?}"
+        );
+    }
+
+    /// Bool define using `tag()` and `!~` regex match.
+    #[test]
+    fn test_parameterized_define_with_tag_and_regex_passing() {
+        let input = "\
+define hasReceipt(x) = tag(\"Receipt\") !~ /^\\s*$/ and x > 0
+
+account Expenses:Food
+    assert hasReceipt(amount)
+
+2024-01-01 Lunch
+    Expenses:Food  $10.00
+    ; Receipt: scan123.pdf
+    Assets:Cash
+";
+        elaborate(input);
+    }
+
+    /// Two-argument define: `between(lo, hi) = amount > lo and amount < hi`
+    /// where `amount` is in scope from the posting context.
+    #[test]
+    fn test_parameterized_define_two_args_passing() {
+        let input = "\
+define between(lo, hi) = amount > lo and amount < hi
+
+account Expenses:Food
+    assert between(0, 100)
+
+2024-01-01 Lunch
+    Expenses:Food  $50.00
+    Assets:Cash
+";
+        elaborate(input);
+    }
+
+    /// Same `between` define — amount outside range fails.
+    #[test]
+    fn test_parameterized_define_two_args_failing() {
+        let input = "\
+define between(lo, hi) = amount > lo and amount < hi
+
+account Expenses:Food
+    assert between(0, 10)
+
+2024-01-01 BigPurchase
+    Expenses:Food  $50.00
+    Assets:Cash
+";
+        let ast = crate::parser::parse_ledger(input).expect("parse failed");
+        let hir = crate::resolution::HIR::try_from(ast).expect("resolution failed");
+        let result = Journal::try_from(hir);
+        assert!(
+            matches!(result, Err(ElaborationError::AccountAssertionFailed { .. })),
+            "$50 should fail between(0, 10); got: {result:?}"
+        );
+    }
+
+    /// Param named `amount` shadows the implicit posting binding.
+    #[test]
+    fn test_parameterized_define_param_shadows_amount() {
+        let input = "\
+define isPositiveAmt(amount) = amount > 0
+
+account Expenses:Food
+    assert isPositiveAmt(amount)
+
+2024-01-01 Lunch
+    Expenses:Food  $10.00
+    Assets:Cash
+";
+        elaborate(input);
+    }
+
+    /// A zero-parameter value-body define continues to work as before.
+    #[test]
+    fn test_zero_param_define_value_body_still_works() {
+        let input = "\
+define monthly = $1500.00
+
+2024-01-01 Rent
+    Expenses:Rent  monthly
+    Assets:Cash
+";
+        let journal = elaborate(input);
+        let rent = journal.transactions[0]
+            .postings
+            .iter()
+            .find(|p| p.account == "Expenses:Rent")
+            .unwrap();
+        assert_eq!(rent.amount.0.get("$").copied(), Some(dec!(1500.00)));
+    }
+
+    /// A parameterized value-body define can be used in a posting amount.
+    #[test]
+    fn test_parameterized_define_value_body_in_posting() {
+        let input = "\
+define double(x) = x * 2
+
+2024-01-01 Purchase
+    Expenses:Food  double(50 USD)
+    Assets:Cash
+";
+        let journal = elaborate(input);
+        let food = journal.transactions[0]
+            .postings
+            .iter()
+            .find(|p| p.account == "Expenses:Food")
+            .unwrap();
+        assert_eq!(food.amount.0.get("USD").copied(), Some(dec!(100)));
     }
 }

--- a/src/elaboration.rs
+++ b/src/elaboration.rs
@@ -945,7 +945,7 @@ mod evaluator {
         // empty map so the `tag()` built-in is a no-op when called from amount
         // contexts (which would be a programmer error, but we don't panic).
         let empty_meta = BTreeMap::default();
-        match eval(val, eval_context, running_state, &empty_meta)? {
+        match eval(val, eval_context, running_state, &empty_meta, EVAL_BUDGET)? {
             ast::ValueExpr::Amount { value, commodity } => {
                 let commodity = if let Some(commodity) = commodity {
                     // Apply commodity alias (e.g. "Bitcoin" → "BTC")
@@ -1029,7 +1029,7 @@ mod evaluator {
             // Bind arguments into a new context and evaluate the bool body.
             let mut call_ctx = ctx.clone();
             for (param, arg_expr) in define.params.iter().zip(args.iter()) {
-                let arg_val = eval(arg_expr.clone(), &ctx, state, posting_metadata)?;
+                let arg_val = eval(arg_expr.clone(), &ctx, state, posting_metadata, EVAL_BUDGET)?;
                 call_ctx.defines.insert(
                     param.clone(),
                     resolution::Define {
@@ -1081,7 +1081,7 @@ mod evaluator {
         }
 
         // Evaluate LHS.
-        let lhs_val = eval(expr.lhs.clone(), &ctx, state, posting_metadata)?;
+        let lhs_val = eval(expr.lhs.clone(), &ctx, state, posting_metadata, EVAL_BUDGET)?;
 
         // Compute this segment's boolean value. With no comparison operator,
         // the expression is truthy iff the LHS evaluates to a non-zero amount
@@ -1097,7 +1097,7 @@ mod evaluator {
                 // the AST — pass it through to eval_cmp without re-evaluating.
                 let rhs_val = match rhs_expr {
                     ast::ValueExpr::Regex(_) => rhs_expr.clone(),
-                    other => eval(other.clone(), &ctx, state, posting_metadata)?,
+                    other => eval(other.clone(), &ctx, state, posting_metadata, EVAL_BUDGET)?,
                 };
                 eval_cmp(cmp_op, &lhs_val, &rhs_val)?
             }
@@ -1170,7 +1170,13 @@ mod evaluator {
             }
             let mut call_ctx = eval_context.clone();
             for (param, arg_expr) in define.params.iter().zip(args.iter()) {
-                let arg_val = eval(arg_expr.clone(), eval_context, state, posting_metadata)?;
+                let arg_val = eval(
+                    arg_expr.clone(),
+                    eval_context,
+                    state,
+                    posting_metadata,
+                    EVAL_BUDGET,
+                )?;
                 call_ctx.defines.insert(
                     param.clone(),
                     resolution::Define {
@@ -1220,7 +1226,13 @@ mod evaluator {
             };
         }
 
-        let lhs_val = eval(expr.lhs.clone(), eval_context, state, posting_metadata)?;
+        let lhs_val = eval(
+            expr.lhs.clone(),
+            eval_context,
+            state,
+            posting_metadata,
+            EVAL_BUDGET,
+        )?;
         let result = match &expr.cmp {
             None => match lhs_val {
                 ast::ValueExpr::Amount { value, .. } => !value.is_zero(),
@@ -1229,7 +1241,13 @@ mod evaluator {
             Some((cmp_op, rhs_expr)) => {
                 let rhs_val = match rhs_expr {
                     ast::ValueExpr::Regex(_) => rhs_expr.clone(),
-                    other => eval(other.clone(), eval_context, state, posting_metadata)?,
+                    other => eval(
+                        other.clone(),
+                        eval_context,
+                        state,
+                        posting_metadata,
+                        EVAL_BUDGET,
+                    )?,
                 };
                 eval_cmp(cmp_op, &lhs_val, &rhs_val)?
             }
@@ -1296,7 +1314,7 @@ mod evaluator {
             },
         );
 
-        let lhs_val = eval(expr.lhs.clone(), &ctx, state, &empty_meta)?;
+        let lhs_val = eval(expr.lhs.clone(), &ctx, state, &empty_meta, EVAL_BUDGET)?;
 
         let result = match &expr.cmp {
             None => match lhs_val {
@@ -1306,7 +1324,7 @@ mod evaluator {
             Some((cmp_op, rhs_expr)) => {
                 let rhs_val = match rhs_expr {
                     ast::ValueExpr::Regex(_) => rhs_expr.clone(),
-                    other => eval(other.clone(), &ctx, state, &empty_meta)?,
+                    other => eval(other.clone(), &ctx, state, &empty_meta, EVAL_BUDGET)?,
                 };
                 eval_cmp(cmp_op, &lhs_val, &rhs_val)?
             }
@@ -1418,45 +1436,27 @@ mod evaluator {
     /// `posting_metadata` carries the key-value tag pairs from the posting's
     /// notes. It is forwarded into recursive calls and is read by the `tag()`
     /// built-in function.
-    /// Maximum recursion depth for [`eval`]. Protects against cyclic
-    /// `define`s (e.g. `define a = b; define b = a`), which would otherwise
-    /// recurse until the OS aborts the process with a stack overflow.
+    /// Initial recursion budget passed to [`eval`] by every external caller.
+    /// Each recursive `eval` call decrements `budget`; `eval` errors with
+    /// [`EvaluationError::RecursionLimitExceeded`] when it reaches 0. Protects
+    /// against cyclic `define`s (e.g. `define a = b; define b = a`), which
+    /// would otherwise recurse until the OS aborts the process with a stack
+    /// overflow.
+    ///
     /// 64 is well above any sane real-world expression depth and well below
     /// debug-build stack limits (debug frames are large).
-    const MAX_EVAL_DEPTH: usize = 64;
-
-    thread_local! {
-        static EVAL_DEPTH: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
-    }
-
-    /// RAII guard that increments the eval recursion counter on construction
-    /// and decrements on drop, regardless of how the calling function exits.
-    struct EvalDepthGuard;
-    impl EvalDepthGuard {
-        fn enter() -> Result<Self, EvaluationError> {
-            EVAL_DEPTH.with(|d| {
-                let depth = d.get();
-                if depth >= MAX_EVAL_DEPTH {
-                    return Err(EvaluationError::RecursionLimitExceeded);
-                }
-                d.set(depth + 1);
-                Ok(EvalDepthGuard)
-            })
-        }
-    }
-    impl Drop for EvalDepthGuard {
-        fn drop(&mut self) {
-            EVAL_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
-        }
-    }
+    pub const EVAL_BUDGET: usize = 64;
 
     fn eval(
         val: ast::ValueExpr,
         eval_context: &resolution::Context,
         state: &RunningState,
         posting_metadata: &BTreeMap<String, String>,
+        budget: usize,
     ) -> Result<ast::ValueExpr, EvaluationError> {
-        let _guard = EvalDepthGuard::enter()?;
+        let Some(budget) = budget.checked_sub(1) else {
+            return Err(EvaluationError::RecursionLimitExceeded);
+        };
         match val {
             // Base cases: already-reduced values pass through unchanged.
             a @ ast::ValueExpr::Amount { .. } => Ok(a),
@@ -1465,7 +1465,7 @@ mod evaluator {
             o @ ast::ValueExpr::Object(_) => Ok(o),
 
             ast::ValueExpr::Unary { op, expr } => {
-                match eval(*expr, eval_context, state, posting_metadata)? {
+                match eval(*expr, eval_context, state, posting_metadata, budget)? {
                     ast::ValueExpr::Amount { value, commodity } => match op {
                         ast::Op::Sub => Ok(ast::ValueExpr::Amount {
                             value: -value,
@@ -1481,8 +1481,8 @@ mod evaluator {
 
             ast::ValueExpr::Binary { lhs, rhs, op } => {
                 match (
-                    eval(*lhs, eval_context, state, posting_metadata)?,
-                    eval(*rhs, eval_context, state, posting_metadata)?,
+                    eval(*lhs, eval_context, state, posting_metadata, budget)?,
+                    eval(*rhs, eval_context, state, posting_metadata, budget)?,
                 ) {
                     // One side has a commodity, the other is dimensionless —
                     // the commodity propagates to the result. Both match arms
@@ -1606,8 +1606,13 @@ mod evaluator {
                             // bind them by name in a temporary child context.
                             let mut ctx = eval_context.clone();
                             for (param, arg_expr) in define.params.iter().zip(args.iter()) {
-                                let arg_val =
-                                    eval(arg_expr.clone(), eval_context, state, posting_metadata)?;
+                                let arg_val = eval(
+                                    arg_expr.clone(),
+                                    eval_context,
+                                    state,
+                                    posting_metadata,
+                                    budget,
+                                )?;
                                 ctx.defines.insert(
                                     param.clone(),
                                     resolution::Define {
@@ -1616,7 +1621,7 @@ mod evaluator {
                                     },
                                 );
                             }
-                            eval(body_expr.clone(), &ctx, state, posting_metadata)
+                            eval(body_expr.clone(), &ctx, state, posting_metadata, budget)
                         }
                     };
                 }
@@ -1624,15 +1629,21 @@ mod evaluator {
                 match (name.as_str(), args.as_slice()) {
                     // scrub(x) — identity function used by some ledger-cli extensions
                     // to mark amounts as "scrubbed" (processed). Treated as a no-op.
-                    ("scrub", [arg]) => eval(arg.clone(), eval_context, state, posting_metadata),
+                    ("scrub", [arg]) => {
+                        eval(arg.clone(), eval_context, state, posting_metadata, budget)
+                    }
 
                     // account("Name") — returns an object with a "total" field
                     // containing the current running balance of the named account.
                     // Only the primary commodity ($) is currently surfaced.
                     ("account", [account]) => {
-                        if let ValueExpr::Str(account) =
-                            eval(account.clone(), eval_context, state, posting_metadata)?
-                        {
+                        if let ValueExpr::Str(account) = eval(
+                            account.clone(),
+                            eval_context,
+                            state,
+                            posting_metadata,
+                            budget,
+                        )? {
                             let account = eval_context
                                 .account_aliases
                                 .get(&account)
@@ -1666,9 +1677,13 @@ mod evaluator {
                     // an empty string is returned so that `tag("X") =~ /pattern/`
                     // works naturally (empty string never matches a non-empty pattern).
                     ("tag", [key_expr]) => {
-                        if let ValueExpr::Str(key) =
-                            eval(key_expr.clone(), eval_context, state, posting_metadata)?
-                        {
+                        if let ValueExpr::Str(key) = eval(
+                            key_expr.clone(),
+                            eval_context,
+                            state,
+                            posting_metadata,
+                            budget,
+                        )? {
                             let value = posting_metadata.get(&key).cloned().unwrap_or_default();
                             Ok(ast::ValueExpr::Str(value))
                         } else {
@@ -1695,7 +1710,7 @@ mod evaluator {
                     if define.params.is_empty() {
                         match &define.body {
                             ast::DefineBody::Value(expr) => {
-                                eval(expr.clone(), eval_context, state, posting_metadata)
+                                eval(expr.clone(), eval_context, state, posting_metadata, budget)
                             }
                             // A boolean-body define referenced as a plain identifier is
                             // not meaningful in a value-expression context; treat it as
@@ -1713,7 +1728,7 @@ mod evaluator {
             ast::ValueExpr::Typed {
                 expr,
                 commodity: new_commodity,
-            } => match eval(*expr, eval_context, state, posting_metadata)? {
+            } => match eval(*expr, eval_context, state, posting_metadata, budget)? {
                 // Accept if the inner expression has no commodity or the same commodity.
                 ast::ValueExpr::Amount { value, commodity }
                     if commodity.is_none() || commodity.as_ref() == Some(&new_commodity) =>
@@ -1730,7 +1745,7 @@ mod evaluator {
             },
 
             ast::ValueExpr::Access { expr, field } => {
-                match eval(*expr, eval_context, state, posting_metadata)? {
+                match eval(*expr, eval_context, state, posting_metadata, budget)? {
                     ast::ValueExpr::Object(map) => map
                         .get(&field)
                         .cloned()

--- a/src/elaboration.rs
+++ b/src/elaboration.rs
@@ -1005,72 +1005,70 @@ mod evaluator {
         // Check whether the LHS is a call to a bool-body define. If it is and
         // there is no comparison operator, we expand the define body as a full
         // bool expression rather than treating the call result as a numeric value.
-        if expr.cmp.is_none() {
-            if let ast::ValueExpr::Function { ref name, ref args } = expr.lhs {
-                if let Some(define) = ctx.defines.get(name.as_str()) {
-                    if let ast::DefineBody::Bool(ref body) = define.body.clone() {
-                        if define.params.len() != args.len() {
-                            return Err(EvaluationError::DefineArgCountMismatch {
-                                name: name.clone(),
-                                expected: define.params.len(),
-                                got: args.len(),
-                            });
-                        }
-                        // Bind arguments into a new context and evaluate the bool body.
-                        let mut call_ctx = ctx.clone();
-                        for (param, arg_expr) in define.params.iter().zip(args.iter()) {
-                            let arg_val = eval(arg_expr.clone(), &ctx, state, posting_metadata)?;
-                            call_ctx.defines.insert(
-                                param.clone(),
-                                resolution::Define {
-                                    params: vec![],
-                                    body: ast::DefineBody::Value(arg_val),
-                                },
-                            );
-                        }
-                        // Evaluate the define's bool body, then apply any chain.
-                        let segment_result = eval_bool_expr_with_context(
-                            body,
+        if expr.cmp.is_none()
+            && let ast::ValueExpr::Function { name, args } = &expr.lhs
+            && let Some(define) = ctx.defines.get(name.as_str())
+            && let ast::DefineBody::Bool(body) = define.body.clone()
+        {
+            if define.params.len() != args.len() {
+                return Err(EvaluationError::DefineArgCountMismatch {
+                    name: name.clone(),
+                    expected: define.params.len(),
+                    got: args.len(),
+                });
+            }
+            // Bind arguments into a new context and evaluate the bool body.
+            let mut call_ctx = ctx.clone();
+            for (param, arg_expr) in define.params.iter().zip(args.iter()) {
+                let arg_val = eval(arg_expr.clone(), &ctx, state, posting_metadata)?;
+                call_ctx.defines.insert(
+                    param.clone(),
+                    resolution::Define {
+                        params: vec![],
+                        body: ast::DefineBody::Value(arg_val),
+                    },
+                );
+            }
+            // Evaluate the define's bool body, then apply any chain.
+            let segment_result = eval_bool_expr_with_context(
+                &body,
+                posting_amount,
+                posting_commodity,
+                posting_metadata,
+                &call_ctx,
+                state,
+            )?;
+            return match &expr.chain {
+                None => Ok(segment_result),
+                Some((ast::BoolOp::And, cont)) => {
+                    if !segment_result {
+                        Ok(false)
+                    } else {
+                        eval_bool_expr(
+                            cont,
                             posting_amount,
                             posting_commodity,
                             posting_metadata,
-                            &call_ctx,
+                            eval_context,
                             state,
-                        )?;
-                        return match &expr.chain {
-                            None => Ok(segment_result),
-                            Some((ast::BoolOp::And, cont)) => {
-                                if !segment_result {
-                                    Ok(false)
-                                } else {
-                                    eval_bool_expr(
-                                        cont,
-                                        posting_amount,
-                                        posting_commodity,
-                                        posting_metadata,
-                                        eval_context,
-                                        state,
-                                    )
-                                }
-                            }
-                            Some((ast::BoolOp::Or, cont)) => {
-                                if segment_result {
-                                    Ok(true)
-                                } else {
-                                    eval_bool_expr(
-                                        cont,
-                                        posting_amount,
-                                        posting_commodity,
-                                        posting_metadata,
-                                        eval_context,
-                                        state,
-                                    )
-                                }
-                            }
-                        };
+                        )
                     }
                 }
-            }
+                Some((ast::BoolOp::Or, cont)) => {
+                    if segment_result {
+                        Ok(true)
+                    } else {
+                        eval_bool_expr(
+                            cont,
+                            posting_amount,
+                            posting_commodity,
+                            posting_metadata,
+                            eval_context,
+                            state,
+                        )
+                    }
+                }
+            };
         }
 
         // Evaluate LHS.
@@ -1137,6 +1135,9 @@ mod evaluator {
     /// the caller has already bound the define's parameters as zero-param value
     /// defines in `eval_context`, so we evaluate the body without re-injecting
     /// `amount`/`commodity` (they are already in the context or in `eval_context`).
+    // posting_amount and posting_commodity are forwarded through recursive calls
+    // to eval_bool_expr (for chains); they are not used directly in the body.
+    #[allow(clippy::only_used_in_recursion)]
     fn eval_bool_expr_with_context(
         expr: &BoolExpr,
         posting_amount: Decimal,
@@ -1146,71 +1147,68 @@ mod evaluator {
         state: &RunningState,
     ) -> Result<bool, EvaluationError> {
         // Check for a bool-body define call in the LHS (recursive define calls).
-        if expr.cmp.is_none() {
-            if let ast::ValueExpr::Function { ref name, ref args } = expr.lhs {
-                if let Some(define) = eval_context.defines.get(name.as_str()) {
-                    if let ast::DefineBody::Bool(ref body) = define.body.clone() {
-                        if define.params.len() != args.len() {
-                            return Err(EvaluationError::DefineArgCountMismatch {
-                                name: name.clone(),
-                                expected: define.params.len(),
-                                got: args.len(),
-                            });
-                        }
-                        let mut call_ctx = eval_context.clone();
-                        for (param, arg_expr) in define.params.iter().zip(args.iter()) {
-                            let arg_val =
-                                eval(arg_expr.clone(), eval_context, state, posting_metadata)?;
-                            call_ctx.defines.insert(
-                                param.clone(),
-                                resolution::Define {
-                                    params: vec![],
-                                    body: ast::DefineBody::Value(arg_val),
-                                },
-                            );
-                        }
-                        let segment_result = eval_bool_expr_with_context(
-                            body,
+        if expr.cmp.is_none()
+            && let ast::ValueExpr::Function { name, args } = &expr.lhs
+            && let Some(define) = eval_context.defines.get(name.as_str())
+            && let ast::DefineBody::Bool(body) = define.body.clone()
+        {
+            if define.params.len() != args.len() {
+                return Err(EvaluationError::DefineArgCountMismatch {
+                    name: name.clone(),
+                    expected: define.params.len(),
+                    got: args.len(),
+                });
+            }
+            let mut call_ctx = eval_context.clone();
+            for (param, arg_expr) in define.params.iter().zip(args.iter()) {
+                let arg_val = eval(arg_expr.clone(), eval_context, state, posting_metadata)?;
+                call_ctx.defines.insert(
+                    param.clone(),
+                    resolution::Define {
+                        params: vec![],
+                        body: ast::DefineBody::Value(arg_val),
+                    },
+                );
+            }
+            let segment_result = eval_bool_expr_with_context(
+                &body,
+                posting_amount,
+                posting_commodity,
+                posting_metadata,
+                &call_ctx,
+                state,
+            )?;
+            return match &expr.chain {
+                None => Ok(segment_result),
+                Some((ast::BoolOp::And, cont)) => {
+                    if !segment_result {
+                        Ok(false)
+                    } else {
+                        eval_bool_expr_with_context(
+                            cont,
                             posting_amount,
                             posting_commodity,
                             posting_metadata,
-                            &call_ctx,
+                            eval_context,
                             state,
-                        )?;
-                        return match &expr.chain {
-                            None => Ok(segment_result),
-                            Some((ast::BoolOp::And, cont)) => {
-                                if !segment_result {
-                                    Ok(false)
-                                } else {
-                                    eval_bool_expr_with_context(
-                                        cont,
-                                        posting_amount,
-                                        posting_commodity,
-                                        posting_metadata,
-                                        eval_context,
-                                        state,
-                                    )
-                                }
-                            }
-                            Some((ast::BoolOp::Or, cont)) => {
-                                if segment_result {
-                                    Ok(true)
-                                } else {
-                                    eval_bool_expr_with_context(
-                                        cont,
-                                        posting_amount,
-                                        posting_commodity,
-                                        posting_metadata,
-                                        eval_context,
-                                        state,
-                                    )
-                                }
-                            }
-                        };
+                        )
                     }
                 }
-            }
+                Some((ast::BoolOp::Or, cont)) => {
+                    if segment_result {
+                        Ok(true)
+                    } else {
+                        eval_bool_expr_with_context(
+                            cont,
+                            posting_amount,
+                            posting_commodity,
+                            posting_metadata,
+                            eval_context,
+                            state,
+                        )
+                    }
+                }
+            };
         }
 
         let lhs_val = eval(expr.lhs.clone(), eval_context, state, posting_metadata)?;

--- a/src/ledger.pest
+++ b/src/ledger.pest
@@ -175,8 +175,14 @@ directive = _{ "!"? ~ (commodity_directive | account_directive | alias_directive
 
 tag_directive = ${
     "tag" ~ ws+ ~ identifier ~ (ws* ~ note)? ~ NEWLINE ~
-    (indent+ ~ (!NEWLINE ~ ANY )* ~ (NEWLINE | EOI))*
+    ((indent+ ~ note ~ NEWLINE) | tag_assert | tag_check)*
 }
+
+// assert / check sub-directives for tag blocks. Separate rules from
+// account_assert / account_check so parent context can be determined
+// unambiguously by the parser, even though the shape is identical.
+tag_assert = ${ indent+ ~ "assert" ~ ws+ ~ bool_expr ~ (NEWLINE | EOI) }
+tag_check  = ${ indent+ ~ "check"  ~ ws+ ~ bool_expr ~ (NEWLINE | EOI) }
 
 // A commodity block: declares properties such as aliases, display format,
 // and whether market prices are tracked.
@@ -214,9 +220,20 @@ account_val = @{ (!NEWLINE ~ ANY)* }
 // A top-level "alias short = long" shorthand for account names.
 alias_directive = ${ "alias" ~ ws+ ~ account ~ ws* ~ "=" ~ ws* ~ account ~ (ws+ ~ note)? ~ (NEWLINE | EOI) }
 
-// A define directive: "define name = expr"
-// Associates a name with a value expression usable in posting amounts.
-define_directive = ${ "define" ~ ws+ ~ identifier ~ ws* ~ "=" ~ ws* ~ value_expr ~ (NEWLINE | EOI) }
+// A define directive: "define name[(p1, p2, ...)] = body"
+// Associates a name with a value or boolean expression, optionally parameterized.
+// The body is tried as a bool_expr first (to support comparisons and logical chains),
+// falling back to value_expr for plain arithmetic/amount aliases.
+define_directive = ${
+    "define" ~ ws+ ~ identifier ~
+    (ws* ~ "(" ~ ws* ~ identifier ~ (ws* ~ "," ~ ws* ~ identifier)* ~ ws* ~ ")")? ~
+    ws* ~ "=" ~ ws* ~ define_body ~ (NEWLINE | EOI)
+}
+
+// A define body is either a full boolean expression (supports comparisons and
+// logical chains) or a plain value expression. bool_expr is tried first because
+// it is strictly more expressive; value_expr handles plain amounts and arithmetic.
+define_body = ${ bool_expr | value_expr }
 
 // Include another file by path (glob patterns are resolved in parser.rs).
 include_directive = ${ "include" ~ ws+ ~ filename ~ (NEWLINE | EOI) }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -94,6 +94,9 @@ impl<F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>> Parser<F> {
                 Rule::define_directive => {
                     entries.push(Entry::Directive(parse_define_directive(pair)));
                 }
+                Rule::tag_directive => {
+                    entries.push(Entry::Directive(parse_tag_directive(pair)));
+                }
                 Rule::historical_price => {
                     entries.push(Entry::HistoricalPrice(parse_historical_price(pair)));
                 }
@@ -143,15 +146,25 @@ impl<F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>> Parser<F> {
 /// is encountered.
 fn validate_regexes(journal: &Journal) -> Result<(), Box<dyn std::error::Error>> {
     for entry in &journal.entries {
-        if let Entry::Directive(Directive::Account { items, .. }) = entry {
-            for item in items {
-                match item {
-                    AccountItem::Assert(e) | AccountItem::Check(e) => {
-                        validate_bool_expr_regexes(e)?;
+        match entry {
+            Entry::Directive(Directive::Account { items, .. }) => {
+                for item in items {
+                    match item {
+                        AccountItem::Assert(e) | AccountItem::Check(e) => {
+                            validate_bool_expr_regexes(e)?;
+                        }
+                        _ => {}
                     }
-                    _ => {}
                 }
             }
+            Entry::Directive(Directive::Tag {
+                asserts, checks, ..
+            }) => {
+                for e in asserts.iter().chain(checks.iter()) {
+                    validate_bool_expr_regexes(e)?;
+                }
+            }
+            _ => {}
         }
     }
     Ok(())
@@ -227,12 +240,54 @@ fn parse_alias_directive(pair: Pair<Rule>) -> Directive {
 }
 
 fn parse_define_directive(pair: Pair<Rule>) -> Directive {
-    let mut pairs = pair.into_inner();
-    // The grammar rule is: identifier ~ "=" ~ value_expr
+    let mut pairs = pair.into_inner().peekable();
+
+    // First child is always the macro name.
     let name = pairs.next().unwrap().as_str().to_string();
-    let expr_pair = pairs.next().unwrap();
-    let expr = parse_expr(expr_pair);
-    Directive::Define { name, expr }
+
+    // Collect any parameter identifiers that precede the define_body.
+    // All inner pairs before the final `define_body` are parameter identifiers.
+    let mut params = Vec::new();
+    let mut body_pair = None;
+    for p in pairs {
+        match p.as_rule() {
+            Rule::identifier => params.push(p.as_str().to_string()),
+            Rule::define_body => {
+                body_pair = Some(p);
+            }
+            _ => {}
+        }
+    }
+
+    let body_pair = body_pair.expect("define_directive must have a define_body");
+    // define_body = ${ bool_expr | value_expr }
+    // Because `bool_expr` is `value_expr ~ (cmp ~ rhs)? ~ (bool_op ~ bool_expr)?`,
+    // the `bool_expr` alternative always matches when `value_expr` does. We
+    // distinguish the two cases by checking whether the parsed `BoolExpr` actually
+    // carries a comparison or a chain:
+    //   - If it has a `cmp` or `chain`, it is a genuine boolean expression.
+    //   - If neither, it is a plain value expression wrapped in a trivial BoolExpr;
+    //     we unwrap it into `DefineBody::Value` so the evaluator handles it correctly.
+    let inner = body_pair
+        .into_inner()
+        .next()
+        .expect("define_body must have one child");
+
+    let body = match inner.as_rule() {
+        Rule::bool_expr => {
+            let bool_expr = parse_bool_expr(inner);
+            // Unwrap a trivial bool_expr (no comparison, no chain) → Value.
+            if bool_expr.cmp.is_none() && bool_expr.chain.is_none() {
+                DefineBody::Value(bool_expr.lhs)
+            } else {
+                DefineBody::Bool(bool_expr)
+            }
+        }
+        Rule::value_expr => DefineBody::Value(parse_expr(inner)),
+        r => unreachable!("unexpected rule in define_body: {r:?}"),
+    };
+
+    Directive::Define { name, params, body }
 }
 
 fn parse_account_directive(pair: Pair<Rule>) -> Directive {
@@ -260,6 +315,36 @@ fn parse_account_directive(pair: Pair<Rule>) -> Directive {
     }
 
     Directive::Account { name, notes, items }
+}
+
+fn parse_tag_directive(pair: Pair<Rule>) -> Directive {
+    let mut inner = pair.into_inner();
+    let name = inner.next().unwrap().as_str().to_string();
+    let mut asserts = Vec::new();
+    let mut checks = Vec::new();
+
+    for p in inner {
+        match p.as_rule() {
+            Rule::note => {
+                // Header-level note on the tag directive line — discarded.
+            }
+            Rule::tag_assert => {
+                let expr = parse_bool_expr(p.into_inner().next().unwrap());
+                asserts.push(expr);
+            }
+            Rule::tag_check => {
+                let expr = parse_bool_expr(p.into_inner().next().unwrap());
+                checks.push(expr);
+            }
+            _ => {}
+        }
+    }
+
+    Directive::Tag {
+        name,
+        asserts,
+        checks,
+    }
 }
 
 fn parse_commodity_directive(pair: Pair<Rule>) -> Directive {

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -98,11 +98,20 @@ pub struct Context {
     pub commodity_aliases: BTreeMap<String, String>,
     /// The commodity assumed when a posting amount has no explicit commodity.
     pub default_commodity: Option<String>,
-    /// Named value aliases defined with `define name = expr`.
+    /// Named aliases defined with `define name[(params)] = body`.
     ///
-    /// During elaboration, a bare identifier in a value expression is looked
-    /// up here and substituted with the stored expression.
-    pub defines: BTreeMap<String, ast::ValueExpr>,
+    /// During elaboration, a bare identifier or parameterized call `name(args)`
+    /// in a value or boolean expression is looked up here and expanded.
+    pub defines: BTreeMap<String, Define>,
+}
+
+/// A resolved `define` entry, carrying parameter names and the macro body.
+#[derive(Debug, Clone)]
+pub struct Define {
+    /// Ordered parameter names. Empty for zero-argument defines.
+    pub params: Vec<String>,
+    /// The body expression to evaluate when the define is invoked.
+    pub body: ast::DefineBody,
 }
 
 /// Global properties of commodities and accounts that are shared across all
@@ -113,6 +122,19 @@ pub struct GlobalContext {
     pub commodity_properties: BTreeMap<String, CommodityProperties>,
     /// Properties declared in `account` directives.
     pub account_properties: BTreeMap<String, AccountProperties>,
+    /// Properties declared in `tag` directives.
+    pub tag_properties: BTreeMap<String, TagProperties>,
+}
+
+/// Validation rules for a tag declared with a `tag` directive.
+#[derive(Default, Debug)]
+pub struct TagProperties {
+    /// Fatal assertions: elaboration halts if any fails for a matching
+    /// `; TagName: value` metadata pair.
+    pub asserts: Vec<ast::BoolExpr>,
+    /// Non-fatal checks: a warning is printed to stderr but elaboration
+    /// continues if any fails.
+    pub checks: Vec<ast::BoolExpr>,
 }
 
 /// Display and market-data properties of a commodity.
@@ -589,12 +611,29 @@ impl TryFrom<ast::Journal> for HIR {
                         ctx
                     });
                 }
-                ast::Entry::Directive(ast::Directive::Define { name, expr }) => {
+                ast::Entry::Directive(ast::Directive::Define { name, params, body }) => {
                     new_context = Some({
                         let mut ctx = new_context.unwrap_or_else(|| context.clone());
-                        ctx.defines.insert(name, expr);
+                        ctx.defines.insert(name, Define { params, body });
                         ctx
                     });
+                }
+                ast::Entry::Directive(ast::Directive::Tag {
+                    name,
+                    asserts,
+                    checks,
+                }) => {
+                    let props = result
+                        .global_context
+                        .tag_properties
+                        .entry(name)
+                        .or_default();
+                    for expr in asserts {
+                        props.asserts.push(expr);
+                    }
+                    for expr in checks {
+                        props.checks.push(expr);
+                    }
                 }
                 ast::Entry::Transaction(transaction) => {
                     let date = Self::resolve_date(&transaction.date, current_default_year)?;
@@ -929,7 +968,8 @@ mod resolution_tests {
         let journal = ast::Journal {
             entries: vec![ast::Entry::Directive(ast::Directive::Define {
                 name: "monthly_rent".into(),
-                expr: expr.clone(),
+                params: vec![],
+                body: ast::DefineBody::Value(expr.clone()),
             })],
         };
 
@@ -937,9 +977,8 @@ mod resolution_tests {
 
         // A new context should have been pushed for the define directive.
         assert_eq!(hir.contexts.len(), 2);
-        assert_eq!(
-            hir.contexts[1].defines.get("monthly_rent"),
-            Some(&expr),
+        assert!(
+            hir.contexts[1].defines.contains_key("monthly_rent"),
             "define should be stored in the new context"
         );
         // The original context must not be affected.
@@ -968,7 +1007,8 @@ mod resolution_tests {
                 ast::Entry::Transaction(tx_ast.clone()),
                 ast::Entry::Directive(ast::Directive::Define {
                     name: "budget".into(),
-                    expr: expr.clone(),
+                    params: vec![],
+                    body: ast::DefineBody::Value(expr.clone()),
                 }),
                 ast::Entry::Transaction(tx_ast),
             ],


### PR DESCRIPTION
## Summary

- Extends the `tag` directive grammar to accept `assert` and `check` sub-directives with full `bool_expr` bodies (mirrors `account_directive`)
- Parses `tag_assert` / `tag_check` into a new `Directive::Tag { asserts, checks }` AST variant
- Accumulates tag validation rules in `GlobalContext::tag_properties` (a new `BTreeMap<String, TagProperties>`) during resolution
- During elaboration, validates metadata-style tags (`; TagName: value`) on both transaction-level and posting-level metadata by binding `value` as a `Str` in the expression context; failed `assert` returns `ElaborationError::TagAssertionFailed`; failed `check` warns to stderr
- Bare colon-tags (`; :payroll:`) are intentionally skipped — they carry no value
- Adds 9 targeted tests covering assert pass/fail, check warn-and-continue, posting-level validation, bare-tag bypass, and the declared-but-unused case
- Also fixes the in-progress parameterized-define work (already on this branch) to compile cleanly

Closes #82

## Test plan

- [x] `tag X\n    assert value =~ /^foo/` with `; X: foobar` → passes
- [x] Same with `; X: barfoo` → `TagAssertionFailed`
- [x] `tag X\n    check value =~ /^foo/` with `; X: barfoo` → warns, elaboration succeeds
- [x] Multiple asserts under one tag (IncomeType regex) → all must pass
- [x] Tag declared but not referenced → no errors
- [x] Posting-level metadata validated (not just transaction-level)
- [x] Bare colon-tags (`; :payroll:`) NOT validated — no value to check
- [x] All 113 unit tests + integration tests pass