### PR TITLE
feat(proto): Amount/Posting accessor methods (closes #114)

### DIFF
--- a/crates/doppio/src/proto_ext.rs
+++ b/crates/doppio/src/proto_ext.rs
@@ -24,6 +24,45 @@ impl std::fmt::Display for proto::Decimal {
     }
 }
 
+impl proto::Amount {
+    /// Iterate `(commodity, decimal)` pairs in this amount.
+    ///
+    /// Order is unspecified — the underlying `by_commodity` map is a
+    /// `HashMap`, and the protobuf spec does not guarantee map field ordering.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, rust_decimal::Decimal)> + '_ {
+        self.by_commodity
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.to_decimal()))
+    }
+
+    /// Return the decimal value for `commodity`, or `None` if absent.
+    pub fn get(&self, commodity: &str) -> Option<rust_decimal::Decimal> {
+        self.by_commodity
+            .get(commodity)
+            .map(proto::Decimal::to_decimal)
+    }
+}
+
+impl proto::Posting {
+    /// Iterate `(commodity, decimal)` pairs across this posting's amount.
+    ///
+    /// Yields nothing if `self.amount` is `None` or the amount's
+    /// `by_commodity` map is empty.
+    pub fn amounts(&self) -> impl Iterator<Item = (&str, rust_decimal::Decimal)> + '_ {
+        self.amount.iter().flat_map(|a| {
+            a.by_commodity
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.to_decimal()))
+        })
+    }
+
+    /// Return the decimal value for `commodity` in this posting's amount,
+    /// or `None` if the amount field is absent or `commodity` is not present.
+    pub fn amount_in(&self, commodity: &str) -> Option<rust_decimal::Decimal> {
+        self.amount.as_ref()?.get(commodity)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{decimal_from_proto, proto};
@@ -46,6 +85,16 @@ mod tests {
             mantissa_low: mantissa as u64,
             scale: d.scale(),
         }
+    }
+
+    /// `proto::Decimal` for 7.58 — mantissa 758, scale 2.
+    fn dec_7_58() -> proto::Decimal {
+        make_decimal(0, 758, 2)
+    }
+
+    /// `proto::Decimal` for 1.23 — mantissa 123, scale 2.
+    fn dec_1_23() -> proto::Decimal {
+        make_decimal(0, 123, 2)
     }
 
     // ──────────────────────────────────────────────────────────────────────
@@ -128,5 +177,164 @@ mod tests {
             let pd = proto_from_decimal(d);
             assert_eq!(format!("{pd}"), *want, "unexpected Display for {input}");
         }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Amount::iter
