### PR TITLE
Rename proto -> elaboration; demote old elaboration types to crate-private (#121)

### DIFF
--- a/crates/doppio-cli/examples/list_accounts.rs
+++ b/crates/doppio-cli/examples/list_accounts.rs
@@ -41,15 +41,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Accumulate per-account, per-commodity balances by walking every posting
     // in every transaction.  Running state is no longer stored on individual
     // transactions, so we compute it here from scratch.
-    let mut balances: BTreeMap<&String, BTreeMap<&String, Decimal>> = BTreeMap::new();
+    let mut balances: BTreeMap<&String, BTreeMap<String, Decimal>> = BTreeMap::new();
     for txn in journal.transactions.iter() {
         for posting in txn.postings.iter() {
-            for (commodity, amount) in posting.amount.0.iter() {
+            for (commodity, amount) in posting.amounts() {
                 *(balances
                     .entry(&posting.account)
                     .or_default()
-                    .entry(commodity)
-                    .or_default()) += *amount;
+                    .entry(commodity.to_string())
+                    .or_default()) += amount;
             }
         }
     }

--- a/crates/doppio-cli/src/bin/timings.rs
+++ b/crates/doppio-cli/src/bin/timings.rs
@@ -43,7 +43,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --- elaboration ---
     // Expression evaluation, transaction balancing, account registration.
     let t3 = Instant::now();
-    let journal: doppio::elaboration::Journal = hir.try_into()?;
+    let journal: doppio::elaboration_pipeline::Journal = hir.try_into()?;
     eprintln!("elaboration: {:>8.3}s", t3.elapsed().as_secs_f64());
 
     // --- serialize ---

--- a/crates/doppio-cli/src/bin/timings.rs
+++ b/crates/doppio-cli/src/bin/timings.rs
@@ -43,7 +43,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --- elaboration ---
     // Expression evaluation, transaction balancing, account registration.
     let t3 = Instant::now();
-    let journal: doppio::elaboration_pipeline::Journal = hir.try_into()?;
+    let journal: doppio::elaboration::Journal = doppio::elaborate(hir)?;
     eprintln!("elaboration: {:>8.3}s", t3.elapsed().as_secs_f64());
 
     // --- serialize ---

--- a/crates/doppio-cli/src/main.rs
+++ b/crates/doppio-cli/src/main.rs
@@ -315,7 +315,7 @@ impl JournalFilter {
 /// Returns `None` if the commodity has no declared format.
 fn commodity_format<'a>(
     commodity: &str,
-    commodities: &'a std::collections::HashMap<String, doppio::elaboration::CommodityProperties>,
+    commodities: &'a std::collections::BTreeMap<String, doppio::elaboration::CommodityProperties>,
 ) -> Option<&'a str> {
     commodities.get(commodity).and_then(|p| p.format.as_deref())
 }

--- a/crates/doppio-cli/src/main.rs
+++ b/crates/doppio-cli/src/main.rs
@@ -152,7 +152,7 @@ impl OutputFormat {
     }
 }
 
-/// Load a [`doppio::proto::Journal`] from either a compiled `.dop` file or a
+/// Load a [`doppio::elaboration::Journal`] from either a compiled `.dop` file or a
 /// raw source file, without performing the `proto::Journal → elaboration::Journal`
 /// reverse conversion.
 ///
