### PR TITLE
feat: hledger frontend for .hledger and .journal files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## [Unreleased]
 
+### Added
+
+- **hledger frontend** (issue #103): `.hledger` and `.journal` files are now
+  parsed by a dedicated hledger frontend (`HledgerFrontend`) rather than
+  falling through to the ledger-cli parser. Key additions over the ledger-cli
+  grammar:
+  - Date separators `/` and `.` in addition to `-` (e.g. `2024/01/15`,
+    `2024.01.15`).
+  - Comment lines starting with `#` (in addition to `;`).
+  - `commodity` directive accepts a format string directly
+    (e.g. `commodity $1,000.00`) as well as a bare symbol.
+  - `account` directive accepts a `type` sub-key.
+  - Periodic transactions (`~`) are parsed and silently ignored.
+  - Automated posting rules (`= query`) are parsed and silently ignored.
+    **Automated posting arithmetic bodies (`*N`) are not yet elaborated**
+    (TODO #103 followup).
+  - The `Frontend` trait, `frontend_for_extension()`, and
+    `HledgerFrontend` are all public so library consumers can select or
+    instantiate the frontend directly.
+
 ### Internal
 
 - **Repo restructured into a Cargo workspace.** The library now lives in

--- a/README.md
+++ b/README.md
@@ -133,6 +133,23 @@ Full API documentation:
 cargo doc --no-deps --open
 ```
 
+## Supported input formats
+
+doppio recognises two input formats by file extension:
+
+| Extension | Format | Frontend |
+|---|---|---|
+| `.ledger` | [ledger-cli](https://ledger-cli.org/) | `LedgerFrontend` |
+| `.hledger` | [hledger](https://hledger.org/) | `HledgerFrontend` |
+| `.journal` | hledger (alternative extension) | `HledgerFrontend` |
+
+The hledger frontend parses the same core constructs as the ledger-cli frontend
+(transactions, postings, balance assertions/assignments, lot pricing, historical
+prices, account/commodity directives, include) and adds hledger-specific
+extensions (`/` and `.` date separators, `#` comment lines). Automated posting
+rule arithmetic bodies (`*N` multipliers) are stubbed out and produce a parse
+error if encountered — see issue #103.
+
 ## Supported Ledger features
 
 doppio supports the subset of ledger-cli syntax needed for typical day-to-day
@@ -146,6 +163,7 @@ At a glance:
 | Expressions — arithmetic, comparisons, regex `=~`/`!~`, `tag()`, parameterised function calls | Supported |
 | CLI — `compile`, `balance`, `register`, `print`, `stats`, `accounts`, `commodities`; text / JSON / CSV output | Supported |
 | Library API — `compile`, `eval_transaction`, `write_ledger`, `.dop` binary format | Supported |
+| hledger input format (`.hledger`, `.journal`) | Supported (v0.3.0, issue #103) |
 | Budgets (`~`), automated transactions (`= payee expr`), Lisp-style scripting | Not supported |
 
 See [`docs/SUPPORTED_FEATURES.md`](./docs/SUPPORTED_FEATURES.md) for the full

--- a/crates/doppio-cli/tests/fixtures/sample.hledger
+++ b/crates/doppio-cli/tests/fixtures/sample.hledger
@@ -1,0 +1,63 @@
+; A small but representative hledger journal used by the integration test suite.
+; Covers 11 of 12 entry forms from the doppio-research prototype.
+; (Automated-posting arithmetic bodies are intentionally omitted — see TODO #103.)
+
+; --- Account / commodity / price directives ---
+
+account assets:bank:checking    ; type:A
+account expenses:groceries
+account income:salary
+
+commodity $1,000.00
+commodity 1,000.00 EUR
+
+P 2024-01-02 EUR $1.10
+P 2024-02-15 AAPL $182.50
+
+; --- A simple cleared transaction ---
+
+2024-01-15 * Opening Balances
+    assets:bank:checking          $1000.00
+    equity:opening-balances
+
+; --- Pending status, code, posting comment ---
+
+2024-01-16 ! (INV-42) ACME Corp  ; project:website
+    expenses:consulting           $500.00 ; vendor: ACME
+    assets:bank:checking
+
+; --- Balance assertion (=) ---
+
+2024-01-31 * end-of-month check
+    assets:bank:checking            $0.00 = $500.00
+    expenses:adjustments
+
+; --- Strict balance assertion (==) ---
+
+2024-02-01 * checked
+    assets:bank:checking            $0.00 == $500.00
+    expenses:adjustments
+
+; --- Balance assignment: "= target" with no LHS amount ---
+
+2024-02-05 * Reset to known balance
+    assets:bank:checking          = $750.00
+    income:adjustments
+
+; --- Lot pricing: unit price (@) ---
+
+2024-02-10 * Buy euros
+    assets:eur                  100.00 EUR @ $1.10
+    assets:bank:checking         $-110.00
+
+; --- Lot pricing: total price (@@) ---
+
+2024-02-11 * Buy stock
+    assets:brokerage             10 AAPL @@ $1825.00
+    assets:bank:checking        $-1825.00
+
+; --- Periodic transaction (captured but not elaborated) ---
+
+~ monthly  Rent
+    expenses:rent                $2000
+    assets:bank:checking

--- a/crates/doppio-cli/tests/hledger_parse.rs
+++ b/crates/doppio-cli/tests/hledger_parse.rs
@@ -1,0 +1,388 @@
+//! Integration tests for the hledger frontend.
+//!
+//! These tests invoke the `dop` binary directly (same as CLI users would) and
+//! exercise:
+//!
+//! 1. Round-trip of every entry form in the prototype `sample.hledger`.
+//! 2. File-extension dispatch: `.hledger` and `.journal` both reach the
+//!    hledger frontend.
+//! 3. End-to-end: `dop balance` against a minimal hledger journal exits 0.
+//! 4. Balance assertions do not break elaboration.
+//! 5. Lot-priced postings parse and appear in the balance output.
+
+use std::{io::Write as _, path::PathBuf, process::Command};
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/// Absolute path to the `dop` binary under test.
+fn dop_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_dop"))
+}
+
+/// Run `dop <args>` and return stdout on success, panicking with diagnostics on failure.
+fn run(args: &[&str]) -> String {
+    let out = Command::new(dop_bin())
+        .args(args)
+        .output()
+        .expect("failed to run dop binary");
+    if !out.status.success() {
+        panic!(
+            "dop exited with {}\nargs: {:?}\nstderr: {}",
+            out.status,
+            args,
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+    String::from_utf8(out.stdout).expect("non-UTF-8 stdout")
+}
+
+/// Run `dop <args>` and expect failure; returns the stderr text.
+fn run_fail(args: &[&str]) -> String {
+    let out = Command::new(dop_bin())
+        .args(args)
+        .output()
+        .expect("failed to run dop binary");
+    assert!(
+        !out.status.success(),
+        "expected dop to fail but it exited 0\nargs: {args:?}"
+    );
+    String::from_utf8_lossy(&out.stderr).to_string()
+}
+
+/// Write `content` to a temporary file with the given suffix and return it.
+/// The file is kept alive for the duration of the test via the returned handle.
+fn tmp_file(content: &str, suffix: &str) -> tempfile::NamedTempFile {
+    let mut f = tempfile::NamedTempFile::with_suffix(suffix).expect("tempfile");
+    f.write_all(content.as_bytes()).expect("write");
+    f
+}
+
+/// Path to the bundled sample fixture.
+fn sample_hledger_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/sample.hledger")
+}
+
+// ── extension dispatch ────────────────────────────────────────────────────────
+
+/// A `.hledger` file is dispatched to the hledger frontend and parses cleanly.
+#[test]
+fn hledger_extension_dispatches_to_hledger_frontend() {
+    let f = tmp_file(
+        "2024-01-01 * Test\n    expenses:food  $10\n    assets:cash\n",
+        ".hledger",
+    );
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+    assert!(out.contains("10"), "amount should appear: {out}");
+}
+
+/// A `.journal` file is dispatched to the hledger frontend and parses cleanly.
+#[test]
+fn journal_extension_dispatches_to_hledger_frontend() {
+    let f = tmp_file(
+        "2024-01-01 * Test\n    expenses:food  $10\n    assets:cash\n",
+        ".journal",
+    );
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+    assert!(out.contains("10"), "amount should appear: {out}");
+}
+
+// ── sample fixture round-trips ────────────────────────────────────────────────
+
+/// `dop balance sample.hledger` exits 0 (end-to-end smoke test).
+#[test]
+fn sample_hledger_balance_exits_zero() {
+    let path = sample_hledger_path();
+    // The fixture has an `include common.journal` directive which will fail to
+    // open. Run without includes by relying on the fact that the CLI passes
+    // `file_opener` which returns an error — but `include` silently fails on
+    // missing includes only in the no-op opener.  To keep the fixture clean,
+    // we make a copy without the include line.
+    let content = std::fs::read_to_string(&path).expect("read sample");
+    let without_include: String = content
+        .lines()
+        .filter(|l| !l.trim_start().starts_with("include"))
+        .map(|l| format!("{l}\n"))
+        .collect();
+    let f = tmp_file(&without_include, ".hledger");
+    run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+}
+
+/// The sample fixture contains cleared transactions that affect balances.
+#[test]
+fn sample_hledger_cleared_transactions_appear_in_balance() {
+    let content = fixture_without_includes();
+    let f = tmp_file(&content, ".hledger");
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+    // The sample has postings to assets:bank:checking and expenses:consulting.
+    assert!(
+        out.contains("assets:bank:checking") || out.contains("checking"),
+        "checking account should appear: {out}"
+    );
+}
+
+/// Historical price directives parse without error (they are stored as prices).
+#[test]
+fn sample_hledger_historical_prices_parse() {
+    let content = fixture_without_includes();
+    let f = tmp_file(&content, ".hledger");
+    // If prices fail to parse, `dop balance` would return a non-zero exit code.
+    run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+}
+
+/// Account directives parse without error.
+#[test]
+fn sample_hledger_account_directives_parse() {
+    let content = "account assets:bank:checking    ; type:A\naccount expenses:groceries\n\n2024-01-01 * Test\n    expenses:groceries  $10\n    assets:bank:checking\n";
+    let f = tmp_file(content, ".hledger");
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+    assert!(out.contains("10"), "amount should appear: {out}");
+}
+
+/// Commodity directives parse without error and set formatting.
+#[test]
+fn sample_hledger_commodity_directives_parse() {
+    let content =
+        "commodity $1,000.00\n\n2024-01-01 * Test\n    expenses:food  $10\n    assets:cash\n";
+    let f = tmp_file(content, ".hledger");
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+    assert!(out.contains("10"), "amount should appear: {out}");
+}
+
+// ── specific entry forms ──────────────────────────────────────────────────────
+
+/// Simple two-posting cleared transaction (entry form 1).
+#[test]
+fn entry_form_simple_cleared() {
+    let input = "\
+2024-01-15 * Opening Balances
+    assets:bank:checking          $1000.00
+    equity:opening-balances
+";
+    let f = tmp_file(input, ".hledger");
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+    assert!(out.contains("1000"), "balance should contain 1000: {out}");
+    assert!(
+        out.contains("assets:bank:checking"),
+        "account should appear: {out}"
+    );
+}
+
+/// Pending transaction with code and posting comment (entry form 2).
+#[test]
+fn entry_form_pending_with_code() {
+    let input = "\
+2024-01-16 ! (INV-42) ACME Corp  ; project:website
+    expenses:consulting           $500.00 ; vendor: ACME
+    assets:bank:checking
+";
+    let f = tmp_file(input, ".hledger");
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+    assert!(out.contains("500"), "balance should contain 500: {out}");
+}
+
+/// Balance assertion posting (entry form 3): parses without error.
+///
+/// The assertion `$0.00 = $500.00` means "after this posting the account
+/// balance should be $500".  We prime the account with a prior transaction
+/// so the assertion passes during elaboration.
+#[test]
+fn entry_form_balance_assertion() {
+    let input = "\
+2024-01-15 * Opening Balances
+    assets:bank:checking          $500.00
+    equity:opening-balances
+
+2024-01-31 * end-of-month check
+    assets:bank:checking            $0.00 = $500.00
+    expenses:adjustments
+";
+    let f = tmp_file(input, ".hledger");
+    run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+}
+
+/// Strict balance assertion `==` (entry form 4): parses without error.
+///
+/// Same as the weak assertion test — prime the account first so the
+/// assertion holds during elaboration.
+#[test]
+fn entry_form_strict_balance_assertion() {
+    let input = "\
+2024-01-15 * Opening Balances
+    assets:bank:checking          $500.00
+    equity:opening-balances
+
+2024-02-01 * checked
+    assets:bank:checking            $0.00 == $500.00
+    expenses:adjustments
+";
+    let f = tmp_file(input, ".hledger");
+    run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+}
+
+/// Balance assignment `= target` with no LHS amount (entry form 5).
+#[test]
+fn entry_form_balance_assignment() {
+    let input = "\
+2024-02-05 * Reset to known balance
+    assets:bank:checking          = $750.00
+    income:adjustments
+";
+    let f = tmp_file(input, ".hledger");
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+    // The assignment is elaborated: checking becomes $750, income becomes -$750.
+    assert!(
+        out.contains("750"),
+        "balance assignment amount should appear: {out}"
+    );
+}
+
+/// Lot pricing `@` unit price (entry form 6).
+#[test]
+fn entry_form_lot_unit_price() {
+    let input = "\
+2024-02-10 * Buy euros
+    assets:eur                  100.00 EUR @ $1.10
+    assets:bank:checking         $-110.00
+";
+    let f = tmp_file(input, ".hledger");
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+    assert!(out.contains("EUR"), "EUR commodity should appear: {out}");
+}
+
+/// Lot pricing `@@` total price (entry form 7).
+#[test]
+fn entry_form_lot_total_price() {
+    let input = "\
+2024-02-11 * Buy stock
+    assets:brokerage             10 AAPL @@ $1825.00
+    assets:bank:checking        $-1825.00
+";
+    let f = tmp_file(input, ".hledger");
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+    assert!(out.contains("AAPL"), "AAPL commodity should appear: {out}");
+}
+
+/// Periodic transaction (entry form 8): silently ignored, does not break balance.
+#[test]
+fn entry_form_periodic_transaction_ignored() {
+    let input = "\
+~ monthly  Rent
+    expenses:rent                $2000
+    assets:bank:checking
+
+2024-01-01 * Real
+    expenses:food  $10
+    assets:cash
+";
+    let f = tmp_file(input, ".hledger");
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+    // Only the real transaction's amounts should appear.
+    assert!(
+        out.contains("10"),
+        "real transaction amount should appear: {out}"
+    );
+    // $2000 from the periodic transaction must NOT appear.
+    assert!(
+        !out.contains("2000"),
+        "periodic transaction amount must not appear: {out}"
+    );
+}
+
+/// hledger `/` date separator is accepted (entry form 9 variant).
+#[test]
+fn entry_form_slash_date_separator() {
+    let input = "2024/03/15 * Groceries\n    expenses:food  $30\n    assets:cash\n";
+    let f = tmp_file(input, ".hledger");
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+    assert!(out.contains("30"), "amount should appear: {out}");
+}
+
+/// hledger `.` date separator is accepted (entry form 10 variant).
+#[test]
+fn entry_form_dot_date_separator() {
+    let input = "2024.06.01 * Salary\n    income:salary  $-5000\n    assets:bank\n";
+    let f = tmp_file(input, ".hledger");
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+    assert!(out.contains("5000"), "amount should appear: {out}");
+}
+
+/// Comment lines starting with `#` parse cleanly (entry form 11).
+#[test]
+fn entry_form_hash_comment() {
+    let input =
+        "# This is a hash comment\n2024-01-01 * Test\n    expenses:food  $10\n    assets:cash\n";
+    let f = tmp_file(input, ".hledger");
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+    assert!(out.contains("10"), "amount should appear: {out}");
+}
+
+// ── automated posting rule stub ───────────────────────────────────────────────
+
+/// An automated posting rule with a plain account posting (no `*N` arithmetic)
+/// is silently ignored — it should not crash the parser.
+///
+/// Note: `*N` multiplier bodies are stubbed out (TODO #103).
+#[test]
+fn auto_rule_without_arithmetic_body_is_ignored() {
+    let input = "\
+= expenses:groceries
+    (budget:groceries)           10
+
+2024-01-01 * Groceries
+    expenses:groceries  $10
+    assets:cash
+";
+    let f = tmp_file(input, ".hledger");
+    // Auto rules are ignored; only the real transaction contributes to balance.
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+    assert!(out.contains("10"), "real transaction should appear: {out}");
+    // The automated posting itself must NOT appear in the balance.
+    assert!(
+        !out.contains("budget"),
+        "automated posting must not be elaborated: {out}"
+    );
+}
+
+// ── date formats ──────────────────────────────────────────────────────────────
+
+/// `dop balance` on a minimal `.hledger` file exits 0 (pure end-to-end check).
+#[test]
+fn end_to_end_balance_exits_zero() {
+    let input = "2024-01-01 * Salary\n    income:salary  $-1000\n    assets:checking  $1000\n";
+    let f = tmp_file(input, ".hledger");
+    run(&["balance", f.path().to_str().unwrap()]);
+}
+
+/// `dop balance` on a `.journal` extension exits 0.
+#[test]
+fn end_to_end_journal_extension_balance() {
+    let input = "2024-01-01 * Salary\n    income:salary  $-1000\n    assets:checking  $1000\n";
+    let f = tmp_file(input, ".journal");
+    run(&["balance", f.path().to_str().unwrap()]);
+}
+
+/// An invalid hledger file produces a non-zero exit code.
+#[test]
+fn invalid_hledger_file_returns_error() {
+    // A truncated header that cannot parse (missing year's century).
+    let input = "24-01-01 Bad date\n    expenses:food  $10\n    assets:cash\n";
+    let f = tmp_file(input, ".hledger");
+    let stderr = run_fail(&["balance", f.path().to_str().unwrap()]);
+    assert!(
+        !stderr.is_empty(),
+        "error output should explain the failure: {stderr}"
+    );
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/// Load sample.hledger, strip the include directive (which would attempt I/O).
+fn fixture_without_includes() -> String {
+    let path = sample_hledger_path();
+    let content = std::fs::read_to_string(path).expect("read sample fixture");
+    content
+        .lines()
+        .filter(|l| !l.trim_start().starts_with("include"))
+        .map(|l| format!("{l}\n"))
+        .collect()
+}

--- a/crates/doppio/src/grammars/hledger/hledger.pest
+++ b/crates/doppio/src/grammars/hledger/hledger.pest
@@ -1,0 +1,247 @@
+// ============================================================
+// hledger.pest — PEG grammar for the hledger journal format.
+//
+// Conventions from pest (https://pest.rs/):
+//   UPPERCASE  — built-in rules (NEWLINE, EOI, ANY, ASCII_DIGIT, …)
+//   _{ … }    — silent rule: matched but not included in the pair tree
+//   @{ … }    — atomic rule: inner tokens are NOT individually paired
+//   ${ … }    — compound-atomic: inner named rules ARE paired but
+//               implicit whitespace skipping is disabled
+//
+// Key differences from ledger.pest:
+//   - Date separators include `.` and `/` in addition to `-`
+//   - Comment lines also start with `#` (in addition to `;`)
+//   - `description` is optional (hledger allows bare `DATE *` lines)
+//   - `account` directives may have a type comment on the header line
+//   - `commodity` directive accepts a commodity-format string, not just
+//     a bare commodity name
+//   - Automated posting rule bodies may reference `*N` multipliers;
+//     parsing of the multiplier expression is STUBBED out (see TODO below)
+//
+// NOT YET SUPPORTED (stubbed / ignored):
+//   - Automated posting arithmetic bodies (`= query\n    account  *1.1`):
+//     the auto_rule rule captures the shape but the posting amounts inside
+//     automated rules that use `*N` will fail to parse.  See TODO(#103).
+//   - `comment` / `end comment` block comment syntax.
+//   - Full hledger date inference from a preceding `Y year` directive.
+//   - Directive-attached tags (metadata on the same line as a directive).
+// ============================================================
+
+// --- Top Level ---
+
+journal = ${ (entry | NEWLINE)* ~ EOI }
+
+entry = _{
+    transaction
+    | periodic_transaction
+    | auto_rule
+    | historical_price
+    | account_directive
+    | commodity_directive
+    | include_directive
+    | comment_line
+}
+
+// --- Transactions ---
+
+// A transaction header followed by optional indented notes and postings.
+transaction = ${
+    header ~ NEWLINE ~
+    (transaction_note | posting | empty_indented_line)*
+}
+
+// hledger header:
+//   DATE [STATUS] [CODE] [DESCRIPTION] [; COMMENT]
+//
+// Description is optional in hledger (bare `2024-01-01 *` is valid).
+header = ${
+    date
+    ~ (ws+ ~ status)?
+    ~ (ws+ ~ code)?
+    ~ (ws+ ~ description)?
+    ~ (ws* ~ note)?
+}
+
+transaction_note = ${ indent+ ~ note ~ (NEWLINE | EOI) }
+empty_indented_line = _{ indent+ ~ NEWLINE }
+
+// --- Periodic transactions ---
+//
+// `~ PERIOD_EXPR\n POSTINGS…`
+// The period expression is the rest of the header line; it is stored as a raw
+// string and not elaborated (same as the ledger frontend budget entries).
+periodic_transaction = ${
+    "~" ~ ws+ ~ period_expr ~ NEWLINE ~
+    (transaction_note | posting | empty_indented_line)*
+}
+period_expr = @{ (!(NEWLINE | ";") ~ ANY)+ }
+
+// --- Automated posting rules ---
+//
+// `= QUERY\n POSTINGS…`
+//
+// TODO(#103): Automated posting amounts may use `*N` multiplier expressions
+// that reference the matched posting's amount.  Parsing these is not yet
+// implemented.  For now the rule captures the outer shape; any posting whose
+// amount body uses `*N` will produce a parse error with a clear message.
+auto_rule = ${
+    "=" ~ ws+ ~ rule_query ~ NEWLINE ~
+    (transaction_note | posting | empty_indented_line)*
+}
+rule_query = @{ (!(NEWLINE | ";") ~ ANY)+ }
+
+// --- Postings ---
+
+posting = ${
+    indent+ ~ !NEWLINE ~
+    (status ~ ws+)? ~
+    account ~
+    (amount_logic)? ~
+    (ws* ~ note)? ~
+    (NEWLINE | EOI) ~
+    posting_note*
+}
+posting_note = ${ indent+ ~ note ~ (NEWLINE | EOI) }
+
+// The amount field of a posting.
+// Two or more spaces (or a tab) separate the account from the amount —
+// identical to the ledger-cli convention so that account names containing a
+// single space are parsed correctly.
+amount_logic = ${
+    (ws{2,} | "\t") ~ (
+        value_logic
+        | assertion
+    )
+}
+
+value_logic = ${ value_expr ~ (ws* ~ lot_price)? ~ (ws* ~ assertion)? }
+
+// hledger uses `==` for "all-commodity" (strict) balance assertions and `=`
+// for single-commodity assertions.  The longer token must be tried first.
+assertion = ${ assertion_op ~ ws* ~ value_expr }
+assertion_op = @{ "==" | "=" }
+
+// --- Atoms ---
+
+// hledger accepts YYYY-MM-DD, YYYY/MM/DD, and YYYY.MM.DD.
+date = ${ year ~ date_sep ~ monthdate ~ date_sep ~ monthdate }
+year = @{ ASCII_DIGIT{4} }
+monthdate = @{ ASCII_DIGIT{1,2} }
+date_sep = _{ "-" | "/" | "." }
+
+// Cleared (*) or pending (!) state marker.
+status = { "*" | "!" }
+
+// An optional reference code in parentheses, e.g. "(INV-042)".
+code = { "(" ~ (!")" ~ ANY)* ~ ")" }
+
+// Everything after the header fields up to a semicolon or newline.
+// hledger trims trailing whitespace from the description at display time.
+description = @{ (!(";" | NEWLINE) ~ ANY)+ }
+
+// An account name: stops at double-space, semicolon, tab, equals, or newline.
+account = @{ (!("  " | ";" | "\t" | "=" | NEWLINE) ~ ANY)+ }
+
+// Lot pricing: `@ unit_price` or `@@ total_price`.
+lot_price = ${ ("@@" | "@") ~ ws* ~ value_expr }
+
+indent = _{ " " | "\t" }
+ws = _{ " " | "\t" }
+
+// hledger comments start with `;` or `#`.
+note = ${ ";" ~ note_str }
+note_str = ${ (!NEWLINE ~ ANY)* }
+comment_line = @{ (";" | "#") ~ (!NEWLINE ~ ANY)* }
+
+// --- Historical prices ---
+
+historical_price = ${
+    "P" ~ ws+ ~ date ~ ws+ ~ commodity ~ ws+ ~ value_expr ~ (NEWLINE | EOI)
+}
+
+// --- Account directive ---
+//
+// hledger's account directive optionally has indented sub-directives
+// (note, alias, type, …) which are treated as key/value account items,
+// mirroring the structure of the ledger-cli account block.
+account_directive = ${
+    "account" ~ ws+ ~ account ~ (ws* ~ note)? ~ NEWLINE ~
+    ((indent+ ~ note ~ NEWLINE) | account_item)*
+}
+
+account_item = ${
+    indent+ ~ account_key ~ (ws+ ~ account_val)? ~ (ws* ~ note)? ~ (NEWLINE | EOI)
+}
+account_key = @{ "note" | "alias" | "type" | identifier }
+account_val = @{ (!NEWLINE ~ ANY)* }
+
+// --- Commodity directive ---
+//
+// hledger accepts:
+//   commodity SYMBOL           (bare symbol)
+//   commodity FORMAT_STRING    (e.g. `commodity $1,000.00`)
+//
+// Both forms are captured as a raw format string; parsing the format is done
+// in the Rust layer by inspecting the string.
+commodity_directive = ${
+    "commodity" ~ ws+ ~ commodity_format ~ (ws* ~ note)? ~ (NEWLINE | EOI) ~
+    ((indent+ ~ note ~ NEWLINE) | commodity_item)*
+}
+
+// A commodity format string is the rest of the line up to a comment.
+commodity_format = @{ (!(";" | NEWLINE) ~ ANY)+ }
+
+commodity_item = ${
+    indent+ ~ commodity_key ~ (ws+ ~ commodity_val)? ~ (ws* ~ note)? ~ (NEWLINE | EOI)
+}
+commodity_key = @{ "alias" | "format" | "nomarket" | "default" | "note" | identifier }
+commodity_val = @{ (!NEWLINE ~ ANY)* }
+
+// --- Include directive ---
+
+include_directive = ${ "include" ~ ws+ ~ filename ~ (NEWLINE | EOI) }
+filename = @{ (!NEWLINE ~ ANY)+ }
+
+// --- Value expressions ---
+//
+// Identical in shape to ledger.pest.  hledger's posting-amount syntax is a
+// subset of ledger-cli's (no `define`, no boolean-expressions in directives),
+// so the same Pratt-parsed expression grammar is fully sufficient.
+
+value_expr = ${ expr ~ (ws+ ~ commodity)? }
+expr = ${ term ~ (ws* ~ infix_op ~ ws* ~ term)* }
+term = ${ (prefix_op ~ ws*)? ~ primary }
+primary = { base_primary }
+
+base_primary = _{
+    "(" ~ expr ~ ")"
+    | amount
+    | commodity
+}
+
+amount = ${
+    (commodity ~ ws* ~ number)
+    | (number ~ ws+ ~ commodity)
+    | number
+}
+
+number = @{
+    ASCII_DIGIT+ ~ ("," ~ ASCII_DIGIT{3})* ~ ("." ~ ASCII_DIGIT+)?
+    | "." ~ ASCII_DIGIT+
+}
+
+commodity = @{
+    symbol+
+    | (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_" | "." | ":" | "#")*
+}
+symbol = _{ "$" | "€" | "£" | "¥" }
+
+// A plain identifier: letter or underscore, then alphanumeric or underscore.
+identifier = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
+
+infix_op = _{ add | sub | mul | div }
+    add = { "+" }
+    sub = { "-" }
+    mul = { "*" }
+    div = { "/" }
+prefix_op = { "-" | "+" }

--- a/crates/doppio/src/grammars/hledger/mod.rs
+++ b/crates/doppio/src/grammars/hledger/mod.rs
@@ -1,0 +1,940 @@
+//! hledger frontend: parse `.hledger` / `.journal` source text into an
+//! [`ast::Journal`].
+//!
+//! This module follows the same three-layer structure as [`crate::grammars::ledger`]:
+//!
+//! 1. **[`HledgerParser`]** — a `pest`-derived parser generated from
+//!    `hledger.pest`.
+//! 2. **[`parse_hledger`]** — convenience function that wraps the parser with a
+//!    no-op include opener; useful in tests.
+//! 3. **[`HledgerFrontend`]** — implements [`crate::frontend::Frontend`] so the
+//!    CLI can select this parser by file extension (`.hledger`, `.journal`).
+//!
+//! ## Known limitations / stubs
+//!
+//! - **Automated posting arithmetic bodies** (`*N` multiplier expressions):
+//!   the `auto_rule` grammar rule captures the shape of an automated posting
+//!   rule but postings whose amounts use `*N` will produce a parse error.
+//!   See TODO(#103).
+//! - `comment` / `end comment` block comments are not yet supported.
+//! - Full date inference from a `Y year` directive is not implemented.
+
+use crate::ast::*;
+use pest::Parser as _;
+use pest::iterators::Pair;
+use pest_derive::Parser;
+use rust_decimal::Decimal;
+use std::path::PathBuf;
+
+/// The raw pest parser generated from `hledger.pest` via `pest_derive`.
+#[derive(Parser)]
+#[grammar = "grammars/hledger/hledger.pest"]
+pub struct HledgerParser;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Internal parser state
+// ──────────────────────────────────────────────────────────────────────────────
+
+struct Parser<F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>> {
+    opener: F,
+    base_path: PathBuf,
+}
+
+impl<F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>> Parser<F> {
+    fn parse(&mut self, input: &str) -> Result<Journal, Box<dyn std::error::Error>> {
+        let pairs = HledgerParser::parse(Rule::journal, input)?;
+        let mut entries = Vec::new();
+
+        for pair in pairs.into_iter().next().unwrap().into_inner() {
+            match pair.as_rule() {
+                Rule::transaction => {
+                    entries.push(Entry::Transaction(parse_transaction(pair)));
+                }
+                Rule::comment_line => {
+                    entries.push(Entry::Comment(pair.as_str().to_string()));
+                }
+                Rule::historical_price => {
+                    entries.push(Entry::HistoricalPrice(parse_historical_price(pair)));
+                }
+                Rule::account_directive => {
+                    entries.push(Entry::Directive(parse_account_directive(pair)));
+                }
+                Rule::commodity_directive => {
+                    entries.push(Entry::Directive(parse_commodity_directive(pair)));
+                }
+                Rule::include_directive => {
+                    let include_path = self.base_path.join(pair.into_inner().as_str());
+                    let new_input = (self.opener)(include_path.as_os_str().to_str().unwrap())?;
+                    let new_base_path = include_path
+                        .parent()
+                        .map(std::path::PathBuf::from)
+                        .unwrap_or_else(|| self.base_path.clone());
+                    let old_base_path = std::mem::replace(&mut self.base_path, new_base_path);
+                    entries.append(&mut self.parse(&new_input)?.entries);
+                    let _ = std::mem::replace(&mut self.base_path, old_base_path);
+                }
+                Rule::periodic_transaction => {
+                    // Periodic transactions (`~ monthly …`) share the same
+                    // shape as ledger-cli budget entries: captured but not
+                    // elaborated. The postings are intentionally dropped.
+                }
+                Rule::auto_rule => {
+                    // Automated posting rules (`= QUERY`) are not yet
+                    // elaborated.  TODO(#103): implement automated postings.
+                }
+                _ => {}
+            }
+        }
+
+        Ok(Journal { entries })
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// AST construction helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+fn parse_date(pair: Pair<Rule>) -> Date {
+    // date = ${ year ~ date_sep ~ monthdate ~ date_sep ~ monthdate }
+    let mut inner = pair.into_inner();
+    let year: i32 = inner.next().unwrap().as_str().parse().unwrap();
+    let month: u32 = inner.next().unwrap().as_str().parse().unwrap();
+    let date: u32 = inner.next().unwrap().as_str().parse().unwrap();
+    Date {
+        year: Some(year),
+        month,
+        date,
+    }
+}
+
+fn parse_state(s: &str) -> TransactionState {
+    match s {
+        "*" => TransactionState::Cleared,
+        "!" => TransactionState::Pending,
+        _ => TransactionState::Uncleared,
+    }
+}
+
+fn parse_transaction(pair: Pair<Rule>) -> Transaction {
+    let mut inner = pair.into_inner();
+    let header_pair = inner.next().unwrap();
+    let mut postings = Vec::new();
+    let mut notes = Vec::new();
+
+    for p in inner {
+        match p.as_rule() {
+            Rule::transaction_note => {
+                if let Some(note_pair) = p.into_inner().next() {
+                    notes.push(note_pair.into_inner().as_str().trim().to_string());
+                }
+            }
+            Rule::posting => {
+                postings.push(parse_posting(p));
+            }
+            _ => {}
+        }
+    }
+
+    // Parse header fields
+    let mut header = header_pair.into_inner();
+    let date = parse_date(header.next().unwrap());
+
+    let mut state = TransactionState::Uncleared;
+    let mut code = None;
+    let mut description = String::new();
+
+    for p in header {
+        match p.as_rule() {
+            Rule::status => state = parse_state(p.as_str()),
+            Rule::code => {
+                let s = p.as_str();
+                // Strip the surrounding parentheses.
+                code = Some(s[1..s.len() - 1].to_string());
+            }
+            Rule::description => {
+                description = p.as_str().trim_end().to_string();
+            }
+            Rule::note => {
+                notes.push(p.into_inner().as_str().trim().to_string());
+            }
+            _ => {}
+        }
+    }
+
+    Transaction {
+        date,
+        secondary_date: None,
+        state,
+        code,
+        description,
+        notes,
+        postings,
+    }
+}
+
+fn parse_posting(pair: Pair<Rule>) -> Posting {
+    let inner = pair.into_inner();
+    let mut state = TransactionState::Uncleared;
+    let mut account = String::new();
+    let mut amount = None;
+    let mut notes = Vec::new();
+
+    for p in inner {
+        match p.as_rule() {
+            Rule::status => state = parse_state(p.as_str()),
+            Rule::account => account = p.as_str().trim().to_string(),
+            Rule::amount_logic => amount = Some(parse_amount_logic(p)),
+            Rule::note => notes.push(p.into_inner().as_str().trim().to_string()),
+            Rule::posting_note => {
+                if let Some(note_pair) = p.into_inner().next() {
+                    notes.push(note_pair.into_inner().as_str().trim().to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Posting {
+        account,
+        amount,
+        state,
+        notes,
+    }
+}
+
+fn parse_amount_logic(pair: Pair<Rule>) -> AmountDetails {
+    let p = pair.into_inner().next().unwrap();
+    match p.as_rule() {
+        Rule::value_logic => {
+            let inner = p.into_inner();
+            let mut value = None;
+            let mut lot_pricing = None;
+            let mut balance_assertion = None;
+
+            for p in inner {
+                match p.as_rule() {
+                    Rule::value_expr => {
+                        value = Some(parse_expr(p));
+                    }
+                    Rule::lot_price => {
+                        let s = p.as_str();
+                        let inner_val = parse_expr(p.into_inner().next().unwrap());
+                        if s.starts_with("@@") {
+                            lot_pricing = Some(LotPricing::Total(inner_val));
+                        } else {
+                            lot_pricing = Some(LotPricing::Unit(inner_val));
+                        }
+                    }
+                    Rule::assertion => {
+                        // assertion = ${ assertion_op ~ ws* ~ value_expr }
+                        // The first inner child is assertion_op; the second is
+                        // value_expr.  Skip assertion_op by filtering on rule.
+                        let inner_expr_pair = p
+                            .into_inner()
+                            .find(|p| p.as_rule() == Rule::value_expr)
+                            .expect("assertion must contain a value_expr");
+                        balance_assertion = Some(parse_expr(inner_expr_pair));
+                    }
+                    _ => unreachable!(),
+                }
+            }
+            AmountDetails::Amount {
+                value: value.unwrap(),
+                lot_pricing,
+                balance_assertion,
+            }
+        }
+        Rule::assertion => {
+            // The assertion rule: assertion_op ~ ws* ~ value_expr.
+            // Skip the assertion_op child, take the value_expr.
+            let inner_expr_pair = p
+                .into_inner()
+                .find(|p| p.as_rule() == Rule::value_expr)
+                .expect("assertion must have a value_expr");
+            AmountDetails::BalanceAssignment(parse_expr(inner_expr_pair))
+        }
+        _ => unreachable!("unexpected rule in amount_logic: {:?}", p.as_rule()),
+    }
+}
+
+fn parse_historical_price(pair: Pair<Rule>) -> HistoricalPrice {
+    let mut inner = pair.into_inner();
+    let date = parse_date(inner.next().unwrap());
+    let mut commodity = String::new();
+    let mut price_pair = None;
+
+    for p in inner {
+        match p.as_rule() {
+            Rule::commodity => commodity = p.as_str().to_string(),
+            Rule::value_expr => price_pair = Some(p),
+            _ => {}
+        }
+    }
+
+    HistoricalPrice {
+        date,
+        time: None,
+        commodity,
+        price: parse_expr(price_pair.expect("historical_price must have a price")),
+    }
+}
+
+fn parse_account_directive(pair: Pair<Rule>) -> Directive {
+    let mut inner = pair.into_inner();
+    let name = inner.next().unwrap().as_str().to_string();
+    let mut notes = Vec::new();
+    let mut items = Vec::new();
+
+    for p in inner {
+        match p.as_rule() {
+            Rule::note => notes.push(p.into_inner().as_str().trim().to_string()),
+            Rule::account_item => {
+                items.push(parse_account_item(p));
+            }
+            _ => {}
+        }
+    }
+
+    Directive::Account { name, notes, items }
+}
+
+fn parse_account_item(pair: Pair<Rule>) -> AccountItem {
+    let mut inner = pair.into_inner();
+    let key = inner.next().unwrap().as_str().to_string();
+    let mut val = None;
+
+    for p in inner {
+        if p.as_rule() == Rule::account_val {
+            val = Some(p.as_str().trim().to_string());
+        }
+    }
+
+    match key.as_str() {
+        "alias" => AccountItem::Alias(val.unwrap_or_default()),
+        "note" => AccountItem::Note(val.unwrap_or_default()),
+        _ => AccountItem::Unknown(key, val),
+    }
+}
+
+fn parse_commodity_directive(pair: Pair<Rule>) -> Directive {
+    let mut inner = pair.into_inner();
+    // commodity_format is the first child — the raw format string.
+    let raw = inner.next().unwrap().as_str().trim().to_string();
+
+    // Derive the canonical commodity name from the format string by stripping
+    // digits, commas, dots, and whitespace.
+    let name = derive_commodity_name(&raw);
+
+    let mut notes = Vec::new();
+    let mut items = Vec::new();
+
+    for p in inner {
+        match p.as_rule() {
+            Rule::note => notes.push(p.into_inner().as_str().trim().to_string()),
+            Rule::commodity_item => {
+                items.push(parse_commodity_item(p));
+            }
+            _ => {}
+        }
+    }
+
+    // Store the format string as a `Format` item so downstream code can use it.
+    if !raw.is_empty() {
+        items.insert(0, CommodityItem::Format(raw));
+    }
+
+    Directive::Commodity { name, notes, items }
+}
+
+/// Extract the commodity symbol from a commodity format string.
+///
+/// hledger commodity directives carry a format string like `$1,000.00` or
+/// `1,000.00 EUR`.  This function strips numeric content and whitespace to
+/// recover the bare symbol (`$`, `EUR`, etc.).
+fn derive_commodity_name(format: &str) -> String {
+    // Strip digits, commas, dots, and whitespace to isolate the symbol.
+    let sym: String = format
+        .chars()
+        .filter(|c| !c.is_ascii_digit() && *c != ',' && *c != '.' && !c.is_whitespace())
+        .collect();
+    if sym.is_empty() {
+        format.trim().to_string()
+    } else {
+        sym.trim().to_string()
+    }
+}
+
+fn parse_commodity_item(pair: Pair<Rule>) -> CommodityItem {
+    let mut inner = pair.into_inner();
+    let key = inner.next().unwrap().as_str().to_string();
+    let mut val = None;
+
+    for p in inner {
+        if p.as_rule() == Rule::commodity_val {
+            val = Some(p.as_str().trim().to_string());
+        }
+    }
+
+    match key.as_str() {
+        "alias" => CommodityItem::Alias(val.unwrap_or_default()),
+        "format" => CommodityItem::Format(val.unwrap_or_default()),
+        "nomarket" => CommodityItem::NoMarket,
+        "default" => CommodityItem::Default,
+        "note" => CommodityItem::Note(val.unwrap_or_default()),
+        _ => CommodityItem::Unknown(key, val),
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Value expression parser (Pratt)
+// ──────────────────────────────────────────────────────────────────────────────
+
+use pest::iterators::Pairs;
+use pest::pratt_parser::PrattParser;
+use std::sync::LazyLock;
+
+static PRATT: LazyLock<PrattParser<Rule>> = LazyLock::new(|| {
+    use Rule::*;
+    use pest::pratt_parser::{Assoc::*, Op};
+    PrattParser::new()
+        .op(Op::infix(add, Left) | Op::infix(sub, Left))
+        .op(Op::infix(mul, Left) | Op::infix(div, Left))
+        .op(Op::prefix(prefix_op))
+});
+
+fn parse_expr(pair: Pair<Rule>) -> ValueExpr {
+    // value_expr = ${ expr ~ (ws+ ~ commodity)? }
+    let mut inner = pair.into_inner();
+    let expr_pair = inner.next().expect("empty value_expr");
+    let mut ast = run_pratt(expr_pair.into_inner());
+
+    if let Some(comm_pair) = inner.next() {
+        ast = ValueExpr::Typed {
+            expr: Box::new(ast),
+            commodity: comm_pair.as_str().to_string(),
+        };
+    }
+    ast
+}
+
+fn run_pratt(pairs: Pairs<Rule>) -> ValueExpr {
+    PRATT
+        .map_primary(|pair| match pair.as_rule() {
+            Rule::term => run_pratt(pair.into_inner()),
+            Rule::primary => {
+                let base = pair.into_inner().next().expect("primary must have a base");
+                run_pratt(pest::iterators::Pairs::single(base))
+            }
+            Rule::amount => {
+                let mut inner = pair.into_inner();
+                let first = inner.next().unwrap();
+                match first.as_rule() {
+                    Rule::commodity => {
+                        let comm = first.as_str().to_string();
+                        let val_str = inner.next().unwrap().as_str();
+                        ValueExpr::Amount {
+                            value: clean_decimal(val_str),
+                            commodity: Some(comm),
+                        }
+                    }
+                    Rule::number => {
+                        let val = clean_decimal(first.as_str());
+                        let comm = inner.next().map(|c| c.as_str().to_string());
+                        ValueExpr::Amount {
+                            value: val,
+                            commodity: comm,
+                        }
+                    }
+                    _ => unreachable!(),
+                }
+            }
+            Rule::commodity => ValueExpr::Commodity(pair.as_str().to_string()),
+            Rule::expr => run_pratt(pair.into_inner()),
+            _ => unreachable!("unexpected primary rule: {:?}", pair.as_rule()),
+        })
+        .map_prefix(|op, expr| ValueExpr::Unary {
+            op: if op.as_str() == "-" { Op::Sub } else { Op::Add },
+            expr: Box::new(expr),
+        })
+        .map_infix(|lhs, op, rhs| {
+            let op = match op.as_rule() {
+                Rule::add => Op::Add,
+                Rule::sub => Op::Sub,
+                Rule::mul => Op::Mul,
+                Rule::div => Op::Div,
+                _ => unreachable!(),
+            };
+            ValueExpr::Binary {
+                lhs: Box::new(lhs),
+                rhs: Box::new(rhs),
+                op,
+            }
+        })
+        .parse(pairs)
+}
+
+fn clean_decimal(s: &str) -> Decimal {
+    let cleaned = s.replace(',', "");
+    cleaned.parse().unwrap_or(Decimal::ZERO)
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Convenience function
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Parse hledger source with no `include` support.
+///
+/// Any `include` directives in the input are silently resolved to empty (no
+/// entries included). Useful for unit tests and standalone parsing.
+pub fn parse_hledger(input: &str) -> Result<Journal, Box<dyn std::error::Error>> {
+    Parser {
+        opener: |_| Ok(String::new()),
+        base_path: PathBuf::new(),
+    }
+    .parse(input)
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Frontend impl
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// The hledger file-format frontend.
+///
+/// Recognises `.hledger` and `.journal` files and converts them to
+/// [`ast::Journal`] via the hledger PEG grammar.
+///
+/// ## Extension dispatch
+///
+/// | Extension | Frontend |
+/// |-----------|----------|
+/// | `.hledger` | [`HledgerFrontend`] |
+/// | `.journal` | [`HledgerFrontend`] |
+/// | `.ledger`  | [`crate::grammars::ledger::LedgerFrontend`] |
+///
+/// ## Known limitations
+///
+/// See the [module-level documentation](self) for the list of hledger features
+/// that are stubbed out or not yet supported.
+pub struct HledgerFrontend;
+
+impl crate::frontend::Frontend for HledgerFrontend {
+    fn extensions(&self) -> &'static [&'static str] {
+        &["hledger", "journal"]
+    }
+
+    fn parse(
+        &self,
+        input: &str,
+        base_path: &std::path::Path,
+        opener: &crate::frontend::Opener,
+    ) -> Result<crate::ast::Journal, Box<dyn std::error::Error>> {
+        Parser {
+            opener: |path: &str| opener(path),
+            base_path: base_path.to_path_buf(),
+        }
+        .parse(input)
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Unit tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use rust_decimal::dec;
+
+    use super::*;
+
+    // ── simple transaction ────────────────────────────────────────────────────
+
+    #[test]
+    fn simple_cleared_transaction() {
+        let input = "\
+2024-01-15 * Opening Balances
+    assets:bank:checking          $1000.00
+    equity:opening-balances
+";
+        let journal = parse_hledger(input).expect("parse");
+        assert_eq!(journal.entries.len(), 1);
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!("expected transaction");
+        };
+        assert_eq!(tx.date.year, Some(2024));
+        assert_eq!(tx.date.month, 1);
+        assert_eq!(tx.date.date, 15);
+        assert!(matches!(tx.state, TransactionState::Cleared));
+        assert_eq!(tx.description, "Opening Balances");
+        assert_eq!(tx.postings.len(), 2);
+        assert_eq!(tx.postings[0].account, "assets:bank:checking");
+        assert!(tx.postings[1].amount.is_none(), "null posting");
+    }
+
+    // ── pending status, code, inline comment, posting note ───────────────────
+
+    #[test]
+    fn pending_with_code_and_comments() {
+        let input = "\
+2024-01-16 ! (INV-42) ACME Corp  ; project:website
+    expenses:consulting           $500.00 ; vendor: ACME
+    assets:bank:checking
+";
+        let journal = parse_hledger(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!();
+        };
+        assert!(matches!(tx.state, TransactionState::Pending));
+        assert_eq!(tx.code.as_deref(), Some("INV-42"));
+        assert_eq!(tx.description, "ACME Corp");
+        // Inline transaction note is captured.
+        assert!(!tx.notes.is_empty(), "should have note from inline comment");
+        // Posting note.
+        assert_eq!(tx.postings[0].notes.len(), 1);
+        assert!(tx.postings[0].notes[0].contains("vendor"));
+    }
+
+    // ── balance assertion (=) ─────────────────────────────────────────────────
+
+    #[test]
+    fn balance_assertion_single_commodity() {
+        let input = "\
+2024-01-31 * end-of-month check
+    assets:bank:checking            $0.00 = $500.00
+    expenses:adjustments
+";
+        let journal = parse_hledger(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!();
+        };
+        let p = &tx.postings[0];
+        assert!(
+            matches!(
+                &p.amount,
+                Some(AmountDetails::Amount {
+                    balance_assertion: Some(_),
+                    ..
+                })
+            ),
+            "should have balance assertion"
+        );
+    }
+
+    // ── strict balance assertion (==) ─────────────────────────────────────────
+
+    #[test]
+    fn balance_assertion_strict() {
+        let input = "\
+2024-02-01 * checked
+    assets:bank:checking            $0.00 == $500.00
+    expenses:adjustments
+";
+        let journal = parse_hledger(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!();
+        };
+        let p = &tx.postings[0];
+        assert!(
+            matches!(
+                &p.amount,
+                Some(AmountDetails::Amount {
+                    balance_assertion: Some(_),
+                    ..
+                })
+            ),
+            "should have strict balance assertion"
+        );
+    }
+
+    // ── balance assignment (= target, no LHS amount) ──────────────────────────
+
+    #[test]
+    fn balance_assignment() {
+        let input = "\
+2024-02-05 * Reset to known balance
+    assets:bank:checking          = $750.00
+    income:adjustments
+";
+        let journal = parse_hledger(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!();
+        };
+        let p = &tx.postings[0];
+        assert!(
+            matches!(&p.amount, Some(AmountDetails::BalanceAssignment(_))),
+            "should be BalanceAssignment, got {:?}",
+            p.amount
+        );
+    }
+
+    // ── lot pricing @ ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn lot_pricing_unit() {
+        let input = "\
+2024-02-10 * Buy euros
+    assets:eur                  100.00 EUR @ $1.10
+    assets:bank:checking         $-110.00
+";
+        let journal = parse_hledger(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!();
+        };
+        let p = &tx.postings[0];
+        assert!(
+            matches!(
+                &p.amount,
+                Some(AmountDetails::Amount {
+                    lot_pricing: Some(LotPricing::Unit(_)),
+                    ..
+                })
+            ),
+            "should have unit lot pricing"
+        );
+    }
+
+    // ── lot pricing @@ ────────────────────────────────────────────────────────
+
+    #[test]
+    fn lot_pricing_total() {
+        let input = "\
+2024-02-11 * Buy stock
+    assets:brokerage             10 AAPL @@ $1825.00
+    assets:bank:checking        $-1825.00
+";
+        let journal = parse_hledger(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!();
+        };
+        let p = &tx.postings[0];
+        assert!(
+            matches!(
+                &p.amount,
+                Some(AmountDetails::Amount {
+                    lot_pricing: Some(LotPricing::Total(_)),
+                    ..
+                })
+            ),
+            "should have total lot pricing"
+        );
+    }
+
+    // ── historical price ──────────────────────────────────────────────────────
+
+    #[test]
+    fn historical_price() {
+        let input = "P 2024-01-02 EUR $1.10\n";
+        let journal = parse_hledger(input).expect("parse");
+        assert_eq!(journal.entries.len(), 1);
+        let Entry::HistoricalPrice(hp) = &journal.entries[0] else {
+            panic!("expected HistoricalPrice");
+        };
+        assert_eq!(hp.date.year, Some(2024));
+        assert_eq!(hp.commodity, "EUR");
+        assert!(matches!(
+            hp.price,
+            ValueExpr::Amount {
+                commodity: Some(ref c),
+                ..
+            } if c == "$"
+        ));
+    }
+
+    // ── account directive ─────────────────────────────────────────────────────
+
+    #[test]
+    fn account_directive_with_note() {
+        let input = "account assets:bank:checking    ; type:A\n";
+        let journal = parse_hledger(input).expect("parse");
+        assert_eq!(journal.entries.len(), 1);
+        let Entry::Directive(Directive::Account { name, notes, .. }) = &journal.entries[0] else {
+            panic!("expected Account directive");
+        };
+        assert_eq!(name, "assets:bank:checking");
+        assert!(!notes.is_empty(), "should capture the note");
+    }
+
+    // ── commodity directive ───────────────────────────────────────────────────
+
+    #[test]
+    fn commodity_directive_prefix_symbol() {
+        let input = "commodity $1,000.00\n";
+        let journal = parse_hledger(input).expect("parse");
+        let Entry::Directive(Directive::Commodity { name, items, .. }) = &journal.entries[0] else {
+            panic!("expected Commodity directive");
+        };
+        assert_eq!(name, "$");
+        // Format item should be present.
+        assert!(
+            items.iter().any(|i| matches!(i, CommodityItem::Format(_))),
+            "should have Format item"
+        );
+    }
+
+    #[test]
+    fn commodity_directive_suffix_symbol() {
+        let input = "commodity 1,000.00 EUR\n";
+        let journal = parse_hledger(input).expect("parse");
+        let Entry::Directive(Directive::Commodity { name, .. }) = &journal.entries[0] else {
+            panic!("expected Commodity directive");
+        };
+        assert_eq!(name, "EUR");
+    }
+
+    // ── date separators ───────────────────────────────────────────────────────
+
+    #[test]
+    fn date_slash_separator() {
+        let input = "2024/03/15 Test\n    expenses:food  $10\n    assets:cash\n";
+        let journal = parse_hledger(input).expect("parse with / separator");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!();
+        };
+        assert_eq!(tx.date.year, Some(2024));
+        assert_eq!(tx.date.month, 3);
+        assert_eq!(tx.date.date, 15);
+    }
+
+    #[test]
+    fn date_dot_separator() {
+        let input = "2024.06.01 Test\n    expenses:food  $10\n    assets:cash\n";
+        let journal = parse_hledger(input).expect("parse with . separator");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!();
+        };
+        assert_eq!(tx.date.month, 6);
+        assert_eq!(tx.date.date, 1);
+    }
+
+    // ── hash comment ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn hash_comment_line() {
+        let input = "# This is a hash comment\n";
+        let journal = parse_hledger(input).expect("parse");
+        assert_eq!(journal.entries.len(), 1);
+        assert!(matches!(journal.entries[0], Entry::Comment(_)));
+    }
+
+    // ── negative amount ───────────────────────────────────────────────────────
+
+    #[test]
+    fn negative_prefix_amount() {
+        let input = "2024-01-01 Test\n    assets:bank  $-110.00\n    income:salary\n";
+        let journal = parse_hledger(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!();
+        };
+        let p = &tx.postings[0];
+        // $-110.00 → Unary(Sub, Amount($, 110.00))
+        assert!(p.amount.is_some());
+    }
+
+    // ── amount with comma thousands separator ─────────────────────────────────
+
+    #[test]
+    fn amount_comma_thousands() {
+        let input = "2024-01-01 Test\n    expenses:food  $1,234.56\n    assets:cash\n";
+        let journal = parse_hledger(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!();
+        };
+        let AmountDetails::Amount { value, .. } = tx.postings[0].amount.as_ref().unwrap() else {
+            panic!();
+        };
+        assert!(
+            matches!(value, ValueExpr::Amount { value, .. } if *value == dec!(1234.56)),
+            "expected 1234.56, got {value:?}"
+        );
+    }
+
+    // ── arithmetic in posting amount ──────────────────────────────────────────
+
+    #[test]
+    fn arithmetic_amount() {
+        let input = "2024-01-01 Test\n    expenses:food  (100 + 50) USD\n    assets:cash\n";
+        let journal = parse_hledger(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!();
+        };
+        let AmountDetails::Amount { value, .. } = tx.postings[0].amount.as_ref().unwrap() else {
+            panic!();
+        };
+        assert!(
+            matches!(value, ValueExpr::Typed { .. }),
+            "expected Typed wrapping an arithmetic expr, got {value:?}"
+        );
+    }
+
+    // ── periodic transaction is silently ignored ──────────────────────────────
+
+    #[test]
+    fn periodic_transaction_ignored() {
+        let input = "\
+~ monthly  Rent
+    expenses:rent                $2000
+    assets:bank:checking
+
+2024-01-01 Real
+    expenses:food  $10
+    assets:cash
+";
+        let journal = parse_hledger(input).expect("parse");
+        // The periodic transaction produces no entry; only the real transaction does.
+        let txns: Vec<_> = journal
+            .entries
+            .iter()
+            .filter(|e| matches!(e, Entry::Transaction(_)))
+            .collect();
+        assert_eq!(txns.len(), 1);
+    }
+
+    // ── full sample-journal smoke test ────────────────────────────────────────
+
+    #[test]
+    fn sample_journal_parses_without_error() {
+        // The sample.hledger from doppio-research, minus the include directive
+        // (which would attempt file I/O).
+        let input = "\
+; A small but representative hledger journal
+
+account assets:bank:checking    ; type:A
+account expenses:groceries
+account income:salary
+
+commodity $1,000.00
+commodity 1,000.00 EUR
+
+P 2024-01-02 EUR $1.10
+P 2024-02-15 AAPL $182.50
+
+2024-01-15 * Opening Balances
+    assets:bank:checking          $1000.00
+    equity:opening-balances
+
+2024-01-16 ! (INV-42) ACME Corp  ; project:website
+    expenses:consulting           $500.00 ; vendor: ACME
+    assets:bank:checking
+
+2024-01-31 * end-of-month check
+    assets:bank:checking            $0.00 = $500.00
+    expenses:adjustments
+
+2024-02-01 * checked
+    assets:bank:checking            $0.00 == $500.00
+    expenses:adjustments
+
+2024-02-05 * Reset to known balance
+    assets:bank:checking          = $750.00
+    income:adjustments
+
+2024-02-10 * Buy euros
+    assets:eur                  100.00 EUR @ $1.10
+    assets:bank:checking         $-110.00
+
+2024-02-11 * Buy stock
+    assets:brokerage             10 AAPL @@ $1825.00
+    assets:bank:checking        $-1825.00
+";
+        parse_hledger(input).expect("sample journal should parse without error");
+    }
+}

--- a/crates/doppio/src/grammars/mod.rs
+++ b/crates/doppio/src/grammars/mod.rs
@@ -4,9 +4,8 @@
 //! format and houses the corresponding pest grammar.
 //!
 //! Currently available:
-//! - [`ledger`] — the ledger-cli plain-text accounting format.
-//!
-//! Planned (see issue #103):
-//! - `hledger` — the hledger dialect.
+//! - [`ledger`] — the ledger-cli plain-text accounting format (`.ledger`).
+//! - [`hledger`] — the hledger dialect (`.hledger`, `.journal`).
 
+pub mod hledger;
 pub mod ledger;

--- a/crates/doppio/src/lib.rs
+++ b/crates/doppio/src/lib.rs
@@ -83,15 +83,20 @@ pub mod parser {
 
 pub use elaboration::Journal;
 pub use frontend::Frontend;
+pub use grammars::hledger::HledgerFrontend;
 pub use grammars::ledger::LedgerFrontend;
 
 /// Select a frontend by file extension.
 ///
-/// Returns the appropriate [`Frontend`] implementation for `ext`. Currently
-/// only the ledger-cli frontend is registered; it is also used as the default
-/// for unrecognised extensions, preserving today's behaviour.
+/// Returns the appropriate [`Frontend`] implementation for `ext`.
+/// Dispatch table:
 ///
-/// When the hledger frontend lands (issue #103), it will be added here.
+/// | Extension | Frontend |
+/// |-----------|----------|
+/// | `"ledger"` | [`LedgerFrontend`] |
+/// | `"hledger"` | [`HledgerFrontend`] |
+/// | `"journal"` | [`HledgerFrontend`] |
+/// | anything else / `None` | [`LedgerFrontend`] (default) |
 ///
 /// # Example
 ///
@@ -99,15 +104,29 @@ pub use grammars::ledger::LedgerFrontend;
 /// let fe = doppio::frontend_for_extension(Some("ledger"));
 /// assert!(fe.extensions().contains(&"ledger"));
 ///
+/// let fe2 = doppio::frontend_for_extension(Some("hledger"));
+/// assert!(fe2.extensions().contains(&"hledger"));
+///
+/// let fe3 = doppio::frontend_for_extension(Some("journal"));
+/// assert!(fe3.extensions().contains(&"journal"));
+///
 /// // Unknown extensions fall back to the ledger frontend.
-/// let fe2 = doppio::frontend_for_extension(None);
-/// assert!(fe2.extensions().contains(&"ledger"));
+/// let fe4 = doppio::frontend_for_extension(None);
+/// assert!(fe4.extensions().contains(&"ledger"));
 /// ```
 pub fn frontend_for_extension(ext: Option<&str>) -> Box<dyn Frontend> {
-    let frontends: &[&dyn Frontend] = &[&LedgerFrontend];
+    let frontends: &[&dyn Frontend] = &[&HledgerFrontend, &LedgerFrontend];
     for fe in frontends {
         if ext.is_some_and(|e| fe.extensions().contains(&e)) {
-            return Box::new(LedgerFrontend);
+            // Construct an owned Box of the concrete type matched above.
+            // We iterate over trait-object refs to find the right frontend,
+            // then return a fresh Box of the concrete type.  This avoids
+            // cloning or storing the Frontend behind Arc.
+            if fe.extensions().contains(&"hledger") || fe.extensions().contains(&"journal") {
+                return Box::new(HledgerFrontend);
+            } else {
+                return Box::new(LedgerFrontend);
+            }
         }
     }
     // Default: ledger frontend (preserves existing behaviour for unknown extensions).

--- a/docs/SUPPORTED_FEATURES.md
+++ b/docs/SUPPORTED_FEATURES.md
@@ -1,10 +1,10 @@
 # doppio: Supported Ledger features
 
-**Last updated**: 2026-04-27 (doppio v0.2.0)
+**Last updated**: 2026-04-26 (doppio v0.3.0)
 
 This document is a feature-by-feature comparison of doppio's syntax surface
-against [ledger-cli](https://ledger-cli.org/). The authoritative behaviour is
-the test suite — this matrix is a navigation aid.
+against [ledger-cli](https://ledger-cli.org/) and [hledger](https://hledger.org/).
+The authoritative behaviour is the test suite — this matrix is a navigation aid.
 
 Status legend:
 
@@ -128,19 +128,65 @@ Status legend:
 | `.dop` binary format v2 (`elaboration::Journal` with `commodities`) | ✅ | v0.2.0 breaking change. v1 files are rejected with a clear "recompile" message |
 | Append / framed `.dop` (range-scan, partial decode) | 🚫 | Phase 4 / issues #17, #39–41 |
 
+## hledger frontend
+
+Added in v0.3.0 (issue #103). Recognised by the `.hledger` and `.journal`
+file extensions; selected automatically by `dop` and by
+`doppio::frontend_for_extension`.
+
+### Parity with the ledger-cli frontend
+
+| Feature | Status | Notes |
+|---|---|---|
+| Transactions, cleared/pending state, code, description | ✅ | |
+| Postings with two-space rule | ✅ | Same convention as ledger-cli |
+| Number-first amounts `100 USD` | ✅ | |
+| Symbol-first amounts `$100` | ✅ | |
+| Negative amounts `-$110`, `$-110` | ✅ | |
+| Null posting (auto-inferred amount) | ✅ | |
+| Lot pricing `@ unit` / `@@ total` | ✅ | |
+| Balance assertion `= amount` (single-commodity) | ✅ | |
+| Strict balance assertion `== amount` (all-commodity) | ✅ | |
+| Balance assignment `= target` | ✅ | |
+| Transaction notes / posting notes (`;` lines) | ✅ | |
+| `P` historical price directive | ✅ | Time component not parsed (hledger omits it) |
+| `account` directive with inline note | ✅ | |
+| `account` directive with indented sub-directives | ✅ | `note`, `alias`, `type`, unknown keys |
+| `commodity` directive (format string) | ✅ | Both `$1,000.00` and `1,000.00 EUR` forms |
+| `commodity` directive with indented sub-directives | ✅ | `alias`, `format`, `nomarket`, `default`, `note` |
+| `include` directive (literal and glob) | ✅ | Same glob expansion as ledger-cli frontend |
+| Arithmetic in posting amounts | ✅ | Pratt-parsed; same precedence as ledger-cli |
+| Comment lines `;` | ✅ | |
+| Comment lines `#` | ✅ | hledger extension; not accepted by ledger-cli frontend |
+| Date format `YYYY-MM-DD` | ✅ | |
+| Date format `YYYY/MM/DD` | ✅ | hledger extension |
+| Date format `YYYY.MM.DD` | ✅ | hledger extension |
+| Periodic transactions `~` | ✅ | Parsed but not elaborated (same as ledger-cli `~` budget) |
+
+### Known limitations
+
+| Feature | Status | Notes |
+|---|---|---|
+| Automated posting `*N` arithmetic bodies | 🚫 | TODO(#103). The auto-rule shape is parsed but postings with `*N` multipliers cause a parse error. |
+| `comment` / `end comment` block comments | 🚫 | Not yet supported |
+| `Y year` directive (date inference) | 🚫 | Full four-digit year required in all dates |
+| Per-transaction `= DATE` effective date | 🚫 | hledger uses a different secondary-date syntax; not supported |
+| Multiple commodities per posting | 🚫 | v1 limitation shared with ledger-cli frontend |
+| `assert` / `check` in account sub-directives | 🚫 | Parsed but not enforced (hledger's semantics differ from ledger-cli's) |
+
 ## Out of scope (explicitly)
 
 These ledger-cli features are not modelled by doppio and aren't planned:
 
 - `~` budget directives (parsed but ignored)
-- `= payee` automated transactions
+- `= payee` automated transactions (automated posting rule arithmetic bodies)
 - Third-or-later effective dates in transaction headers
 - ledger-cli's Lisp-style scripting / Python integration
 - Real-time market-price-driven FX conversion in balance reports
 
 ## Reporting gaps
 
-If you find a ledger-cli construct that doppio rejects (or accepts but
-elaborates wrong) and it isn't documented here, please open an issue at
+If you find a ledger-cli or hledger construct that doppio rejects (or accepts
+but elaborates wrong) and it isn't documented here, please open an issue at
 <https://github.com/alevy/doppio/issues> — small minimal-failing-case
-ledger snippets are especially welcome.
+snippets are especially welcome.


### PR DESCRIPTION
## Summary

Closes #103.

- Adds `crates/doppio/src/grammars/hledger/` with a dedicated PEG grammar (`hledger.pest`) and frontend implementation (`mod.rs`).
- Registers `HledgerFrontend` in `frontend_for_extension()` to dispatch `.hledger` and `.journal` extensions.
- Re-exports `HledgerFrontend` from the crate root alongside `LedgerFrontend`.
- Adds 22 CLI integration tests in `crates/doppio-cli/tests/hledger_parse.rs` plus a `tests/fixtures/sample.hledger` covering all 11 prototype entry forms.
- Updates README, CHANGELOG, and `docs/SUPPORTED_FEATURES.md`.

## What's implemented

| Entry form | Status |
|---|---|
| Simple cleared transaction | ✅ |
| Pending with code + posting comment | ✅ |
| Balance assertion `= amount` | ✅ |
| Strict balance assertion `== amount` | ✅ |
| Balance assignment `= target` (no LHS amount) | ✅ |
| Lot pricing `@` unit price | ✅ |
| Lot pricing `@@` total price | ✅ |
| Periodic transaction `~` | ✅ (captured, not elaborated) |
| Date separator `/` | ✅ |
| Date separator `.` | ✅ |
| Comment lines `#` | ✅ |
| Automated posting rule arithmetic bodies `*N` | stub — parse error with TODO |

## AST mapping

hledger fits `ast::Journal` without any AST changes:
- Dates: `YYYY-MM-DD`, `YYYY/MM/DD`, `YYYY.MM.DD` all parsed to `Date { year, month, date }`.
- Secondary dates: hledger's secondary date syntax differs from ledger-cli's; the field is always `None` for now.
- `commodity` directive format strings (`$1,000.00`, `1,000.00 EUR`) are stored as `CommodityItem::Format` and the commodity name is derived by stripping numeric characters.
- `auto_rule` and `periodic_transaction` produce no `Entry` — silently dropped, matching the ledger frontend's treatment of `budget` entries.

## Known limitations (documented in SUPPORTED_FEATURES.md)

- Automated posting arithmetic bodies (`*N`): grammar captures the outer shape; posting amounts using `*N` will parse-error. TODO(#103 followup).
- `comment` / `end comment` block comments: not supported.
- `Y year` date inference: not supported — four-digit year required in all dates.
- `assert`/`check` in hledger account sub-directives: parsed but not enforced (hledger semantics differ from ledger-cli's).

## Quality gates

All passing:
- `cargo fmt --all --check` ✅
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo test --workspace` ✅ (157 library tests + 22 new CLI integration tests + all existing tests)
- `cargo build -p doppio --target wasm32-unknown-unknown --lib` ✅

## Test plan

- [ ] CI passes all checks
- [ ] `dop balance some.hledger` produces a balance report
- [ ] `dop balance some.journal` routes to hledger frontend (not ledger-cli)
- [ ] All 11 entry forms from sample.hledger parse without error
- [ ] Existing ledger-cli tests are unaffected (no regression)