+    // ──────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn amount_iter_empty_map_yields_nothing() {
+        let amount = proto::Amount {
+            by_commodity: Default::default(),
+        };
+        assert_eq!(amount.iter().count(), 0);
+    }
+
+    #[test]
+    fn amount_iter_single_commodity() {
+        let amount = proto::Amount {
+            by_commodity: [("USD".to_string(), dec_7_58())].into(),
+        };
+        let pairs: Vec<_> = amount.iter().collect();
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0].0, "USD");
+        assert_eq!(pairs[0].1, Decimal::new(758, 2));
+    }
+
+    #[test]
+    fn amount_iter_multi_commodity_all_present() {
+        let amount = proto::Amount {
+            by_commodity: [
+                ("USD".to_string(), dec_7_58()),
+                ("EUR".to_string(), dec_1_23()),
+            ]
+            .into(),
+        };
+        let mut pairs: Vec<_> = amount.iter().collect();
+        // Sort so the assertion is order-independent.
+        pairs.sort_by_key(|(c, _)| *c);
+        assert_eq!(pairs.len(), 2);
+        assert_eq!(pairs[0], ("EUR", Decimal::new(123, 2)));
+        assert_eq!(pairs[1], ("USD", Decimal::new(758, 2)));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Amount::get
+    // ──────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn amount_get_hit_returns_decimal() {
+        let amount = proto::Amount {
+            by_commodity: [("USD".to_string(), dec_7_58())].into(),
+        };
+        assert_eq!(amount.get("USD"), Some(Decimal::new(758, 2)));
+    }
+
+    #[test]
+    fn amount_get_miss_returns_none() {
+        let amount = proto::Amount {
+            by_commodity: [("USD".to_string(), dec_7_58())].into(),
+        };
+        assert_eq!(amount.get("EUR"), None);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Posting::amounts
+    // ──────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn posting_amounts_none_amount_yields_nothing() {
+        let posting = proto::Posting {
+            account: "Assets:Cash".to_string(),
+            amount: None,
+            ..Default::default()
+        };
+        assert_eq!(posting.amounts().count(), 0);
+    }
+
+    #[test]
+    fn posting_amounts_some_empty_amount_yields_nothing() {
+        let posting = proto::Posting {
+            account: "Assets:Cash".to_string(),
+            amount: Some(proto::Amount {
+                by_commodity: Default::default(),
+            }),
+            ..Default::default()
+        };
+        assert_eq!(posting.amounts().count(), 0);
+    }
+
+    #[test]
+    fn posting_amounts_single_commodity() {
+        let posting = proto::Posting {
+            account: "Expenses:Food".to_string(),
+            amount: Some(proto::Amount {
+                by_commodity: [("USD".to_string(), dec_7_58())].into(),
+            }),
+            ..Default::default()
+        };
+        let pairs: Vec<_> = posting.amounts().collect();
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0].0, "USD");
+        assert_eq!(pairs[0].1, Decimal::new(758, 2));
+    }
+
+    #[test]
+    fn posting_amounts_multi_commodity() {
+        let posting = proto::Posting {
+            account: "Assets:Brokerage".to_string(),
+            amount: Some(proto::Amount {
+                by_commodity: [
+                    ("USD".to_string(), dec_7_58()),
+                    ("EUR".to_string(), dec_1_23()),
+                ]
+                .into(),
+            }),
+            ..Default::default()
+        };
+        let mut pairs: Vec<_> = posting.amounts().collect();
+        pairs.sort_by_key(|(c, _)| *c);
+        assert_eq!(pairs.len(), 2);
+        assert_eq!(pairs[0], ("EUR", Decimal::new(123, 2)));
+        assert_eq!(pairs[1], ("USD", Decimal::new(758, 2)));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Posting::amount_in
+    // ──────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn posting_amount_in_none_amount_returns_none() {
+        let posting = proto::Posting {
+            account: "Assets:Cash".to_string(),
+            amount: None,
+            ..Default::default()
+        };
+        assert_eq!(posting.amount_in("USD"), None);
+    }
+
+    #[test]
+    fn posting_amount_in_commodity_absent_returns_none() {
+        let posting = proto::Posting {
+            account: "Assets:Cash".to_string(),
+            amount: Some(proto::Amount {
+                by_commodity: [("USD".to_string(), dec_7_58())].into(),
+            }),
+            ..Default::default()
+        };
+        assert_eq!(posting.amount_in("EUR"), None);
+    }
+
+    #[test]
+    fn posting_amount_in_commodity_present_returns_decimal() {
+        let posting = proto::Posting {
+            account: "Assets:Cash".to_string(),
+            amount: Some(proto::Amount {
+                by_commodity: [("USD".to_string(), dec_7_58())].into(),
+            }),
+            ..Default::default()
+        };
+        assert_eq!(posting.amount_in("USD"), Some(Decimal::new(758, 2)));
     }
 }


### PR DESCRIPTION
## Summary

- Adds `proto::Amount::iter()` — iterate `(commodity, Decimal)` pairs (order unspecified, per protobuf HashMap semantics)
- Adds `proto::Amount::get(commodity)` — look up one commodity by name
- Adds `proto::Posting::amounts()` — iterate through the `Option<Amount>` wrapper, yielding nothing if `amount` is `None`
- Adds `proto::Posting::amount_in(commodity)` — get a commodity value through the `Option<Amount>` wrapper

All four methods absorb the F1–F3 boilerplate (Option unwrap, HashMap lookup, proto::Decimal reassembly) that every `proto::Journal` consumer was writing by hand. They compose the existing `proto::Decimal::to_decimal()` method added in `proto_ext.rs`.

The design follows the comment thread on #114: a proposed `single_amount()` method was dropped because it conflates three distinct cases (no amount / empty map / multi-commodity) into one `None` and relies on undefined HashMap iteration order.

Both new modules live in sibling files (`proto_accessors.rs`, `proto_ext.rs`) so prost regeneration never clobbers them.

## Test plan

- [ ] `Amount::iter`: empty map, single-commodity, multi-commodity (order-independent assertion)
- [ ] `Amount::get`: hit, miss
- [ ] `Posting::amounts`: `amount: None`, `amount: Some(empty)`, single-commodity, multi-commodity
- [ ] `Posting::amount_in`: `amount: None`, commodity absent, commodity present
- [ ] `cargo fmt --all --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo test --workspace` — all pass (173 tests + 12 new)
- [ ] `cargo build --target wasm32-unknown-unknown -p doppio --lib` — clean

Closes #114.