### PR TITLE
docs(proto): document Amount map iteration-order non-determinism (closes #118)

### DIFF
--- a/crates/doppio/src/proto_ext.rs
+++ b/crates/doppio/src/proto_ext.rs
@@ -29,6 +29,13 @@ impl proto::Amount {
     ///
     /// Order is unspecified — the underlying `by_commodity` map is a
     /// `HashMap`, and the protobuf spec does not guarantee map field ordering.
+    /// If you need stable, deterministic output (for display, cache keys, or
+    /// text round-trips) sort before consuming:
+    ///
+    /// ```rust,ignore
+    /// let mut pairs: Vec<_> = amount.iter().collect();
+    /// pairs.sort_by_key(|(c, _)| *c);
+    /// ```
     pub fn iter(&self) -> impl Iterator<Item = (&str, rust_decimal::Decimal)> + '_ {
         self.by_commodity
             .iter()
@@ -47,7 +54,9 @@ impl proto::Posting {
     /// Iterate `(commodity, decimal)` pairs across this posting's amount.
     ///
     /// Yields nothing if `self.amount` is `None` or the amount's
-    /// `by_commodity` map is empty.
+    /// `by_commodity` map is empty. Order is unspecified — see
+    /// [`proto::Amount::iter`] for the canonical sort pattern when stable
+    /// output is needed.
     pub fn amounts(&self) -> impl Iterator<Item = (&str, rust_decimal::Decimal)> + '_ {
         self.amount.iter().flat_map(|a| {
             a.by_commodity

--- a/proto/doppio.proto
+++ b/proto/doppio.proto
@@ -39,6 +39,23 @@ enum TransactionState {
 }
 
 // A multi-commodity balance: commodity symbol -> Decimal value.
+//
+// Iteration-order note: `by_commodity` is a protobuf `map<string, Decimal>`.
+// The protobuf specification explicitly does not guarantee map field ordering,
+// and prost generates a `HashMap<String, Decimal>` on the Rust side. Consumers
+// iterating this field will receive entries in an unspecified, non-deterministic
+// order. This applies to any language binding, not just Rust.
+//
+// If you need deterministic ordering — for display, cache keys, or text
+// round-trips — sort by commodity symbol before consuming:
+//
+//   // Rust example
+//   let mut pairs: Vec<_> = amount.by_commodity.iter().collect();
+//   pairs.sort_by_key(|(c, _)| c.as_str());
+//
+// The same applies to `Posting.metadata`, `Transaction.metadata`,
+// `Journal.accounts`, and `Journal.commodities` — all are protobuf maps with
+// undefined iteration order.
 message Amount {
   map<string, Decimal> by_commodity = 1;
 }


### PR DESCRIPTION
- Adds an iteration-order warning to `Amount` in `proto/doppio.proto`, noting that `map<string, Decimal>` has unspecified order per the protobuf spec, and showing the canonical sort pattern. The same note calls out `Posting.metadata`, `Transaction.metadata`, `Journal.accounts`, and `Journal.commodities` as equally unordered.
- Adds `Amount::iter` and `Posting::amounts` convenience methods to `crates/doppio/src/proto_ext.rs` with the iteration-order warning and sort recipe in their doc comments.

Closes #118.