### PR TITLE
feat(proto): canonical protobuf schema for Journal (closes #98)

### DIFF
--- a/proto/doppio.proto
+++ b/proto/doppio.proto
@@ -1,0 +1,165 @@
+// doppio canonical wire format.
+//
+// This file is the source of truth for `.dop` artifacts. All language
+// consumers (Rust, Python, JS/TS, Go, etc.) can generate bindings via their
+// respective `protoc` plugins and read elaborated journals without going
+// through the doppio Rust runtime.
+//
+// The Rust types in `src/elaboration.rs` are kept in sync with this schema;
+// the .proto file is the authoritative description of the wire shape.
+//
+// =============================================================================
+// Schema-evolution policy
+// =============================================================================
+//
+// Pre-1.0 (current):
+//   No backwards-compatibility guarantee. The `.dop` 8-byte header version
+//   gates incompatible reads ("recompile from source"). Schema may churn
+//   freely between minor versions.
+//
+// At 1.0 and beyond:
+//   - Field tags are RESERVED on deletion; never reuse a number.
+//   - Adding a new field with a fresh tag is non-breaking (proto3 default
+//     value applies for older readers).
+//   - Renaming a field is wire-compatible (the tag is the contract) but
+//     breaks generated code in some languages — bundle with a major bump.
+//   - The `.dop` 8-byte header version (DOP\0 + u16) is bumped only for
+//     truly incompatible changes; additive evolution does not require it.
+//
+// =============================================================================
+// Decimal handling
+// =============================================================================
+//
+// `rust_decimal::Decimal` is a 96-bit-mantissa fixed-point type with scale
+// 0..28. Protocol Buffers has no native big-decimal type; we encode the
+// mantissa as a signed 128-bit two's-complement integer split into two
+// halves (low: uint64, high: sint64), plus an unsigned scale.
+//
+// Reassemble client-side with:
+//
+//   value = (((mantissa_high as i128) << 64) | (mantissa_low as i128)) * 10^(-scale)
+//
+// This encoding is deliberately the same as the Cap'n Proto and FlatBuffers
+// prototypes documented in the doppio-research repo, so cross-format
+// comparisons stay apples-to-apples.
+
+syntax = "proto3";
+
+package doppio;
+
+// A 96-bit-mantissa fixed-point decimal value with scale 0..28.
+message Decimal {
+  // Lower 64 bits of the two's-complement mantissa.
+  uint64 mantissa_low = 1;
+  // Upper 64 bits of the two's-complement mantissa.
+  sint64 mantissa_high = 2;
+  // Number of decimal places (0..28).
+  uint32 scale = 3;
+}
+
+// Cleared / pending / uncleared state of a transaction or posting.
+//
+// Note: zero is UNCLEARED to match the Rust `Default` impl. This intentionally
+// deviates from the proto3 convention of an `_UNSPECIFIED = 0` zero value
+// because Uncleared is genuinely the default in ledger-cli semantics, not a
+// "missing" sentinel.
+enum TransactionState {
+  TRANSACTION_STATE_UNCLEARED = 0;
+  TRANSACTION_STATE_PENDING = 1;
+  TRANSACTION_STATE_CLEARED = 2;
+}
+
+// A multi-commodity balance: commodity symbol -> Decimal value.
+//
+// `BTreeMap<String, Decimal>` in Rust. Protobuf maps are unordered on the
+// wire but keys are unique; consumers that need a sorted iteration order
+// can sort by key after decode.
+message Amount {
+  map<string, Decimal> by_commodity = 1;
+}
+
+// A posting with a fully evaluated, concrete amount.
+message Posting {
+  // The canonical account name (after alias resolution).
+  string account = 1;
+  // Payee for this posting — taken from posting-level `payee:` metadata if
+  // present, otherwise inherited from the transaction description.
+  string payee = 2;
+  // The posting amount, keyed by commodity.
+  Amount amount = 3;
+  // Per-posting state.
+  TransactionState state = 4;
+  // Bare tags from `; :tag1:tag2:` syntax in posting notes.
+  repeated string tags = 5;
+  // Key-value metadata from `; key: value` in posting notes.
+  map<string, string> metadata = 6;
+}
+
+// A fully evaluated and balanced transaction.
+message Transaction {
+  // Days since the Unix epoch (1970-01-01 = 0). Negative for pre-epoch dates.
+  sint32 date = 1;
+  // Optional secondary (effective) date in the same epoch-days format.
+  optional sint32 secondary_date = 2;
+  // Cleared / pending / uncleared.
+  TransactionState state = 3;
+  // Optional reference code from the transaction header `( ... )`.
+  optional string code = 4;
+  // Payee / description.
+  string description = 5;
+  // Bare tags from `; :tag1:tag2:` syntax in transaction-header notes.
+  repeated string tags = 6;
+  // Key-value metadata from `; key: value` in transaction-header notes.
+  map<string, string> metadata = 7;
+  // The resolved postings (all amounts concrete, null posting filled in).
+  repeated Posting postings = 8;
+}
+
+// Properties of an account declared with an `account` directive.
+//
+// Note: `assert` / `check` expressions declared on accounts are evaluated
+// during elaboration and are not persisted — they are a compile-time check,
+// not runtime data.
+message AccountProperties {
+  // Free-form note from the `note` sub-directive.
+  optional string note = 1;
+}
+
+// Display and market-data properties of a commodity declared with a
+// `commodity` directive.
+message CommodityProperties {
+  // Display format string from the `format` sub-directive (e.g. "$1,000.00").
+  optional string format = 1;
+  // True iff `nomarket` was declared.
+  bool no_market = 2;
+  // Free-form note from the `note` sub-directive.
+  optional string note = 3;
+}
+
+// A historical-price entry from a `P` directive.
+message HistoricalPrice {
+  // Days since the Unix epoch on which this price was recorded.
+  sint32 date = 1;
+  // Optional wall-clock time of the price quote ("HH:MM" or "HH:MM:SS").
+  optional string time = 2;
+  // The commodity whose price is being recorded.
+  string commodity = 3;
+  // The evaluated price of one unit of `commodity`.
+  Decimal price = 4;
+  // The commodity the price is expressed in.
+  string price_commodity = 5;
+}
+
+// Top-level elaborated journal. This is the canonical wire shape of the
+// `.dop` artifact body. The body follows the 8-byte file header defined in
+// `src/lib.rs`: magic (`DOP\0`, 4 bytes) + version (u16 LE) + reserved (u16).
+message Journal {
+  // All transactions in source order, with amounts fully evaluated.
+  repeated Transaction transactions = 1;
+  // Accounts referenced by any posting, keyed by canonical account name.
+  map<string, AccountProperties> accounts = 2;
+  // Commodity properties from `commodity` directives, keyed by commodity name.
+  map<string, CommodityProperties> commodities = 3;
+  // Market price quotes from `P` directives, in source order.
+  repeated HistoricalPrice prices = 4;
+}

--- a/proto/doppio.proto
+++ b/proto/doppio.proto
@@ -1,47 +1,20 @@
 // doppio canonical wire format.
 //
-// This file is the source of truth for `.dop` artifacts. All language
-// consumers (Rust, Python, JS/TS, Go, etc.) can generate bindings via their
-// respective `protoc` plugins and read elaborated journals without going
-// through the doppio Rust runtime.
-//
-// The Rust types in `src/elaboration.rs` are kept in sync with this schema;
-// the .proto file is the authoritative description of the wire shape.
-//
-// =============================================================================
-// Schema-evolution policy
-// =============================================================================
-//
-// Pre-1.0 (current):
-//   No backwards-compatibility guarantee. The `.dop` 8-byte header version
-//   gates incompatible reads ("recompile from source"). Schema may churn
-//   freely between minor versions.
-//
-// At 1.0 and beyond:
-//   - Field tags are RESERVED on deletion; never reuse a number.
-//   - Adding a new field with a fresh tag is non-breaking (proto3 default
-//     value applies for older readers).
-//   - Renaming a field is wire-compatible (the tag is the contract) but
-//     breaks generated code in some languages — bundle with a major bump.
-//   - The `.dop` 8-byte header version (DOP\0 + u16) is bumped only for
-//     truly incompatible changes; additive evolution does not require it.
+// This file defines the wire shape of `.dop` artifacts. Language consumers
+// generate bindings via their respective `protoc` plugins and read elaborated
+// journals directly.
 //
 // =============================================================================
 // Decimal handling
 // =============================================================================
 //
-// `rust_decimal::Decimal` is a 96-bit-mantissa fixed-point type with scale
-// 0..28. Protocol Buffers has no native big-decimal type; we encode the
-// mantissa as a signed 128-bit two's-complement integer split into two
-// halves (low: uint64, high: sint64), plus an unsigned scale.
+// Protocol Buffers has no native big-decimal type. The mantissa is encoded as
+// a signed 128-bit two's-complement integer split into two halves (low:
+// uint64, high: sint64), plus an unsigned scale (0..28).
 //
 // Reassemble client-side with:
 //
 //   value = (((mantissa_high as i128) << 64) | (mantissa_low as i128)) * 10^(-scale)
-//
-// This encoding is deliberately the same as the Cap'n Proto and FlatBuffers
-// prototypes documented in the doppio-research repo, so cross-format
-// comparisons stay apples-to-apples.
 
 syntax = "proto3";
 
@@ -58,22 +31,14 @@ message Decimal {
 }
 
 // Cleared / pending / uncleared state of a transaction or posting.
-//
-// Note: zero is UNCLEARED to match the Rust `Default` impl. This intentionally
-// deviates from the proto3 convention of an `_UNSPECIFIED = 0` zero value
-// because Uncleared is genuinely the default in ledger-cli semantics, not a
-// "missing" sentinel.
 enum TransactionState {
-  TRANSACTION_STATE_UNCLEARED = 0;
-  TRANSACTION_STATE_PENDING = 1;
-  TRANSACTION_STATE_CLEARED = 2;
+  TRANSACTION_STATE_UNSPECIFIED = 0;
+  TRANSACTION_STATE_UNCLEARED = 1;
+  TRANSACTION_STATE_PENDING = 2;
+  TRANSACTION_STATE_CLEARED = 3;
 }
 
 // A multi-commodity balance: commodity symbol -> Decimal value.
-//
-// `BTreeMap<String, Decimal>` in Rust. Protobuf maps are unordered on the
-// wire but keys are unique; consumers that need a sorted iteration order
-// can sort by key after decode.
 message Amount {
   map<string, Decimal> by_commodity = 1;
 }
@@ -140,7 +105,7 @@ message CommodityProperties {
 message HistoricalPrice {
   // Days since the Unix epoch on which this price was recorded.
   sint32 date = 1;
-  // Optional wall-clock time of the price quote ("HH:MM" or "HH:MM:SS").
+  // Optional wall-clock time of the price quote.
   optional string time = 2;
   // The commodity whose price is being recorded.
   string commodity = 3;
@@ -151,8 +116,8 @@ message HistoricalPrice {
 }
 
 // Top-level elaborated journal. This is the canonical wire shape of the
-// `.dop` artifact body. The body follows the 8-byte file header defined in
-// `src/lib.rs`: magic (`DOP\0`, 4 bytes) + version (u16 LE) + reserved (u16).
+// `.dop` artifact body. The body follows the 8-byte file header
+// (magic + version + reserved).
 message Journal {
   // All transactions in source order, with amounts fully evaluated.
   repeated Transaction transactions = 1;


### PR DESCRIPTION
## Summary

Resolves #98 (Phase A review-gate): adds `proto/doppio.proto` defining the canonical wire format for `.dop` artifacts. **No code changes elsewhere** — the schema lands first, gets reviewed and locked, then #100 wires it into the runtime.

## Decisions locked

Recorded in the file's header comments:

- **File location**: `proto/doppio.proto` at repo root, package `doppio`
- **Decimal encoding**: `(mantissa_low: uint64, mantissa_high: sint64, scale: uint32)` triple — matches the doppio-research prototypes; reassemble client-side as `((high << 64) | low) * 10^(-scale)`
- **TransactionState enum**: zero is `TRANSACTION_STATE_UNCLEARED` to match Rust `Default`. Deliberate deviation from proto3's `_UNSPECIFIED = 0` convention because Uncleared is genuinely the default in ledger-cli semantics, not a 'missing' indicator
- **Optional fields**: proto3 `optional` keyword for `secondary_date`, `code`, `time`, `format`, `note` (presence-tracked, distinct from default-zero)
- **Maps**: `map<string, X>` for the `accounts`/`commodities` collections on `Journal`, `metadata` on transactions/postings, and the `Amount.by_commodity` payload. Protobuf maps don't preserve wire-order; consumers that need sorted iteration (matching today's `BTreeMap` behaviour) sort by key after decode
- **Date encoding**: `sint32` epoch-days (matches Rust `i32`; negative for pre-epoch)
- **Field-number assignments**: sequential within each message starting at 1; reservation discipline kicks in at 1.0
- **Schema-evolution policy**: pre-1.0 we break freely (the `.dop` 8-byte header version still gates incompatible reads with 'recompile from source'). Post-1.0: additive only, tags reserved on deprecation, never reused

## Out of scope (separate issues)

- Wiring the schema into Rust code (#100)
- WASM build target (#101)
- Cross-language consumer SDKs (post-1.0)

## Validation

```sh
nix shell nixpkgs#protobuf -c protoc --proto_path=proto proto/doppio.proto -o /dev/null
```

Exit 0 on this branch.

## Reference

Working schema in [`alevy/doppio-research`](https://github.com/alevy/doppio-research) (private) — `prototypes/serialization-protobuf/journal.proto`. This PR's schema tightens that prototype: adds proto3 `optional` keyword (cleaner than parallel `bool has_X` flags), unifies on `map` for collections, expands the field-level documentation, and adds the schema-evolution policy.