@@ -160,14 +160,14 @@ impl OutputFormat {
 /// - `.dop` — validate header, decompress (if needed), and decode protobuf directly.
 /// - anything else — select a [`doppio::Frontend`] via
 ///   [`doppio::frontend_for_extension`], parse and elaborate, then convert the
-///   resulting [`doppio::Journal`] to [`doppio::proto::Journal`] (the cheaper
+///   resulting [`doppio::Journal`] to [`doppio::elaboration::Journal`] (the cheaper
 ///   forward direction).
 fn load_proto_journal(
     path: &PathBuf,
-) -> Result<doppio::proto::Journal, Box<dyn std::error::Error>> {
+) -> Result<doppio::elaboration::Journal, Box<dyn std::error::Error>> {
     if let Some("dop") = path.extension().and_then(|e| e.to_str()) {
         let mut f = File::open(path)?;
-        doppio::read_dop_proto(&mut f, path)
+        doppio::read_dop(&mut f, path)
     } else {
         let ext = path.extension().and_then(|e| e.to_str());
         let frontend = doppio::frontend_for_extension(ext);
@@ -176,8 +176,7 @@ fn load_proto_journal(
         File::open(path)?.read_to_string(&mut file)?;
         let ast_journal = frontend.parse(&file, base_path, &doppio::file_opener)?;
         let hir: doppio::resolution::HIR = ast_journal.try_into()?;
-        let journal: doppio::elaboration_pipeline::Journal = hir.try_into()?;
-        Ok(doppio::proto::Journal::from(&journal))
+        Ok(doppio::elaborate(hir)?)
     }
 }
 
@@ -226,7 +225,7 @@ fn build_pattern_regex(pattern: Option<String>) -> Result<Regex, Box<dyn std::er
 
 /// `TransactionState` integer values from the proto enum, mirrored here so we
 /// can match without importing the whole proto namespace everywhere.
-const STATE_CLEARED: i32 = doppio::proto::TransactionState::Cleared as i32;
+const STATE_CLEARED: i32 = doppio::elaboration::TransactionState::Cleared as i32;
 
 struct JournalFilter {
     pattern: Regex,
@@ -271,7 +270,7 @@ impl JournalFilter {
     }
 
     /// Returns `true` if `txn` passes all active filters.
-    fn matches_transaction(&self, txn: &doppio::proto::Transaction) -> bool {
+    fn matches_transaction(&self, txn: &doppio::elaboration::Transaction) -> bool {
         if self.cleared && txn.state != STATE_CLEARED {
             return false;
         }
@@ -316,7 +315,7 @@ impl JournalFilter {
 /// Returns `None` if the commodity has no declared format.
 fn commodity_format<'a>(
     commodity: &str,
-    commodities: &'a std::collections::HashMap<String, doppio::proto::CommodityProperties>,
+    commodities: &'a std::collections::HashMap<String, doppio::elaboration::CommodityProperties>,
 ) -> Option<&'a str> {
     commodities.get(commodity).and_then(|p| p.format.as_deref())
 }
@@ -337,7 +336,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             File::open(&source)?.read_to_string(&mut file)?;
             let ast_journal = frontend.parse(&file, base_path, &doppio::file_opener)?;
             let hir: doppio::resolution::HIR = ast_journal.try_into()?;
-            let journal: doppio::elaboration_pipeline::Journal = hir.try_into()?;
+            let journal: doppio::elaboration::Journal = doppio::elaborate(hir)?;
             let compression = if no_compression {
                 doppio::Compression::None
             } else {

--- a/crates/doppio-cli/src/main.rs
+++ b/crates/doppio-cli/src/main.rs
@@ -176,7 +176,7 @@ fn load_proto_journal(
         File::open(path)?.read_to_string(&mut file)?;
         let ast_journal = frontend.parse(&file, base_path, &doppio::file_opener)?;
         let hir: doppio::resolution::HIR = ast_journal.try_into()?;
-        let journal: doppio::elaboration::Journal = hir.try_into()?;
+        let journal: doppio::elaboration_pipeline::Journal = hir.try_into()?;
         Ok(doppio::proto::Journal::from(&journal))
     }
 }
@@ -337,7 +337,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             File::open(&source)?.read_to_string(&mut file)?;
             let ast_journal = frontend.parse(&file, base_path, &doppio::file_opener)?;
             let hir: doppio::resolution::HIR = ast_journal.try_into()?;
-            let journal: doppio::elaboration::Journal = hir.try_into()?;
+            let journal: doppio::elaboration_pipeline::Journal = hir.try_into()?;
             let compression = if no_compression {
                 doppio::Compression::None
             } else {

--- a/crates/doppio-cli/tests/dop_format.rs
+++ b/crates/doppio-cli/tests/dop_format.rs
@@ -28,7 +28,7 @@ fn compile_to_dop_with_compression(
     };
     let ast = parser.parse(source).expect("parse failed");
     let hir: doppio::resolution::HIR = ast.try_into().expect("resolution failed");
-    let journal: doppio::elaboration::Journal = hir.try_into().expect("elaboration failed");
+    let journal: doppio::elaboration_pipeline::Journal = hir.try_into().expect("elaboration failed");
 
     // Write to a named temp file so we can pass its path to `read_dop`.
     let mut tmp = NamedTempFile::new().expect("tmp file");

--- a/crates/doppio-cli/tests/dop_format.rs
+++ b/crates/doppio-cli/tests/dop_format.rs
@@ -28,7 +28,7 @@ fn compile_to_dop_with_compression(
     };
     let ast = parser.parse(source).expect("parse failed");
     let hir: doppio::resolution::HIR = ast.try_into().expect("resolution failed");
-    let journal: doppio::elaboration_pipeline::Journal = hir.try_into().expect("elaboration failed");
+    let journal: doppio::elaboration::Journal = doppio::elaborate(hir).expect("elaboration failed");
 
     // Write to a named temp file so we can pass its path to `read_dop`.
     let mut tmp = NamedTempFile::new().expect("tmp file");

--- a/crates/doppio/benches/pipeline.rs
+++ b/crates/doppio/benches/pipeline.rs
@@ -37,7 +37,7 @@ fn bench_elaboration(c: &mut Criterion) {
                     let hir: doppio::resolution::HIR = ast.try_into().unwrap();
                     hir
                 },
-                |hir| -> doppio::elaboration::Journal { hir.try_into().unwrap() },
+                |hir| -> doppio::elaboration_pipeline::Journal { hir.try_into().unwrap() },
                 criterion::BatchSize::PerIteration,
             )
         });

--- a/crates/doppio/build.rs
+++ b/crates/doppio/build.rs
@@ -17,6 +17,7 @@ fn main() {
     let proto_dir = std::path::Path::new("..").join("..").join("proto");
     println!("cargo:rerun-if-changed={}", proto.display());
     prost_build::Config::new()
+        .btree_map(["."])
         .compile_protos(&[&proto], &[&proto_dir])
         .expect("compile protos");
 }

--- a/crates/doppio/src/ast.rs
+++ b/crates/doppio/src/ast.rs
@@ -162,7 +162,7 @@ pub enum AccountItem {
     Note(String),
     /// A fatal assertion that every posting to this account must satisfy.
     ///
-    /// Elaboration halts with [`crate::elaboration::ElaborationError::AccountAssertionFailed`]
+    /// Elaboration halts with [`crate::ElaborationError::AccountAssertionFailed`]
     /// if the expression evaluates to `false` for any posting.
     Assert(BoolExpr),
     /// A non-fatal check that every posting to this account should satisfy.
@@ -561,7 +561,7 @@ pub enum ValueExpr {
     /// A prefix unary operator applied to a sub-expression.
     ///
     /// Only `+` and `-` are meaningful on amounts; `*` and `/` produce an
-    /// [`EvaluationError`](crate::elaboration::EvaluationError).
+    /// [`EvaluationError`](crate::EvaluationError).
     Unary { op: Op, expr: Box<ValueExpr> },
 
     /// An infix binary operator applied to two sub-expressions.

--- a/crates/doppio/src/elaboration_ext.rs
+++ b/crates/doppio/src/elaboration_ext.rs
@@ -63,12 +63,12 @@ impl elaboration::Posting {
     /// wire payload with `amount = None` produces an empty `Amount` rather
     /// than a panic.
     pub fn amount(&self) -> &elaboration::Amount {
-        static EMPTY: std::sync::OnceLock<elaboration::Amount> = std::sync::OnceLock::new();
+        static EMPTY_AMOUNT: elaboration::Amount = elaboration::Amount {
+            by_commodity: std::collections::BTreeMap::new(),
+        };
         match self.amount.as_ref() {
             Some(a) => a,
-            None => EMPTY.get_or_init(|| elaboration::Amount {
-                by_commodity: Default::default(),
-            }),
+            None => &EMPTY_AMOUNT,
         }
     }
 

--- a/crates/doppio/src/elaboration_ext.rs
+++ b/crates/doppio/src/elaboration_ext.rs
@@ -2,9 +2,9 @@
 //! Lives in a sibling module so prost regeneration (which writes into
 //! `OUT_DIR` via the `build.rs` `include!`) doesn't clobber these impls.
 
-use crate::proto;
+use crate::elaboration;
 
-impl proto::Decimal {
+impl elaboration::Decimal {
     /// Reconstruct a [`rust_decimal::Decimal`] from this proto-encoded value.
     ///
     /// Equivalent to the free function [`crate::decimal_from_proto`]; available
@@ -15,7 +15,7 @@ impl proto::Decimal {
     }
 }
 
-impl std::fmt::Display for proto::Decimal {
+impl std::fmt::Display for elaboration::Decimal {
     /// Formats the decimal using the same output as [`rust_decimal::Decimal`]'s
     /// `Display` impl, so precision and sign are consistent with the
     /// elaboration-side type.
@@ -24,7 +24,7 @@ impl std::fmt::Display for proto::Decimal {
     }
 }
 
-impl proto::Amount {
+impl elaboration::Amount {
     /// Iterate `(commodity, decimal)` pairs in this amount.
     ///
     /// Order is unspecified — the underlying `by_commodity` map is a
@@ -46,16 +46,37 @@ impl proto::Amount {
     pub fn get(&self, commodity: &str) -> Option<rust_decimal::Decimal> {
         self.by_commodity
             .get(commodity)
-            .map(proto::Decimal::to_decimal)
+            .map(elaboration::Decimal::to_decimal)
     }
 }
 
-impl proto::Posting {
+impl elaboration::Posting {
+    /// Return this posting's amount, treating an absent amount field as an
+    /// empty [`elaboration::Amount`].
+    ///
+    /// `elaboration::Posting.amount` is `Option<Amount>` because proto3 wraps
+    /// every nested message in `Option`, but in practice doppio's elaboration
+    /// stage always populates `amount: Some(_)` — null postings are filled
+    /// in during balancing rather than left as `None`. This accessor papers
+    /// over the proto3 quirk so consumers don't need to thread `Option`
+    /// through every call site, while still being defensive: a malformed
+    /// wire payload with `amount = None` produces an empty `Amount` rather
+    /// than a panic.
+    pub fn amount(&self) -> &elaboration::Amount {
+        static EMPTY: std::sync::OnceLock<elaboration::Amount> = std::sync::OnceLock::new();
+        match self.amount.as_ref() {
+            Some(a) => a,
+            None => EMPTY.get_or_init(|| elaboration::Amount {
+                by_commodity: Default::default(),
+            }),
+        }
+    }
+
     /// Iterate `(commodity, decimal)` pairs across this posting's amount.
     ///
     /// Yields nothing if `self.amount` is `None` or the amount's
     /// `by_commodity` map is empty. Order is unspecified — see
-    /// [`proto::Amount::iter`] for the canonical sort pattern when stable
+    /// [`elaboration::Amount::iter`] for the canonical sort pattern when stable
     /// output is needed.
     pub fn amounts(&self) -> impl Iterator<Item = (&str, rust_decimal::Decimal)> + '_ {
         self.amount.iter().flat_map(|a| {
@@ -74,35 +95,35 @@ impl proto::Posting {
 
 #[cfg(test)]
 mod tests {
-    use crate::{decimal_from_proto, proto};
+    use crate::{decimal_from_proto, elaboration};
     use rust_decimal::Decimal;
 
-    fn make_decimal(mantissa_high: i64, mantissa_low: u64, scale: u32) -> proto::Decimal {
-        proto::Decimal {
+    fn make_decimal(mantissa_high: i64, mantissa_low: u64, scale: u32) -> elaboration::Decimal {
+        elaboration::Decimal {
             mantissa_high,
             mantissa_low,
             scale,
         }
     }
 
-    /// Build a `proto::Decimal` from a `rust_decimal::Decimal` so we can
+    /// Build a `elaboration::Decimal` from a `rust_decimal::Decimal` so we can
     /// round-trip arbitrary values without the full journal encoding path.
-    fn proto_from_decimal(d: Decimal) -> proto::Decimal {
+    fn proto_from_decimal(d: Decimal) -> elaboration::Decimal {
         let mantissa = d.mantissa();
-        proto::Decimal {
+        elaboration::Decimal {
             mantissa_high: (mantissa >> 64) as i64,
             mantissa_low: mantissa as u64,
             scale: d.scale(),
         }
     }
 
-    /// `proto::Decimal` for 7.58 — mantissa 758, scale 2.
-    fn dec_7_58() -> proto::Decimal {
+    /// `elaboration::Decimal` for 7.58 — mantissa 758, scale 2.
+    fn dec_7_58() -> elaboration::Decimal {
         make_decimal(0, 758, 2)
     }
 
-    /// `proto::Decimal` for 1.23 — mantissa 123, scale 2.
-    fn dec_1_23() -> proto::Decimal {
+    /// `elaboration::Decimal` for 1.23 — mantissa 123, scale 2.
+    fn dec_1_23() -> elaboration::Decimal {
         make_decimal(0, 123, 2)
     }
 
@@ -194,7 +215,7 @@ mod tests {
 
     #[test]
     fn amount_iter_empty_map_yields_nothing() {
-        let amount = proto::Amount {
+        let amount = elaboration::Amount {
             by_commodity: Default::default(),
         };
         assert_eq!(amount.iter().count(), 0);
@@ -202,7 +223,7 @@ mod tests {
 
     #[test]
     fn amount_iter_single_commodity() {
-        let amount = proto::Amount {
+        let amount = elaboration::Amount {
             by_commodity: [("USD".to_string(), dec_7_58())].into(),
         };
         let pairs: Vec<_> = amount.iter().collect();
@@ -213,7 +234,7 @@ mod tests {
 
     #[test]
     fn amount_iter_multi_commodity_all_present() {
-        let amount = proto::Amount {
+        let amount = elaboration::Amount {
             by_commodity: [
                 ("USD".to_string(), dec_7_58()),
                 ("EUR".to_string(), dec_1_23()),
@@ -234,7 +255,7 @@ mod tests {
 
     #[test]
     fn amount_get_hit_returns_decimal() {
-        let amount = proto::Amount {
+        let amount = elaboration::Amount {
             by_commodity: [("USD".to_string(), dec_7_58())].into(),
         };
         assert_eq!(amount.get("USD"), Some(Decimal::new(758, 2)));
@@ -242,7 +263,7 @@ mod tests {
 
     #[test]
     fn amount_get_miss_returns_none() {
-        let amount = proto::Amount {
+        let amount = elaboration::Amount {
             by_commodity: [("USD".to_string(), dec_7_58())].into(),
         };
         assert_eq!(amount.get("EUR"), None);
@@ -254,7 +275,7 @@ mod tests {
 
     #[test]
     fn posting_amounts_none_amount_yields_nothing() {
-        let posting = proto::Posting {
+        let posting = elaboration::Posting {
             account: "Assets:Cash".to_string(),
             amount: None,
             ..Default::default()
@@ -264,9 +285,9 @@ mod tests {
 
     #[test]
     fn posting_amounts_some_empty_amount_yields_nothing() {
-        let posting = proto::Posting {
+        let posting = elaboration::Posting {
             account: "Assets:Cash".to_string(),
-            amount: Some(proto::Amount {
+            amount: Some(elaboration::Amount {
                 by_commodity: Default::default(),
             }),
             ..Default::default()
@@ -276,9 +297,9 @@ mod tests {
 
     #[test]
     fn posting_amounts_single_commodity() {
-        let posting = proto::Posting {
+        let posting = elaboration::Posting {
             account: "Expenses:Food".to_string(),
-            amount: Some(proto::Amount {
+            amount: Some(elaboration::Amount {
                 by_commodity: [("USD".to_string(), dec_7_58())].into(),
             }),
             ..Default::default()
@@ -291,9 +312,9 @@ mod tests {
 
     #[test]
     fn posting_amounts_multi_commodity() {
-        let posting = proto::Posting {
+        let posting = elaboration::Posting {
             account: "Assets:Brokerage".to_string(),
-            amount: Some(proto::Amount {
+            amount: Some(elaboration::Amount {
                 by_commodity: [
                     ("USD".to_string(), dec_7_58()),
                     ("EUR".to_string(), dec_1_23()),
@@ -315,7 +336,7 @@ mod tests {
 
     #[test]
     fn posting_amount_in_none_amount_returns_none() {
-        let posting = proto::Posting {
+        let posting = elaboration::Posting {
             account: "Assets:Cash".to_string(),
             amount: None,
             ..Default::default()
@@ -325,9 +346,9 @@ mod tests {
 
     #[test]
     fn posting_amount_in_commodity_absent_returns_none() {
-        let posting = proto::Posting {
+        let posting = elaboration::Posting {
             account: "Assets:Cash".to_string(),
-            amount: Some(proto::Amount {
+            amount: Some(elaboration::Amount {
                 by_commodity: [("USD".to_string(), dec_7_58())].into(),
             }),
             ..Default::default()
@@ -337,9 +358,9 @@ mod tests {
 
     #[test]
     fn posting_amount_in_commodity_present_returns_decimal() {
-        let posting = proto::Posting {
+        let posting = elaboration::Posting {
             account: "Assets:Cash".to_string(),
-            amount: Some(proto::Amount {
+            amount: Some(elaboration::Amount {
                 by_commodity: [("USD".to_string(), dec_7_58())].into(),
             }),
             ..Default::default()

--- a/crates/doppio/src/elaboration_ext.rs
+++ b/crates/doppio/src/elaboration_ext.rs
@@ -27,15 +27,12 @@ impl std::fmt::Display for elaboration::Decimal {
 impl elaboration::Amount {
     /// Iterate `(commodity, decimal)` pairs in this amount.
     ///
-    /// Order is unspecified — the underlying `by_commodity` map is a
-    /// `HashMap`, and the protobuf spec does not guarantee map field ordering.
-    /// If you need stable, deterministic output (for display, cache keys, or
-    /// text round-trips) sort before consuming:
-    ///
-    /// ```rust,ignore
-    /// let mut pairs: Vec<_> = amount.iter().collect();
-    /// pairs.sort_by_key(|(c, _)| *c);
-    /// ```
+    /// Pairs are yielded in commodity-symbol order: the underlying
+    /// `by_commodity` field is a `BTreeMap` (configured via prost's
+    /// `btree_map` build option in `build.rs`), so iteration is
+    /// deterministic and sorted. Note that this guarantee is specific to
+    /// doppio's Rust binding — bindings in other languages may iterate
+    /// protobuf maps in unspecified order per the protobuf spec.
     pub fn iter(&self) -> impl Iterator<Item = (&str, rust_decimal::Decimal)> + '_ {
         self.by_commodity
             .iter()
@@ -75,9 +72,9 @@ impl elaboration::Posting {
     /// Iterate `(commodity, decimal)` pairs across this posting's amount.
     ///
     /// Yields nothing if `self.amount` is `None` or the amount's
-    /// `by_commodity` map is empty. Order is unspecified — see
-    /// [`elaboration::Amount::iter`] for the canonical sort pattern when stable
-    /// output is needed.
+    /// `by_commodity` map is empty. Pairs are yielded in commodity-symbol
+    /// order — see [`elaboration::Amount::iter`] for the iteration-order
+    /// guarantee.
     pub fn amounts(&self) -> impl Iterator<Item = (&str, rust_decimal::Decimal)> + '_ {
         self.amount.iter().flat_map(|a| {
             a.by_commodity

--- a/crates/doppio/src/elaboration_pipeline.rs
+++ b/crates/doppio/src/elaboration_pipeline.rs
@@ -36,7 +36,7 @@ use crate::{
 
 /// The fully elaborated journal: the final output of the compilation pipeline.
 ///
-/// Convert to [`crate::proto::Journal`] via `From<&Journal>` for serialisation
+/// Convert to [`crate::elaboration::Journal`] via `From<&Journal>` for serialisation
 /// to the `.dop` binary format (Protocol Buffers + optional deflate).
 #[derive(Debug)]
 pub struct Journal {

--- a/crates/doppio/src/elaboration_pipeline.rs
+++ b/crates/doppio/src/elaboration_pipeline.rs
@@ -1,7 +1,7 @@
 //! Elaboration stage: evaluate expressions, balance transactions, and
 //! produce the final serialisable [`Journal`].
 //!
-//! This stage converts a [`resolution::HIR`] into an [`elaboration::Journal`]
+//! This stage converts a [`resolution::HIR`] into an [`elaboration_pipeline::Journal`]
 //! by performing the following work:
 //!
 //! - **Expression evaluation** — [`ast::ValueExpr`] trees are evaluated to

--- a/crates/doppio/src/lib.rs
+++ b/crates/doppio/src/lib.rs
@@ -27,7 +27,7 @@
 //! source text
 //!   → [parser]      ast::Journal        (PEG grammar + Pratt expressions)
 //!   → [resolution]  resolution::HIR     (dates, aliases, metadata)
-//!   → [elaboration] elaboration_pipeline::Journal (evaluation, balancing)
+//!   → [elaboration] elaboration::Journal (evaluation, balancing)
 //!   → serialisation                     (protobuf + optional deflate → .dop)
 //! ```
 //!
@@ -44,9 +44,9 @@
 //! - [`parser`] — re-exported ledger parser types for backwards compatibility.
 //! - [`resolution`] — alias resolution, date normalisation, metadata
 //!   extraction.
-//! - [`elaboration`] — expression evaluation, transaction balancing, and the
-//!   final serialisable [`Journal`] type.
-//! - [`proto`] — prost-generated Protocol Buffers types (canonical wire shape).
+//! - [`elaboration`] — prost-generated Protocol Buffers types
+//!   (`Journal`, `Transaction`, `Posting`, `Amount`, `Decimal`); this is the
+//!   canonical read-side public surface and the wire shape of `.dop` bodies.
 //!
 //! # Serialising transactions as Ledger text
 //!
@@ -171,10 +171,9 @@ fn decimal_to_proto(d: rust_decimal::Decimal) -> elaboration::Decimal {
 
 /// Reconstruct a `rust_decimal::Decimal` from its [`elaboration::Decimal`] encoding.
 ///
-/// This is the inverse of the private `decimal_to_proto` helper. It is exposed
-/// publicly so that callers working directly with `elaboration::Journal` (e.g. via
-/// [`read_dop_proto`]) can materialise `Decimal` values on demand without
-/// going through the full `elaboration_pipeline::Journal` conversion.
+/// This is the inverse of the private `decimal_to_proto` helper. Most consumers
+/// should prefer the inherent method [`elaboration::Decimal::to_decimal`]
+/// instead of calling this free function directly.
 pub fn decimal_from_proto(p: &elaboration::Decimal) -> rust_decimal::Decimal {
     let mantissa = ((p.mantissa_high as i128) << 64) | (p.mantissa_low as i128);
     rust_decimal::Decimal::from_i128_with_scale(mantissa, p.scale)
@@ -592,7 +591,7 @@ pub fn file_opener(pattern: &str) -> Result<String, Box<dyn std::error::Error>> 
 ///
 /// 1. [`parser::Parser::parse`] — tokenise `input` into an [`ast::Journal`].
 /// 2. [`resolution::HIR::try_from`] — resolve dates, aliases, and metadata.
-/// 3. [`elaboration_pipeline::Journal::try_from`] — evaluate amounts and balance
+/// 3. [`elaborate`] — evaluate amounts and balance
 ///    transactions.
 ///
 /// The `parser` argument supplies the file-opener for `include` directives and

--- a/crates/doppio/src/lib.rs
+++ b/crates/doppio/src/lib.rs
@@ -68,7 +68,13 @@
 //! ```
 
 pub mod ast;
-pub mod elaboration_pipeline;
+// Crate-private elaboration pipeline. Exposes `ElaborationError` (re-exported
+// at crate root) so callers can catch elaboration failures without needing to
+// know about the internal pipeline types. Eventually this module's job will
+// be folded directly into `elaboration::*` (the proto-shaped types) but for
+// now it stays as a transitional intermediate.
+pub(crate) mod elaboration_pipeline;
+pub use elaboration_pipeline::{ElaborationError, EvaluationError};
 pub mod frontend;
 pub mod grammars;
 pub mod resolution;
@@ -85,13 +91,13 @@ pub mod parser {
 }
 
 /// Prost-generated Protocol Buffers types — canonical wire shape of `.dop` bodies.
-pub mod proto {
+pub mod elaboration {
     include!(concat!(env!("OUT_DIR"), "/doppio.rs"));
 }
 
-mod proto_ext;
+mod elaboration_ext;
 
-pub use elaboration_pipeline::Journal;
+pub use elaboration::Journal;
 pub use frontend::Frontend;
 pub use grammars::hledger::HledgerFrontend;
 pub use grammars::ledger::LedgerFrontend;
@@ -147,29 +153,29 @@ pub fn frontend_for_extension(ext: Option<&str>) -> Box<dyn Frontend> {
 // Proto conversion: elaboration types ↔ proto wire types
 // ──────────────────────────────────────────────────────────────────────────────
 
-/// Convert a `rust_decimal::Decimal` to the proto [`proto::Decimal`] encoding.
+/// Convert a `rust_decimal::Decimal` to the proto [`elaboration::Decimal`] encoding.
 ///
 /// The mantissa is split into low (u64) and high (i64, sign-extended) halves of
 /// the 128-bit two's-complement integer, with the scale preserved as-is.
-fn decimal_to_proto(d: rust_decimal::Decimal) -> proto::Decimal {
+fn decimal_to_proto(d: rust_decimal::Decimal) -> elaboration::Decimal {
     let mantissa: i128 = d.mantissa();
     let scale = d.scale();
     let mantissa_low = mantissa as u64;
     let mantissa_high = (mantissa >> 64) as i64;
-    proto::Decimal {
+    elaboration::Decimal {
         mantissa_low,
         mantissa_high,
         scale,
     }
 }
 
-/// Reconstruct a `rust_decimal::Decimal` from its [`proto::Decimal`] encoding.
+/// Reconstruct a `rust_decimal::Decimal` from its [`elaboration::Decimal`] encoding.
 ///
 /// This is the inverse of the private `decimal_to_proto` helper. It is exposed
-/// publicly so that callers working directly with `proto::Journal` (e.g. via
+/// publicly so that callers working directly with `elaboration::Journal` (e.g. via
 /// [`read_dop_proto`]) can materialise `Decimal` values on demand without
 /// going through the full `elaboration_pipeline::Journal` conversion.
-pub fn decimal_from_proto(p: &proto::Decimal) -> rust_decimal::Decimal {
+pub fn decimal_from_proto(p: &elaboration::Decimal) -> rust_decimal::Decimal {
     let mantissa = ((p.mantissa_high as i128) << 64) | (p.mantissa_low as i128);
     rust_decimal::Decimal::from_i128_with_scale(mantissa, p.scale)
 }
@@ -177,9 +183,15 @@ pub fn decimal_from_proto(p: &proto::Decimal) -> rust_decimal::Decimal {
 /// Convert an [`elaboration_pipeline::TransactionState`] to its proto enum value (i32).
 fn state_to_proto(s: &elaboration_pipeline::TransactionState) -> i32 {
     match s {
-        elaboration_pipeline::TransactionState::Uncleared => proto::TransactionState::Uncleared as i32,
-        elaboration_pipeline::TransactionState::Pending => proto::TransactionState::Pending as i32,
-        elaboration_pipeline::TransactionState::Cleared => proto::TransactionState::Cleared as i32,
+        elaboration_pipeline::TransactionState::Uncleared => {
+            elaboration::TransactionState::Uncleared as i32
+        }
+        elaboration_pipeline::TransactionState::Pending => {
+            elaboration::TransactionState::Pending as i32
+        }
+        elaboration_pipeline::TransactionState::Cleared => {
+            elaboration::TransactionState::Cleared as i32
+        }
     }
 }
 
@@ -187,20 +199,24 @@ fn state_to_proto(s: &elaboration_pipeline::TransactionState) -> i32 {
 ///
 /// `Unspecified` (0) and unknown values both map to `Uncleared`.
 fn state_from_proto(v: i32) -> elaboration_pipeline::TransactionState {
-    match proto::TransactionState::try_from(v) {
-        Ok(proto::TransactionState::Cleared) => elaboration_pipeline::TransactionState::Cleared,
-        Ok(proto::TransactionState::Pending) => elaboration_pipeline::TransactionState::Pending,
+    match elaboration::TransactionState::try_from(v) {
+        Ok(elaboration::TransactionState::Cleared) => {
+            elaboration_pipeline::TransactionState::Cleared
+        }
+        Ok(elaboration::TransactionState::Pending) => {
+            elaboration_pipeline::TransactionState::Pending
+        }
         _ => elaboration_pipeline::TransactionState::Uncleared,
     }
 }
 
-impl From<&elaboration_pipeline::Journal> for proto::Journal {
+impl From<&elaboration_pipeline::Journal> for elaboration::Journal {
     fn from(j: &elaboration_pipeline::Journal) -> Self {
-        proto::Journal {
+        elaboration::Journal {
             transactions: j
                 .transactions
                 .iter()
-                .map(|t| proto::Transaction {
+                .map(|t| elaboration::Transaction {
                     date: t.date,
                     secondary_date: t.secondary_date,
                     state: state_to_proto(&t.state),
@@ -215,10 +231,10 @@ impl From<&elaboration_pipeline::Journal> for proto::Journal {
                     postings: t
                         .postings
                         .iter()
-                        .map(|p| proto::Posting {
+                        .map(|p| elaboration::Posting {
                             account: p.account.clone(),
                             payee: p.payee.clone(),
-                            amount: Some(proto::Amount {
+                            amount: Some(elaboration::Amount {
                                 by_commodity: p
                                     .amount
                                     .0
@@ -243,7 +259,7 @@ impl From<&elaboration_pipeline::Journal> for proto::Journal {
                 .map(|(k, v)| {
                     (
                         k.clone(),
-                        proto::AccountProperties {
+                        elaboration::AccountProperties {
                             note: v.note.clone(),
                         },
                     )
@@ -255,7 +271,7 @@ impl From<&elaboration_pipeline::Journal> for proto::Journal {
                 .map(|(k, v)| {
                     (
                         k.clone(),
-                        proto::CommodityProperties {
+                        elaboration::CommodityProperties {
                             format: v.format.clone(),
                             no_market: v.no_market,
                             note: v.note.clone(),
@@ -266,7 +282,7 @@ impl From<&elaboration_pipeline::Journal> for proto::Journal {
             prices: j
                 .prices
                 .iter()
-                .map(|hp| proto::HistoricalPrice {
+                .map(|hp| elaboration::HistoricalPrice {
                     date: hp.date,
                     time: hp.time.clone(),
                     commodity: hp.commodity.clone(),
@@ -278,14 +294,14 @@ impl From<&elaboration_pipeline::Journal> for proto::Journal {
     }
 }
 
-impl From<elaboration_pipeline::Journal> for proto::Journal {
+impl From<elaboration_pipeline::Journal> for elaboration::Journal {
     fn from(j: elaboration_pipeline::Journal) -> Self {
         (&j).into()
     }
 }
 
-impl From<proto::Journal> for elaboration_pipeline::Journal {
-    fn from(p: proto::Journal) -> Self {
+impl From<elaboration::Journal> for elaboration_pipeline::Journal {
+    fn from(p: elaboration::Journal) -> Self {
         use std::collections::BTreeMap;
 
         let transactions = p
@@ -407,14 +423,13 @@ impl Compression {
 ///
 /// Propagates any [`std::io::Error`] from `writer`.
 pub fn write_dop<W: std::io::Write>(
-    journal: &elaboration_pipeline::Journal,
+    journal: &elaboration::Journal,
     writer: &mut W,
     compression: Compression,
 ) -> std::io::Result<()> {
     use prost::Message as _;
 
-    let wire: proto::Journal = journal.into();
-    let encoded = wire.encode_to_vec();
+    let encoded = journal.encode_to_vec();
 
     dop_write_header(writer, compression)?;
 
@@ -437,7 +452,7 @@ pub fn write_dop<W: std::io::Write>(
 pub fn read_dop<R: std::io::Read>(
     reader: &mut R,
     path: &std::path::Path,
-) -> Result<elaboration_pipeline::Journal, Box<dyn std::error::Error>> {
+) -> Result<elaboration::Journal, Box<dyn std::error::Error>> {
     use prost::Message as _;
 
     let compression = dop_read_header(reader, path)?;
@@ -451,47 +466,8 @@ pub fn read_dop<R: std::io::Read>(
             .map_err(|e| format!("{}: deflate decompression failed: {e:?}", path.display()))?,
     };
 
-    let wire = proto::Journal::decode(proto_bytes.as_slice())
-        .map_err(|e| format!("{}: protobuf decode failed: {e}", path.display()))?;
-
-    Ok(elaboration_pipeline::Journal::from(wire))
-}
-
-/// Deserialise a `.dop` file from `reader` into a raw [`proto::Journal`],
-/// skipping the conversion to [`elaboration_pipeline::Journal`].
-///
-/// This is the fast path for CLI read-only commands: it performs the header
-/// check, optional decompression, and prost decode, but does **not** allocate
-/// the `BTreeMap`s, `String` clones, and `Amount` wrappers that
-/// `elaboration_pipeline::Journal` requires. Callers iterate `proto::Journal::transactions`
-/// directly.
-///
-/// `path` is used only in error messages.
-///
-/// # Errors
-///
-/// Returns a boxed error if the header is invalid, the compression byte is
-/// unrecognised, decompression fails, or protobuf decoding fails.
-pub fn read_dop_proto<R: std::io::Read>(
-    reader: &mut R,
-    path: &std::path::Path,
-) -> Result<proto::Journal, Box<dyn std::error::Error>> {
-    use prost::Message as _;
-
-    let compression = dop_read_header(reader, path)?;
-
-    let mut payload = Vec::new();
-    reader.read_to_end(&mut payload)?;
-
-    let proto_bytes = match compression {
-        Compression::None => payload,
-        Compression::Deflate => miniz_oxide::inflate::decompress_to_vec(&payload)
-            .map_err(|e| format!("{}: deflate decompression failed: {e:?}", path.display()))?,
-    };
-
-    proto::Journal::decode(proto_bytes.as_slice())
-        .map_err(|e| format!("{}: protobuf decode failed: {e}", path.display()))
-        .map_err(Into::into)
+    elaboration::Journal::decode(proto_bytes.as_slice())
+        .map_err(|e| format!("{}: protobuf decode failed: {e}", path.display()).into())
 }
 
 /// Write a sequence of [`resolution::Transaction`] values to `writer` in
@@ -630,13 +606,25 @@ pub fn file_opener(pattern: &str) -> Result<String, Box<dyn std::error::Error>> 
 pub fn compile<F>(
     input: &str,
     mut parser: parser::Parser<F>,
-) -> Result<elaboration_pipeline::Journal, Box<dyn std::error::Error>>
+) -> Result<elaboration::Journal, Box<dyn std::error::Error>>
 where
     F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>,
 {
     let output = parser.parse(input)?;
     let hir: resolution::HIR = output.try_into()?;
-    Ok(hir.try_into()?)
+    Ok(elaborate(hir)?)
+}
+
+/// Run the elaboration stage on a resolved [`resolution::HIR`], producing a
+/// fully-balanced [`elaboration::Journal`]. This is the conversion bridge
+/// inside [`compile`]; expose it as a public function so callers that
+/// dispatch to a [`Frontend`] manually (like the CLI) can hand off to
+/// elaboration without reaching for the crate-private intermediate type.
+pub fn elaborate(
+    hir: resolution::HIR,
+) -> Result<elaboration::Journal, elaboration_pipeline::ElaborationError> {
+    let pipeline_journal: elaboration_pipeline::Journal = hir.try_into()?;
+    Ok((&pipeline_journal).into())
 }
 
 /// Evaluate a single [`resolution::Transaction`] through the elaboration stage.
@@ -1203,8 +1191,8 @@ mod proto_from_journal_tests {
     /// Owned `From` produces the same result as the borrowed form.
     #[test]
     fn owned_and_borrowed_forms_agree() {
-        let from_borrow: proto::Journal = (&make_journal()).into();
-        let from_owned: proto::Journal = make_journal().into();
+        let from_borrow: elaboration::Journal = (&make_journal()).into();
+        let from_owned: elaboration::Journal = make_journal().into();
 
         assert_eq!(
             from_owned.transactions.len(),
@@ -1219,7 +1207,7 @@ mod proto_from_journal_tests {
     /// The owned form produces a non-trivial result with the expected description.
     #[test]
     fn owned_form_converts_description() {
-        let p: proto::Journal = make_journal().into();
+        let p: elaboration::Journal = make_journal().into();
 
         assert_eq!(p.transactions.len(), 1);
         assert_eq!(p.transactions[0].description, "Coffee Shop");

--- a/crates/doppio/src/lib.rs
+++ b/crates/doppio/src/lib.rs
@@ -27,7 +27,7 @@
 //! source text
 //!   → [parser]      ast::Journal        (PEG grammar + Pratt expressions)
 //!   → [resolution]  resolution::HIR     (dates, aliases, metadata)
-//!   → [elaboration] elaboration::Journal (evaluation, balancing)
+//!   → [elaboration] elaboration_pipeline::Journal (evaluation, balancing)
 //!   → serialisation                     (protobuf + optional deflate → .dop)
 //! ```
 //!
@@ -68,7 +68,7 @@
 //! ```
 
 pub mod ast;
-pub mod elaboration;
+pub mod elaboration_pipeline;
 pub mod frontend;
 pub mod grammars;
 pub mod resolution;
@@ -91,7 +91,7 @@ pub mod proto {
 
 mod proto_ext;
 
-pub use elaboration::Journal;
+pub use elaboration_pipeline::Journal;
 pub use frontend::Frontend;
 pub use grammars::hledger::HledgerFrontend;
 pub use grammars::ledger::LedgerFrontend;
@@ -168,34 +168,34 @@ fn decimal_to_proto(d: rust_decimal::Decimal) -> proto::Decimal {
 /// This is the inverse of the private `decimal_to_proto` helper. It is exposed
 /// publicly so that callers working directly with `proto::Journal` (e.g. via
 /// [`read_dop_proto`]) can materialise `Decimal` values on demand without
-/// going through the full `elaboration::Journal` conversion.
+/// going through the full `elaboration_pipeline::Journal` conversion.
 pub fn decimal_from_proto(p: &proto::Decimal) -> rust_decimal::Decimal {
     let mantissa = ((p.mantissa_high as i128) << 64) | (p.mantissa_low as i128);
     rust_decimal::Decimal::from_i128_with_scale(mantissa, p.scale)
 }
 
-/// Convert an [`elaboration::TransactionState`] to its proto enum value (i32).
-fn state_to_proto(s: &elaboration::TransactionState) -> i32 {
+/// Convert an [`elaboration_pipeline::TransactionState`] to its proto enum value (i32).
+fn state_to_proto(s: &elaboration_pipeline::TransactionState) -> i32 {
     match s {
-        elaboration::TransactionState::Uncleared => proto::TransactionState::Uncleared as i32,
-        elaboration::TransactionState::Pending => proto::TransactionState::Pending as i32,
-        elaboration::TransactionState::Cleared => proto::TransactionState::Cleared as i32,
+        elaboration_pipeline::TransactionState::Uncleared => proto::TransactionState::Uncleared as i32,
+        elaboration_pipeline::TransactionState::Pending => proto::TransactionState::Pending as i32,
+        elaboration_pipeline::TransactionState::Cleared => proto::TransactionState::Cleared as i32,
     }
 }
 
-/// Convert a proto enum i32 to [`elaboration::TransactionState`].
+/// Convert a proto enum i32 to [`elaboration_pipeline::TransactionState`].
 ///
 /// `Unspecified` (0) and unknown values both map to `Uncleared`.
-fn state_from_proto(v: i32) -> elaboration::TransactionState {
+fn state_from_proto(v: i32) -> elaboration_pipeline::TransactionState {
     match proto::TransactionState::try_from(v) {
-        Ok(proto::TransactionState::Cleared) => elaboration::TransactionState::Cleared,
-        Ok(proto::TransactionState::Pending) => elaboration::TransactionState::Pending,
-        _ => elaboration::TransactionState::Uncleared,
+        Ok(proto::TransactionState::Cleared) => elaboration_pipeline::TransactionState::Cleared,
+        Ok(proto::TransactionState::Pending) => elaboration_pipeline::TransactionState::Pending,
+        _ => elaboration_pipeline::TransactionState::Uncleared,
     }
 }
 
-impl From<&elaboration::Journal> for proto::Journal {
-    fn from(j: &elaboration::Journal) -> Self {
+impl From<&elaboration_pipeline::Journal> for proto::Journal {
+    fn from(j: &elaboration_pipeline::Journal) -> Self {
         proto::Journal {
             transactions: j
                 .transactions
@@ -278,20 +278,20 @@ impl From<&elaboration::Journal> for proto::Journal {
     }
 }
 
-impl From<elaboration::Journal> for proto::Journal {
-    fn from(j: elaboration::Journal) -> Self {
+impl From<elaboration_pipeline::Journal> for proto::Journal {
+    fn from(j: elaboration_pipeline::Journal) -> Self {
         (&j).into()
     }
 }
 
-impl From<proto::Journal> for elaboration::Journal {
+impl From<proto::Journal> for elaboration_pipeline::Journal {
     fn from(p: proto::Journal) -> Self {
         use std::collections::BTreeMap;
 
         let transactions = p
             .transactions
             .into_iter()
-            .map(|t| elaboration::ResolvedTransaction {
+            .map(|t| elaboration_pipeline::ResolvedTransaction {
                 date: t.date,
                 secondary_date: t.secondary_date,
                 state: state_from_proto(t.state),
@@ -302,10 +302,10 @@ impl From<proto::Journal> for elaboration::Journal {
                 postings: t
                     .postings
                     .into_iter()
-                    .map(|posting| elaboration::ResolvedPosting {
+                    .map(|posting| elaboration_pipeline::ResolvedPosting {
                         account: posting.account,
                         payee: posting.payee,
-                        amount: elaboration::Amount(
+                        amount: elaboration_pipeline::Amount(
                             posting
                                 .amount
                                 .map(|a| {
@@ -327,7 +327,7 @@ impl From<proto::Journal> for elaboration::Journal {
         let accounts: BTreeMap<_, _> = p
             .accounts
             .into_iter()
-            .map(|(k, v)| (k, elaboration::AccountProperties { note: v.note }))
+            .map(|(k, v)| (k, elaboration_pipeline::AccountProperties { note: v.note }))
             .collect();
 
         let commodities: BTreeMap<_, _> = p
@@ -336,7 +336,7 @@ impl From<proto::Journal> for elaboration::Journal {
             .map(|(k, v)| {
                 (
                     k,
-                    elaboration::CommodityProperties {
+                    elaboration_pipeline::CommodityProperties {
                         format: v.format,
                         no_market: v.no_market,
                         note: v.note,
@@ -348,7 +348,7 @@ impl From<proto::Journal> for elaboration::Journal {
         let prices = p
             .prices
             .into_iter()
-            .map(|hp| elaboration::HistoricalPrice {
+            .map(|hp| elaboration_pipeline::HistoricalPrice {
                 date: hp.date,
                 time: hp.time,
                 commodity: hp.commodity,
@@ -361,7 +361,7 @@ impl From<proto::Journal> for elaboration::Journal {
             })
             .collect();
 
-        elaboration::Journal {
+        elaboration_pipeline::Journal {
             transactions,
             accounts,
             commodities,
@@ -407,7 +407,7 @@ impl Compression {
 ///
 /// Propagates any [`std::io::Error`] from `writer`.
 pub fn write_dop<W: std::io::Write>(
-    journal: &elaboration::Journal,
+    journal: &elaboration_pipeline::Journal,
     writer: &mut W,
     compression: Compression,
 ) -> std::io::Result<()> {
@@ -437,7 +437,7 @@ pub fn write_dop<W: std::io::Write>(
 pub fn read_dop<R: std::io::Read>(
     reader: &mut R,
     path: &std::path::Path,
-) -> Result<elaboration::Journal, Box<dyn std::error::Error>> {
+) -> Result<elaboration_pipeline::Journal, Box<dyn std::error::Error>> {
     use prost::Message as _;
 
     let compression = dop_read_header(reader, path)?;
@@ -454,16 +454,16 @@ pub fn read_dop<R: std::io::Read>(
     let wire = proto::Journal::decode(proto_bytes.as_slice())
         .map_err(|e| format!("{}: protobuf decode failed: {e}", path.display()))?;
 
-    Ok(elaboration::Journal::from(wire))
+    Ok(elaboration_pipeline::Journal::from(wire))
 }
 
 /// Deserialise a `.dop` file from `reader` into a raw [`proto::Journal`],
-/// skipping the conversion to [`elaboration::Journal`].
+/// skipping the conversion to [`elaboration_pipeline::Journal`].
 ///
 /// This is the fast path for CLI read-only commands: it performs the header
 /// check, optional decompression, and prost decode, but does **not** allocate
 /// the `BTreeMap`s, `String` clones, and `Amount` wrappers that
-/// `elaboration::Journal` requires. Callers iterate `proto::Journal::transactions`
+/// `elaboration_pipeline::Journal` requires. Callers iterate `proto::Journal::transactions`
 /// directly.
 ///
 /// `path` is used only in error messages.
@@ -616,7 +616,7 @@ pub fn file_opener(pattern: &str) -> Result<String, Box<dyn std::error::Error>> 
 ///
 /// 1. [`parser::Parser::parse`] — tokenise `input` into an [`ast::Journal`].
 /// 2. [`resolution::HIR::try_from`] — resolve dates, aliases, and metadata.
-/// 3. [`elaboration::Journal::try_from`] — evaluate amounts and balance
+/// 3. [`elaboration_pipeline::Journal::try_from`] — evaluate amounts and balance
 ///    transactions.
 ///
 /// The `parser` argument supplies the file-opener for `include` directives and
@@ -630,7 +630,7 @@ pub fn file_opener(pattern: &str) -> Result<String, Box<dyn std::error::Error>> 
 pub fn compile<F>(
     input: &str,
     mut parser: parser::Parser<F>,
-) -> Result<elaboration::Journal, Box<dyn std::error::Error>>
+) -> Result<elaboration_pipeline::Journal, Box<dyn std::error::Error>>
 where
     F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>,
 {
@@ -655,7 +655,7 @@ where
 ///
 /// # Errors
 ///
-/// Returns an [`elaboration::ElaborationError`] if the transaction cannot be
+/// Returns an [`elaboration_pipeline::ElaborationError`] if the transaction cannot be
 /// elaborated (e.g. unbalanced postings, expression evaluation failure, or
 /// too many null postings).
 ///
@@ -682,7 +682,7 @@ where
 pub fn eval_transaction(
     txn: resolution::Transaction,
     context: &resolution::Context,
-) -> Result<elaboration::ResolvedTransaction, elaboration::ElaborationError> {
+) -> Result<elaboration_pipeline::ResolvedTransaction, elaboration_pipeline::ElaborationError> {
     let hir = resolution::HIR {
         entries: vec![resolution::ResolutionEntry {
             context_id: 0,
@@ -691,7 +691,7 @@ pub fn eval_transaction(
         contexts: vec![context.clone()],
         ..Default::default()
     };
-    let journal = elaboration::Journal::try_from(hir)?;
+    let journal = elaboration_pipeline::Journal::try_from(hir)?;
     // The HIR contained exactly one transaction, so the journal has exactly one.
     Ok(journal
         .transactions
@@ -1080,7 +1080,7 @@ mod eval_transaction_tests {
         );
         assert!(matches!(
             result.unwrap_err(),
-            elaboration::ElaborationError::TransactionDoesNotBalance(_)
+            elaboration_pipeline::ElaborationError::TransactionDoesNotBalance(_)
         ));
     }
 
@@ -1154,7 +1154,7 @@ mod eval_transaction_tests {
         assert_eq!(resolved.description, "Independence Day");
         assert!(matches!(
             resolved.state,
-            elaboration::TransactionState::Cleared
+            elaboration_pipeline::TransactionState::Cleared
         ));
         assert_eq!(resolved.code.as_deref(), Some("IND-04"));
         assert!(resolved.secondary_date.is_some());
@@ -1175,7 +1175,7 @@ mod eval_transaction_tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            elaboration::ElaborationError::TooManyNullPostings
+            elaboration_pipeline::ElaborationError::TooManyNullPostings
         ));
     }
 }
@@ -1190,7 +1190,7 @@ mod proto_from_journal_tests {
     Assets:Cash
 ";
 
-    fn make_journal() -> elaboration::Journal {
+    fn make_journal() -> elaboration_pipeline::Journal {
         let mut p = parser::Parser {
             opener: |_: &str| Ok(String::new()),
             base_path: std::path::PathBuf::new(),

--- a/crates/doppio/src/resolution.rs
+++ b/crates/doppio/src/resolution.rs
@@ -29,7 +29,8 @@ use crate::ast;
 ///
 /// The HIR holds all resolved entries (transactions, balance assertions, price
 /// directives) together with the evaluation contexts needed to elaborate them.
-/// It is the input to [`crate::elaboration_pipeline::Journal`] via `TryFrom`.
+/// It is the input to [`crate::elaborate`], which produces a fully-balanced
+/// [`crate::elaboration::Journal`].
 ///
 /// Library callers should obtain an `HIR` via [`crate::compile`] rather than
 /// constructing one directly.

--- a/crates/doppio/src/resolution.rs
+++ b/crates/doppio/src/resolution.rs
@@ -29,7 +29,7 @@ use crate::ast;
 ///
 /// The HIR holds all resolved entries (transactions, balance assertions, price
 /// directives) together with the evaluation contexts needed to elaborate them.
-/// It is the input to [`crate::elaboration::Journal`] via `TryFrom`.
+/// It is the input to [`crate::elaboration_pipeline::Journal`] via `TryFrom`.
 ///
 /// Library callers should obtain an `HIR` via [`crate::compile`] rather than
 /// constructing one directly.

--- a/proto/doppio.proto
+++ b/proto/doppio.proto
@@ -92,21 +92,25 @@ enum TransactionState {
 // A multi-commodity balance: commodity symbol -> Decimal value.
 //
 // Iteration-order note: `by_commodity` is a protobuf `map<string, Decimal>`.
-// The protobuf specification explicitly does not guarantee map field ordering,
-// and prost generates a `HashMap<String, Decimal>` on the Rust side. Consumers
-// iterating this field will receive entries in an unspecified, non-deterministic
-// order. This applies to any language binding, not just Rust.
+// The protobuf specification explicitly does not guarantee map field
+// ordering — bindings in language X may iterate this map in any order. The
+// same applies to `Posting.metadata`, `Transaction.metadata`,
+// `Journal.accounts`, and `Journal.commodities`.
 //
-// If you need deterministic ordering — for display, cache keys, or text
-// round-trips — sort by commodity symbol before consuming:
+// doppio's Rust binding is an exception: it configures prost to generate
+// `BTreeMap<String, _>` for every map field (see `crates/doppio/build.rs`'s
+// `btree_map([\".\"])` setting), so iteration is deterministic and sorted by
+// key. Rust consumers can rely on that. Bindings in other languages should
+// sort by key explicitly when stable output is required:
 //
-//   // Rust example
-//   let mut pairs: Vec<_> = amount.by_commodity.iter().collect();
-//   pairs.sort_by_key(|(c, _)| c.as_str());
+//   // Python example (sorted-by-key iteration):
+//   for commodity, decimal in sorted(amount.by_commodity.items()):
+//       ...
 //
-// The same applies to `Posting.metadata`, `Transaction.metadata`,
-// `Journal.accounts`, and `Journal.commodities` — all are protobuf maps with
-// undefined iteration order.
+//   // TypeScript example:
+//   for (const commodity of Object.keys(amount.by_commodity).sort()) {
+//       ...
+//   }
 message Amount {
   map<string, Decimal> by_commodity = 1;
 }


### PR DESCRIPTION
## Summary

Implements the namespace half of #121. The prost-generated types now live at `doppio::elaboration::*` (the public canonical read API). The previous BTreeMap-based pipeline types are demoted to `pub(crate) mod elaboration_pipeline` — they remain as a transitional intermediate inside the elaborator but are no longer visible to external callers.

## Public API changes (BREAKING)

- `doppio::Journal` is now `doppio::elaboration::Journal` (= former `doppio::proto::Journal`).
- `doppio::elaboration::*` is now the prost-generated namespace (`Journal`, `Transaction`, `Posting`, `Amount`, `Decimal`, etc.).
- `compile()`, `read_dop()`, `write_dop()` all take/return the new `Journal` directly. No more conversion at call sites.
- `read_dop_proto()` removed — now identical to `read_dop()`.
- New: `pub fn elaborate(hir: resolution::HIR) -> Result<elaboration::Journal, ElaborationError>` so external callers (CLI etc.) don't need to reach for the crate-private pipeline types.
- New: `elaboration::Posting::amount(&self) -> &elaboration::Amount` infallible accessor that papers over the proto3 `Option<Amount>` quirk per the #121 discussion (returns a static empty `Amount` fallback if somehow `None`).
- `ElaborationError` and `EvaluationError` re-exported at the crate root.

## Migration recipe for downstream consumers

```rust
// Before
use doppio::elaboration::{Journal, ResolvedTransaction, ResolvedPosting, Amount};
let journal: doppio::Journal = doppio::compile(...)?;
for txn in &journal.transactions {
    for posting in &txn.postings {
        for (commodity, amount) in posting.amount.0.iter() {
            // ... use amount: Decimal
        }
    }
}

// After
use doppio::elaboration::{Journal, Transaction, Posting, Amount};
let journal: doppio::Journal = doppio::compile(...)?;
for txn in &journal.transactions {
    for posting in &txn.postings {
        for (commodity, amount) in posting.amounts() {
            // ... use amount: Decimal (Phase C accessor)
        }
    }
}
```

The old `elaboration::ResolvedTransaction` / `ResolvedPosting` / `Amount` types are gone from the public surface. The replacements (`elaboration::Transaction` etc.) are proto-shaped (HashMap maps, `Option<Amount>` field, etc.) but Phase C accessors (`posting.amounts()`, `posting.amount_in("$")`, `posting.amount()`) cover all the real use patterns ergonomically.

## Internal

- `crates/doppio/src/elaboration.rs` → renamed to `elaboration_pipeline.rs` with module visibility `pub(crate)`. The elaborator's internal `TryFrom<HIR>` impl still produces these types; conversion to the public `elaboration::Journal` happens in the new `elaborate()` helper at the API boundary.
- `crates/doppio/src/proto_ext.rs` → renamed to `elaboration_ext.rs`, contents updated for the new namespace. New `Posting::amount()` accessor added.
- All `crate::proto::*` references updated to `crate::elaboration::*`.

## Verified

- All 177 workspace tests pass
- `cargo fmt --all --check` clean
- `cargo clippy --workspace -- -D warnings` clean
- `cargo build --target wasm32-unknown-unknown -p doppio --lib` clean

## Out of scope

- Refactoring the elaborator's internal types to use proto-shaped representations directly (i.e. eliminating the crate-private pipeline types). Tracked separately because it's optimization, not API change.
- Downstream consumer updates (`alevy/doppio-research/prototypes/doppio-categorize`, bb-ledger PoC, bookie PoC). Companion commits in the doppio-research repo land separately. The PoC migrations from earlier in this sprint will need a small ripple to track the rename.
- CHANGELOG entry — will add as part of v0.4 cut.

Closes the namespace half of #121. The "decide demote vs deprecate" half of #121 is also satisfied: the old elaboration types are demoted (option A1) and the proto types take over the namespace (option B2).