### PR TITLE
feat: graduate doppio-categorize from research prototype to workspace crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "doppio-categorize"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "doppio",
+ "rand 0.9.4",
+ "regex",
+ "rust_decimal",
+ "rust_decimal_macros",
+]
+
+[[package]]
 name = "doppio-cli"
 version = "0.4.0-rc.1"
 dependencies = [
@@ -508,13 +520,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -962,6 +986,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -979,8 +1009,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -990,7 +1030,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1000,6 +1050,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1099,7 +1158,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rkyv",
  "rust_decimal_macros",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/doppio", "crates/doppio-cli"]
+members = ["crates/doppio", "crates/doppio-categorize", "crates/doppio-cli"]
 resolver = "3"
 
 # Shared metadata that applies to every member crate by default. Crates

--- a/crates/doppio-categorize/Cargo.toml
+++ b/crates/doppio-categorize/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "doppio-categorize"
+description = "Counter-account prediction for the doppio ledger compiler — given a partial transaction, suggest the most likely counter-account from journal history."
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license-file = "../../LICENSE"
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+doppio = { path = "../doppio" }
+chrono = { workspace = true }
+rust_decimal = { workspace = true }
+
+[dev-dependencies]
+rand = "0.9"
+regex = { workspace = true }
+rust_decimal_macros = "1.40.0"

--- a/crates/doppio-categorize/README.md
+++ b/crates/doppio-categorize/README.md
@@ -1,0 +1,117 @@
+# doppio-categorize
+
+A counter-account prediction library for the [doppio](https://github.com/alevy/doppio) ledger compiler.
+
+Given a partial transaction (one side known — typically a bank/credit-card account from an import), suggest the most likely counter-account based on patterns in the existing journal.
+
+This is a **classifier**, not a forecaster. It runs at import time, per-transaction, against an index built once from the journal.
+
+## Status
+
+**v0.2 prototype** — lives here in `doppio-research/prototypes/` so the API can shake out before the crate is promoted to a workspace member of doppio and published to crates.io.
+
+## API
+
+```rust
+use doppio_categorize::{Index, Query, Config, DefaultNormalizer};
+
+// Build once from a journal:
+let index = Index::build(&journal, DefaultNormalizer);
+
+// Query many times:
+let query = Query {
+    date: chrono::NaiveDate::from_ymd_opt(2024, 4, 27).unwrap(),
+    payee: "STARBUCKS #1234 SEATTLE WA".into(),
+    amount: rust_decimal::Decimal::new(-758, 2), // -$7.58
+    known_account: "Liabilities:Visa".into(),
+};
+let suggestions = index.suggest(&query, &Config::default());
+// → vec![Suggestion { account: "Expenses:Coffee", confidence: 0.83, sample_count: 24, last_seen: ... }, ...]
+```
+
+## Algorithm
+
+The pipeline is the same shape across all scoring strategies:
+
+1. Look up the per-known-account bucket. (Bucket missing → empty result.)
+2. Pick candidate samples via the configured [`ScoringStrategy`].
+3. Apply the **sign filter** (sample's amount sign must match query's — refunds vs charges).
+4. Apply **amount-similarity weighting**: each candidate's match-score is multiplied by `1 / (1 + |ln(|query.amount|) - ln(|sample.amount|)|)`. Disable via `Config { use_amount_weighting: false, .. }`.
+5. Aggregate `match_score * amount_weight` per `counter_account`.
+6. Rank by `weight_sum / total_weight` descending.
+
+What varies across strategies is step 2 — how candidates are picked and how their match-score is computed:
+
+- **`ScoringStrategy::ExactMatch`**: candidates are samples whose normalized payee equals the query's. Match-score = 1.0 for each. This is v0.1 behavior.
+- **`ScoringStrategy::TokenIdf { df_threshold }`**: candidates are samples whose tokens overlap with the query's. Match-score for a sample is `Σ ln(N / df(t))` over shared tokens `t`, excluding tokens where `df(t) >= df_threshold`. The threshold filters geographic / structural noise tokens like "seattle", "wa" that appear in too many distinct payees.
+- **`ScoringStrategy::Hybrid { df_threshold, .. }`**: try `ExactMatch` first; if it returns no candidates, fall back to `TokenIdf`. **This is the default** since v0.2.
+
+### Normalization (v0.2 default)
+
+`DefaultNormalizer` lowercases alphabetic characters; treats digits, punctuation, and whitespace as word separators; collapses runs of separators. So `"STARBUCKS #1234 SEATTLE WA"` and `"Starbucks Seattle, WA"` both become `"starbucks seattle wa"`.
+
+The `Normalizer` trait is pluggable — a v0.3 implementation can swap in stemming, abbreviation expansion, currency-suffix stripping, etc.
+
+## Evaluation harness
+
+A held-out evaluation harness lives at `examples/eval_holdout.rs`. It:
+
+1. Loads a journal (`.ledger`, `.hledger`, `.journal`, or pre-compiled `.dop`).
+2. Filters to 2-posting transactions where exactly one posting matches an "import-side" account regex (default: `Liabilities:.*Visa`, bank/checking/savings/etc).
+3. Holds out a fraction of the eligible transactions (10% by default, seeded shuffle with `seed=42`).
+4. Builds the index from the remaining transactions.
+5. For each held-out transaction, queries with the import-side `(date, payee, amount, known_account)` and checks whether the true counter-account appears at rank 1 / 2-3.
+6. Reports top-1 / top-3 accuracy plus stratification by training-cluster size.
+
+```sh
+# default: hybrid strategy, df_threshold=50, 10% holdout, amount weighting
+cargo run --release --example eval_holdout -- /path/to/journal.ledger
+
+# pin to v0.1 exact-match behavior:
+cargo run --release --example eval_holdout -- /path/to/journal.ledger \
+    --strategy exact
+
+# pure token-IDF with a tighter df threshold:
+cargo run --release --example eval_holdout -- /path/to/journal.ledger \
+    --strategy token-idf --df-threshold 20
+
+# different import-side regex for non-default ledger conventions:
+cargo run --release --example eval_holdout -- /path/to/journal.ledger \
+    --import-regex '^Liabilities:Mercury'
+```
+
+## Real-data results
+
+### Better Bytes nonprofit books (188 transactions, 90 eligible)
+
+| Strategy | Top-1 | Top-3 | Cold-start |
+|---|---:|---:|---:|
+| `exact` | 88.9% | 88.9% | 11.1% |
+| `token-idf` (df<50) | 83.3% | 83.3% | 11.1% |
+| **`hybrid` (default)** | **88.9%** | **88.9%** | **11.1%** |
+
+Small, consistent corpus. Pure token-IDF *hurts* slightly here because rare tokens cross-match across vendors. Hybrid avoids the regression by preferring exact-match when there's a hit.
+
+### Personal household ledger (3,075 transactions, 2,960 eligible, 20% holdout for stable estimate)
+
+| Strategy | Top-1 | Top-3 |
+|---|---:|---:|
+| `exact` | 58.8% | 63.9% |
+| `token-idf` (df<50) | 68.1% | 78.2% |
+| **`hybrid` (default)** | **70.8%** | **78.5%** |
+
+Long-tail corpus where 70% of normalized payees appear exactly once. Hybrid lifts top-1 by **+12 points** over the v0.1 exact-match baseline by recovering cold-start cases through shared rare tokens (e.g. "amazon" matching across `AMZN MKTP US*ABC123` / `AMZN MKTP US*XYZ987` variants). The cold-start *rate* (32.9%) doesn't change — that's a property of the corpus and the holdout — but token-IDF rescues many of those formerly-empty cases.
+
+## v0.3 trajectory
+
+Things deliberately deferred:
+
+- **Recency weighting**: confidence is currently pure frequency × IDF × amount-similarity. v0.3 will weight recent samples higher.
+- **Naive Bayes / probabilistic classifier**: real-data evaluation showed cold-start (not classification error) is the dominant failure mode on both bb-org and household corpora. Token-IDF closed most of that gap. NB-style discrimination would help on a corpus with same-payee-different-counter ambiguity (the synthetic PCC $14 vs $200 case), but neither real corpus exhibits much of this. Worth revisiting with more downstream consumers.
+- **Multi-posting pattern recognition**: each posting in an N-posting transaction is currently an independent sample. v0.3 may recognize "Starbucks usually splits as Coffee + Tax" and surface structured multi-posting suggestions.
+- **Online learning / feedback**: the index is stateless — the caller rebuilds when the journal changes. No `Index::observe(accepted_suggestion)` API yet.
+- **Custom normalizers documented and tested**: the `Normalizer` trait is pluggable today, but only `DefaultNormalizer` is shipped. v0.3 will exercise the customization path.
+
+## Notes on the doppio API
+
+See `NOTES.md` for ergonomic friction encountered against the doppio library API during development. Each entry is a candidate for a tracking issue against doppio core.

--- a/crates/doppio-categorize/examples/eval_holdout.rs
+++ b/crates/doppio-categorize/examples/eval_holdout.rs
@@ -1,0 +1,396 @@
+//! Held-out evaluation harness for doppio-categorize v0.1.
+//!
+//! Holds out a fraction of 2-posting transactions (whose import-side posting
+//! matches a regex), builds the index from the rest, then queries each
+//! held-out transaction and reports top-1 / top-3 accuracy.
+//!
+//! Usage:
+//!
+//! ```sh
+//! cargo run --release --example eval_holdout -- \
+//!   <journal-path> \
+//!   [--import-regex REGEX] \
+//!   [--no-amount-weighting] \
+//!   [--holdout 0.10] \
+//!   [--seed 42]
+//! ```
+//!
+//! The journal can be a `.ledger`, `.hledger`, `.journal`, or `.dop` file.
+
+use std::collections::{BTreeMap, HashSet};
+use std::env;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+use std::process::ExitCode;
+
+use doppio::elaboration::{Journal, Transaction};
+use doppio_categorize::{Config, DefaultNormalizer, Index, Query, ScoringStrategy};
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use rand::seq::SliceRandom;
+use regex::Regex;
+use rust_decimal::Decimal;
+
+const DEFAULT_HOLDOUT: f64 = 0.10;
+const DEFAULT_SEED: u64 = 42;
+const DEFAULT_IMPORT_REGEX: &str = r"(?i)^(Assets:.*Bank|Assets:.*Checking|Assets:.*Saving|Assets:.*Cash|Liabilities:.*Card|Liabilities:.*Visa|Liabilities:.*Mastercard|Liabilities:Credit)";
+
+fn load_journal(path: &Path) -> Result<Journal, Box<dyn std::error::Error>> {
+    if path.extension().and_then(|e| e.to_str()) == Some("dop") {
+        let mut f = File::open(path)?;
+        Ok(doppio::read_dop(&mut f, path)?)
+    } else {
+        let ext = path.extension().and_then(|e| e.to_str());
+        let frontend = doppio::frontend_for_extension(ext);
+        let base_path = path.parent().unwrap_or(Path::new(""));
+        let mut input = String::new();
+        File::open(path)?.read_to_string(&mut input)?;
+        let ast_journal = frontend.parse(&input, base_path, &doppio::file_opener)?;
+        let hir: doppio::resolution::HIR = ast_journal.try_into()?;
+        Ok(hir.try_into()?)
+    }
+}
+
+/// Extract a single decimal from a posting's amount: returns the first
+/// (and usually only) commodity's value.
+fn first_amount(txn: &Transaction, posting_idx: usize) -> Option<Decimal> {
+    txn.postings
+        .get(posting_idx)?
+        .amounts()
+        .next()
+        .map(|(_, d)| d)
+}
+
+/// One row of the evaluation result table.
+struct Hit {
+    /// 1-indexed rank of the true counter-account in the suggestion list,
+    /// or `None` if it was not in the returned suggestions at all.
+    rank: Option<usize>,
+    /// Number of training samples in the queried bucket. 0 = cold-start.
+    cluster_size: usize,
+    /// Confidence of the rank-1 suggestion, only set when rank == Some(1).
+    confidence_at_top1: Option<f64>,
+}
+
+fn print_usage() {
+    eprintln!(
+        "usage: eval_holdout <journal-path> [--import-regex REGEX] [--no-amount-weighting] \
+         [--strategy exact|token-idf|hybrid] [--df-threshold N] \
+         [--holdout FRACTION] [--seed N]"
+    );
+}
+
+fn parse_strategy(name: &str, df_threshold: u32) -> Option<ScoringStrategy> {
+    match name {
+        "exact" => Some(ScoringStrategy::ExactMatch),
+        "token-idf" => Some(ScoringStrategy::TokenIdf { df_threshold }),
+        "hybrid" => Some(ScoringStrategy::Hybrid {
+            exact_first: true,
+            df_threshold,
+        }),
+        _ => None,
+    }
+}
+
+fn main() -> ExitCode {
+    // ---- argument parsing -----------------------------------------------
+    let mut args = env::args().skip(1);
+    let journal_path = match args.next() {
+        Some(p) => p,
+        None => {
+            print_usage();
+            return ExitCode::from(2);
+        }
+    };
+    let mut import_regex = DEFAULT_IMPORT_REGEX.to_string();
+    let mut config = Config::default();
+    let mut holdout_fraction = DEFAULT_HOLDOUT;
+    let mut seed = DEFAULT_SEED;
+    let mut strategy_name = String::from("hybrid");
+    let mut df_threshold: u32 = 50;
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--import-regex" => {
+                import_regex = match args.next() {
+                    Some(v) => v,
+                    None => {
+                        eprintln!("--import-regex requires a value");
+                        return ExitCode::from(2);
+                    }
+                };
+            }
+            "--no-amount-weighting" => {
+                config.use_amount_weighting = false;
+            }
+            "--strategy" => {
+                strategy_name = match args.next() {
+                    Some(v) => v,
+                    None => {
+                        eprintln!("--strategy requires a value (exact|token-idf|hybrid)");
+                        return ExitCode::from(2);
+                    }
+                };
+            }
+            "--df-threshold" => {
+                df_threshold = match args.next().and_then(|v| v.parse().ok()) {
+                    Some(n) => n,
+                    None => {
+                        eprintln!("--df-threshold requires a u32");
+                        return ExitCode::from(2);
+                    }
+                };
+            }
+            "--holdout" => {
+                holdout_fraction = match args.next().and_then(|v| v.parse().ok()) {
+                    Some(f) if (0.0..1.0).contains(&f) => f,
+                    _ => {
+                        eprintln!("--holdout requires a fraction in [0, 1)");
+                        return ExitCode::from(2);
+                    }
+                };
+            }
+            "--seed" => {
+                seed = match args.next().and_then(|v| v.parse().ok()) {
+                    Some(s) => s,
+                    None => {
+                        eprintln!("--seed requires a u64");
+                        return ExitCode::from(2);
+                    }
+                };
+            }
+            other => {
+                eprintln!("unknown argument: {other}");
+                print_usage();
+                return ExitCode::from(2);
+            }
+        }
+    }
+
+    // ---- load journal ---------------------------------------------------
+    let mut journal = match load_journal(Path::new(&journal_path)) {
+        Ok(j) => j,
+        Err(e) => {
+            eprintln!("failed to load journal: {e}");
+            return ExitCode::from(1);
+        }
+    };
+
+    let import_re = match Regex::new(&import_regex) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("invalid --import-regex: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    config.strategy = match parse_strategy(&strategy_name, df_threshold) {
+        Some(s) => s,
+        None => {
+            eprintln!("--strategy must be one of: exact, token-idf, hybrid");
+            return ExitCode::from(2);
+        }
+    };
+
+    eprintln!(
+        "Loaded {} transactions from {}",
+        journal.transactions.len(),
+        journal_path
+    );
+    eprintln!("Import regex:    {}", import_regex);
+    eprintln!("Holdout fraction: {:.2} (seed={})", holdout_fraction, seed);
+    eprintln!("Amount weighting: {}", config.use_amount_weighting);
+    eprintln!("Strategy:         {:?}", config.strategy);
+    eprintln!();
+
+    // ---- partition into train / test -----------------------------------
+    let all_txns: Vec<Transaction> = std::mem::take(&mut journal.transactions);
+
+    // Eligible: 2 postings, exactly one of which matches the import regex.
+    let mut eligible: Vec<usize> = Vec::new();
+    for (i, txn) in all_txns.iter().enumerate() {
+        if txn.postings.len() != 2 {
+            continue;
+        }
+        let m0 = import_re.is_match(&txn.postings[0].account);
+        let m1 = import_re.is_match(&txn.postings[1].account);
+        if m0 ^ m1 {
+            eligible.push(i);
+        }
+    }
+    eprintln!(
+        "Eligible 2-posting txns with exactly one import-side posting: {}",
+        eligible.len()
+    );
+
+    if eligible.is_empty() {
+        eprintln!(
+            "\nNo eligible transactions matched. Check --import-regex against the \
+             account names in your journal."
+        );
+        return ExitCode::from(1);
+    }
+
+    let mut rng = StdRng::seed_from_u64(seed);
+    eligible.shuffle(&mut rng);
+
+    let holdout_count = ((eligible.len() as f64) * holdout_fraction)
+        .round()
+        .max(1.0) as usize;
+    let holdout: HashSet<usize> = eligible.iter().take(holdout_count).copied().collect();
+    eprintln!(
+        "Held out {} transactions; training set has {}",
+        holdout.len(),
+        all_txns.len() - holdout.len()
+    );
+
+    let mut train_txns: Vec<Transaction> = Vec::new();
+    let mut test_txns: Vec<Transaction> = Vec::new();
+    for (i, txn) in all_txns.into_iter().enumerate() {
+        if holdout.contains(&i) {
+            test_txns.push(txn);
+        } else {
+            train_txns.push(txn);
+        }
+    }
+
+    let training_journal = Journal {
+        transactions: train_txns,
+        accounts: BTreeMap::new(),
+        commodities: BTreeMap::new(),
+        prices: Vec::new(),
+    };
+
+    // ---- build index ---------------------------------------------------
+    let index = Index::build(&training_journal, DefaultNormalizer);
+    eprintln!(
+        "Index built. Evaluating {} held-out queries...\n",
+        test_txns.len()
+    );
+
+    // ---- evaluate ------------------------------------------------------
+    let mut hits: Vec<Hit> = Vec::new();
+    for txn in &test_txns {
+        let (known_idx, counter_idx) = if import_re.is_match(&txn.postings[0].account) {
+            (0usize, 1usize)
+        } else {
+            (1usize, 0usize)
+        };
+        let known = &txn.postings[known_idx];
+        let counter = &txn.postings[counter_idx];
+
+        let amount = match first_amount(txn, known_idx) {
+            Some(d) if !d.is_zero() => d,
+            _ => continue,
+        };
+
+        let query = Query {
+            date: txn.date_naive(),
+            payee: known.payee.clone(),
+            amount,
+            known_account: known.account.clone(),
+        };
+
+        let cluster_size = index.bucket_size(&query.payee, &query.known_account);
+        let suggestions = index.suggest(&query, &config);
+
+        let rank = suggestions
+            .iter()
+            .position(|s| s.account == counter.account)
+            .map(|p| p + 1);
+        let confidence_at_top1 = if rank == Some(1) {
+            suggestions.first().map(|s| s.confidence)
+        } else {
+            None
+        };
+
+        hits.push(Hit {
+            rank,
+            cluster_size,
+            confidence_at_top1,
+        });
+    }
+
+    if hits.is_empty() {
+        eprintln!("No queries were evaluable (all held-out transactions had zero amounts).");
+        return ExitCode::from(1);
+    }
+
+    // ---- report --------------------------------------------------------
+    let total = hits.len();
+    let top1 = hits.iter().filter(|h| h.rank == Some(1)).count();
+    let top3 = hits
+        .iter()
+        .filter(|h| matches!(h.rank, Some(r) if r <= 3))
+        .count();
+    let cold_start = hits.iter().filter(|h| h.cluster_size == 0).count();
+    let avg_conf_top1: f64 = {
+        let confs: Vec<f64> = hits.iter().filter_map(|h| h.confidence_at_top1).collect();
+        if confs.is_empty() {
+            0.0
+        } else {
+            confs.iter().sum::<f64>() / confs.len() as f64
+        }
+    };
+
+    println!("=== Results ===");
+    println!("Total queries:               {}", total);
+    println!(
+        "Top-1 accuracy:              {} / {} = {:.1}%",
+        top1,
+        total,
+        100.0 * top1 as f64 / total as f64
+    );
+    println!(
+        "Top-3 accuracy:              {} / {} = {:.1}%",
+        top3,
+        total,
+        100.0 * top3 as f64 / total as f64
+    );
+    println!(
+        "Cold-start (bucket empty):   {} / {} = {:.1}%",
+        cold_start,
+        total,
+        100.0 * cold_start as f64 / total as f64
+    );
+    println!("Avg confidence on top-1 hits: {:.3}", avg_conf_top1);
+    println!();
+
+    println!("Top-1 accuracy by training cluster size:");
+    let buckets: [(usize, usize, &str); 4] = [
+        (10, usize::MAX, "≥ 10 samples"),
+        (3, 9, "3-9 samples"),
+        (1, 2, "1-2 samples"),
+        (0, 0, "0 samples (cold-start)"),
+    ];
+    for (lo, hi, label) in buckets {
+        let in_bucket: Vec<&Hit> = hits
+            .iter()
+            .filter(|h| h.cluster_size >= lo && h.cluster_size <= hi)
+            .collect();
+        let n = in_bucket.len();
+        let hits1 = in_bucket.iter().filter(|h| h.rank == Some(1)).count();
+        let pct = if n == 0 {
+            0.0
+        } else {
+            100.0 * hits1 as f64 / n as f64
+        };
+        println!("  {:24}  {:>4} / {:<4}  =  {:>5.1}%", label, hits1, n, pct);
+    }
+
+    let acc = top1 as f64 / total as f64;
+    println!();
+    if acc >= 0.70 {
+        println!(
+            "Top-1 accuracy {:.1}% meets the v0.1 ship criterion (>=70%).",
+            acc * 100.0
+        );
+    } else {
+        println!(
+            "Top-1 accuracy {:.1}% is BELOW the v0.1 ship criterion (>=70%).",
+            acc * 100.0
+        );
+    }
+
+    ExitCode::from(0)
+}

--- a/crates/doppio-categorize/src/index.rs
+++ b/crates/doppio-categorize/src/index.rs
@@ -1,0 +1,149 @@
+//! Index construction: build sample buckets from a journal.
+
+use chrono::NaiveDate;
+use doppio::elaboration::Journal;
+use rust_decimal::Decimal;
+use std::collections::{HashMap, HashSet};
+
+use crate::normalize::Normalizer;
+
+/// A historical observation: when payee X was charged via known_account A,
+/// the counter-balance went to `counter_account` for `amount` on `date`.
+///
+/// Internal type. Public API uses [`crate::Suggestion`].
+#[derive(Debug, Clone)]
+pub(crate) struct Sample {
+    pub counter_account: String,
+    pub amount: Decimal,
+    pub date: NaiveDate,
+    /// Tokens of the normalized payee (used by the token-IDF scorer).
+    /// The full normalized string isn't stored on each sample — exact-match
+    /// lookups go through [`KnownAccountBucket::by_payee`] which keys by
+    /// the full normalized string.
+    pub payee_tokens: Vec<String>,
+}
+
+/// Per-known-account storage. Holds a flat sample list (for token-IDF
+/// scanning) plus a `(normalized_payee → sample-indices)` map (for the
+/// exact-match fast path).
+#[derive(Debug, Default)]
+pub(crate) struct KnownAccountBucket {
+    pub samples: Vec<Sample>,
+    pub by_payee: HashMap<String, Vec<usize>>,
+}
+
+/// A built index over historical transactions, ready to answer suggest
+/// queries.
+///
+/// Build once per journal; query many times.
+pub struct Index {
+    pub(crate) by_known: HashMap<String, KnownAccountBucket>,
+    /// `token_df[t]` = number of distinct normalized payees that contain `t`.
+    pub(crate) token_df: HashMap<String, u32>,
+    /// Total distinct normalized payees observed.
+    pub(crate) total_payees: u32,
+    pub(crate) normalizer: Box<dyn Normalizer>,
+}
+
+impl Index {
+    /// Build an index from a journal.
+    ///
+    /// For each transaction with N ≥ 2 postings, every ordered pair of
+    /// postings (i, j) where i ≠ j produces a sample associating posting i's
+    /// account (the "known" side) with a counter of posting j's account,
+    /// posting i's amount, and the transaction's date. Postings with zero
+    /// or empty amounts are skipped, as are postings whose payee normalizes
+    /// to the empty string.
+    ///
+    /// Also computes per-token document frequency over the set of distinct
+    /// normalized payees in the journal — needed by the token-IDF scoring
+    /// strategy.
+    pub fn build<N: Normalizer + 'static>(journal: &Journal, normalizer: N) -> Self {
+        let mut by_known: HashMap<String, KnownAccountBucket> = HashMap::new();
+        let mut all_payees: HashSet<String> = HashSet::new();
+        let mut token_df: HashMap<String, u32> = HashMap::new();
+
+        // Pass 1: collect distinct normalized payees and per-token DF.
+        for txn in &journal.transactions {
+            for posting in &txn.postings {
+                let normalized = normalizer.normalize(&posting.payee);
+                if normalized.is_empty() {
+                    continue;
+                }
+                if all_payees.insert(normalized.clone()) {
+                    let unique_toks: HashSet<&str> = normalized.split_whitespace().collect();
+                    for tok in unique_toks {
+                        *token_df.entry(tok.to_string()).or_insert(0) += 1;
+                    }
+                }
+            }
+        }
+
+        // Pass 2: build per-known-account sample buckets.
+        for txn in &journal.transactions {
+            let date = txn.date_naive();
+            for (i, known) in txn.postings.iter().enumerate() {
+                let normalized = normalizer.normalize(&known.payee);
+                if normalized.is_empty() {
+                    continue;
+                }
+                let payee_tokens: Vec<String> =
+                    normalized.split_whitespace().map(String::from).collect();
+
+                // Materialize the known posting's amounts once per posting
+                // since we iterate them for every counter posting below.
+                let known_amounts: Vec<Decimal> = known.amounts().map(|(_, d)| d).collect();
+
+                for (j, counter) in txn.postings.iter().enumerate() {
+                    if i == j {
+                        continue;
+                    }
+                    for &dec in &known_amounts {
+                        if dec.is_zero() {
+                            continue;
+                        }
+                        let bucket = by_known.entry(known.account.clone()).or_default();
+                        let idx = bucket.samples.len();
+                        bucket.samples.push(Sample {
+                            counter_account: counter.account.clone(),
+                            amount: dec,
+                            date,
+                            payee_tokens: payee_tokens.clone(),
+                        });
+                        bucket
+                            .by_payee
+                            .entry(normalized.clone())
+                            .or_default()
+                            .push(idx);
+                    }
+                }
+            }
+        }
+
+        Index {
+            by_known,
+            token_df,
+            total_payees: all_payees.len() as u32,
+            normalizer: Box::new(normalizer),
+        }
+    }
+
+    /// Number of historical samples in the exact-match bucket for
+    /// `(normalize(raw_payee), known_account)`. Returns 0 if the payee
+    /// normalizes to a key not in the index, or if no sample for that key
+    /// has the given known_account.
+    ///
+    /// A query whose bucket has zero samples is a cold-start case for
+    /// [`crate::ScoringStrategy::ExactMatch`]; under
+    /// [`crate::ScoringStrategy::TokenIdf`] or
+    /// [`crate::ScoringStrategy::Hybrid`], some of those cases may still be
+    /// recoverable via shared rare tokens.
+    pub fn bucket_size(&self, raw_payee: &str, known_account: &str) -> usize {
+        let normalized = self.normalizer.normalize(raw_payee);
+        self.by_known
+            .get(known_account)
+            .and_then(|b| b.by_payee.get(&normalized))
+            .map(|v| v.len())
+            .unwrap_or(0)
+    }
+}

--- a/crates/doppio-categorize/src/lib.rs
+++ b/crates/doppio-categorize/src/lib.rs
@@ -1,0 +1,30 @@
+//! Counter-account prediction for the doppio ledger compiler.
+//!
+//! Given a partial transaction (one side known — typically a bank/credit-card
+//! account from an import), suggest the most likely counter-account from
+//! patterns in an existing journal.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use doppio_categorize::{Index, Query, Config, DefaultNormalizer};
+//!
+//! let index = Index::build(&journal, DefaultNormalizer);
+//! let query = Query {
+//!     date: today,
+//!     payee: "STARBUCKS #1234 SEATTLE WA".into(),
+//!     amount: rust_decimal::Decimal::new(-758, 2),
+//!     known_account: "Liabilities:Visa".into(),
+//! };
+//! let suggestions = index.suggest(&query, &Config::default());
+//! ```
+//!
+//! See `README.md` for the v0.2 trajectory.
+
+mod index;
+mod normalize;
+mod query;
+
+pub use index::Index;
+pub use normalize::{DefaultNormalizer, Normalizer};
+pub use query::{Config, Query, ScoringStrategy, Suggestion};

--- a/crates/doppio-categorize/src/normalize.rs
+++ b/crates/doppio-categorize/src/normalize.rs
@@ -1,0 +1,128 @@
+//! Payee normalization.
+//!
+//! v0.1 ships a single implementation, [`DefaultNormalizer`], that lowercases
+//! alphabetic characters and treats every other character (digits,
+//! punctuation, whitespace) as a word separator, then collapses runs of
+//! separators into a single space.
+//!
+//! v0.2 will introduce token-IDF normalization for cases the default
+//! normalizer cannot handle: "starbucks seattle wa" / "starbucks portland or"
+//! (same vendor, different locations) and "gusto payroll" / "gusto taxes"
+//! (same prefix, different services).
+
+/// Strategy for normalizing raw payee strings into a comparison key.
+pub trait Normalizer: Send + Sync {
+    /// Normalize a raw payee string.
+    fn normalize(&self, raw: &str) -> String;
+}
+
+/// Default normalizer: lowercase alphabetic characters; treat everything
+/// else as a word separator; collapse runs of separators.
+#[derive(Default, Debug, Clone, Copy)]
+pub struct DefaultNormalizer;
+
+impl Normalizer for DefaultNormalizer {
+    fn normalize(&self, raw: &str) -> String {
+        let mut out = String::with_capacity(raw.len());
+        let mut prev_space = true;
+        for ch in raw.chars() {
+            if ch.is_alphabetic() {
+                for lower in ch.to_lowercase() {
+                    out.push(lower);
+                }
+                prev_space = false;
+            } else if !prev_space {
+                out.push(' ');
+                prev_space = true;
+            }
+        }
+        if out.ends_with(' ') {
+            out.pop();
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lowercases() {
+        assert_eq!(DefaultNormalizer.normalize("STARBUCKS"), "starbucks");
+    }
+
+    #[test]
+    fn strips_digits_with_word_boundary() {
+        assert_eq!(
+            DefaultNormalizer.normalize("STARBUCKS #1234 SEATTLE WA"),
+            "starbucks seattle wa"
+        );
+    }
+
+    #[test]
+    fn collapses_whitespace() {
+        assert_eq!(
+            DefaultNormalizer.normalize("  Multi   Spaces  "),
+            "multi spaces"
+        );
+    }
+
+    #[test]
+    fn punctuation_is_separator() {
+        assert_eq!(
+            DefaultNormalizer.normalize("AMZN MKTP US*ABC123"),
+            "amzn mktp us abc"
+        );
+    }
+
+    #[test]
+    fn tst_prefix_separates() {
+        assert_eq!(
+            DefaultNormalizer.normalize("TST*Starbucks 4567"),
+            "tst starbucks"
+        );
+    }
+
+    #[test]
+    fn unicode_letters_preserved() {
+        assert_eq!(DefaultNormalizer.normalize("Café 123"), "café");
+    }
+
+    #[test]
+    fn starbucks_variants_collide_when_location_matches() {
+        let n = DefaultNormalizer;
+        assert_eq!(
+            n.normalize("STARBUCKS #1234 SEATTLE WA"),
+            "starbucks seattle wa"
+        );
+        assert_eq!(n.normalize("Starbucks Seattle, WA"), "starbucks seattle wa");
+    }
+
+    #[test]
+    fn locations_differ_v01_limitation() {
+        // v0.1 limitation: different locations normalize to different strings.
+        // v0.2 token-IDF will collapse these.
+        let n = DefaultNormalizer;
+        assert_ne!(
+            n.normalize("Starbucks Seattle WA"),
+            n.normalize("Starbucks Portland OR")
+        );
+    }
+
+    #[test]
+    fn empty_string() {
+        assert_eq!(DefaultNormalizer.normalize(""), "");
+    }
+
+    #[test]
+    fn only_digits() {
+        assert_eq!(DefaultNormalizer.normalize("12345"), "");
+    }
+
+    #[test]
+    fn trailing_separator_trimmed() {
+        assert_eq!(DefaultNormalizer.normalize("foo bar "), "foo bar");
+        assert_eq!(DefaultNormalizer.normalize("foo bar 123"), "foo bar");
+    }
+}

--- a/crates/doppio-categorize/src/query.rs
+++ b/crates/doppio-categorize/src/query.rs
@@ -1,0 +1,768 @@
+//! Query API: given a partial transaction, return ranked counter-account suggestions.
+
+use chrono::NaiveDate;
+use rust_decimal::Decimal;
+use rust_decimal::prelude::ToPrimitive;
+use std::collections::{HashMap, HashSet};
+
+use crate::index::{Index, KnownAccountBucket};
+
+/// A partial transaction to classify.
+#[derive(Debug, Clone)]
+pub struct Query {
+    /// Date of the transaction (currently informational; v0.3 recency
+    /// weighting will use this).
+    pub date: NaiveDate,
+    /// Raw payee string from the import source. Will be normalized by the
+    /// index's normalizer.
+    pub payee: String,
+    /// The known-side amount. Sign matters: a refund (positive on the
+    /// credit-card side) only matches historical refund samples, not charges.
+    pub amount: Decimal,
+    /// The known-side account (typically the bank/credit-card account that
+    /// originated the import).
+    pub known_account: String,
+}
+
+/// A ranked suggestion for the counter-account.
+#[derive(Debug, Clone)]
+pub struct Suggestion {
+    /// The suggested counter-account.
+    pub account: String,
+    /// `weighted_votes_for_account / total_weighted_votes`. Higher is better;
+    /// always in `[0.0, 1.0]`. Not a probability — purely relative ranking
+    /// among the surviving candidates.
+    pub confidence: f64,
+    /// Unweighted count of historical samples backing this suggestion.
+    /// Useful for distinguishing "1 sample at high amount-similarity weight"
+    /// from "50 samples at low weight".
+    pub sample_count: u32,
+    /// The most recent date this counter-account was observed for the
+    /// query payee.
+    pub last_seen: NaiveDate,
+}
+
+/// Strategy used to find candidate samples for a query.
+#[derive(Debug, Clone, Copy)]
+pub enum ScoringStrategy {
+    /// v0.1 behavior. Exact match on the normalized payee. Fast and precise
+    /// when the exact normalized form has been seen before; useless for
+    /// payee variants that differ in noise tokens (different store numbers,
+    /// different city codes).
+    ExactMatch,
+    /// Tokenize the normalized payee on whitespace, weight each token by
+    /// IDF (`ln(N / df(token))`) over the corpus of distinct normalized
+    /// payees, exclude tokens that appear in `df_threshold` or more
+    /// distinct payees. The relevance score for a sample is the sum of
+    /// IDF-weights for tokens shared with the query.
+    ///
+    /// `df_threshold` filters out common geographic / structural tokens
+    /// like "seattle", "wa", "ca" that would over-collapse unrelated
+    /// payees. A value around 50 is a reasonable starting point on a
+    /// multi-thousand-transaction journal.
+    TokenIdf { df_threshold: u32 },
+    /// Try [`ScoringStrategy::ExactMatch`] first; if no candidates are
+    /// found, fall back to [`ScoringStrategy::TokenIdf`]. This is the
+    /// recommended default — exact matches are still the strongest signal
+    /// when available, and IDF rescues the cold-start cases.
+    Hybrid {
+        /// Currently always `true`. Reserved for future extension.
+        exact_first: bool,
+        df_threshold: u32,
+    },
+}
+
+impl Default for ScoringStrategy {
+    fn default() -> Self {
+        ScoringStrategy::Hybrid {
+            exact_first: true,
+            df_threshold: 50,
+        }
+    }
+}
+
+/// Tunables for the suggest algorithm.
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// If true (default), each surviving sample contributes a weight
+    /// `1 / (1 + |ln(query.amount) - ln(sample.amount)|)`. If false, every
+    /// surviving sample contributes weight 1.0 from amount-similarity
+    /// (the per-strategy match weight is unaffected).
+    pub use_amount_weighting: bool,
+    /// Strategy for finding candidate samples. Default is the v0.2 hybrid.
+    pub strategy: ScoringStrategy,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            use_amount_weighting: true,
+            strategy: ScoringStrategy::default(),
+        }
+    }
+}
+
+impl Index {
+    /// Rank candidate counter-accounts for a partial transaction.
+    ///
+    /// Algorithm:
+    /// 1. Normalize the query's payee, look up the bucket for
+    ///    `query.known_account`. (No bucket → empty vec.)
+    /// 2. Use the configured [`ScoringStrategy`] to produce
+    ///    `(sample_index, match_score)` candidates.
+    /// 3. For each candidate, apply the sign filter (sample sign must match
+    ///    query sign), then the amount-similarity weight (if enabled).
+    /// 4. Aggregate `match_score * amount_weight` per counter_account.
+    /// 5. Rank by `weight_sum / total_weight` desc.
+    pub fn suggest(&self, query: &Query, config: &Config) -> Vec<Suggestion> {
+        let normalized = self.normalizer.normalize(&query.payee);
+        let bucket = match self.by_known.get(&query.known_account) {
+            Some(b) => b,
+            None => return Vec::new(),
+        };
+        let candidates = self.candidates(bucket, &normalized, config.strategy);
+        if candidates.is_empty() {
+            return Vec::new();
+        }
+        self.rank_candidates(bucket, &candidates, query, config)
+    }
+
+    fn candidates(
+        &self,
+        bucket: &KnownAccountBucket,
+        normalized: &str,
+        strategy: ScoringStrategy,
+    ) -> Vec<(usize, f64)> {
+        match strategy {
+            ScoringStrategy::ExactMatch => exact_match_candidates(bucket, normalized),
+            ScoringStrategy::TokenIdf { df_threshold } => {
+                token_idf_candidates(self, bucket, normalized, df_threshold)
+            }
+            ScoringStrategy::Hybrid {
+                exact_first: _,
+                df_threshold,
+            } => {
+                // exact_first is reserved for future extension; today we always
+                // try exact first and fall back to token-IDF.
+                let exact = exact_match_candidates(bucket, normalized);
+                if !exact.is_empty() {
+                    exact
+                } else {
+                    token_idf_candidates(self, bucket, normalized, df_threshold)
+                }
+            }
+        }
+    }
+
+    fn rank_candidates(
+        &self,
+        bucket: &KnownAccountBucket,
+        candidates: &[(usize, f64)],
+        query: &Query,
+        config: &Config,
+    ) -> Vec<Suggestion> {
+        let query_sign = query.amount.is_sign_negative();
+        let query_log = log_abs(query.amount);
+
+        struct Acc {
+            weight_sum: f64,
+            count: u32,
+            last_seen: NaiveDate,
+        }
+        let mut by_account: HashMap<String, Acc> = HashMap::new();
+
+        for &(idx, match_score) in candidates {
+            let sample = &bucket.samples[idx];
+            if sample.amount.is_sign_negative() != query_sign {
+                continue;
+            }
+            let amount_weight = if config.use_amount_weighting {
+                let sample_log = log_abs(sample.amount);
+                match (query_log, sample_log) {
+                    (Some(q), Some(s)) => 1.0 / (1.0 + (q - s).abs()),
+                    _ => 0.0,
+                }
+            } else {
+                1.0
+            };
+            let weight = match_score * amount_weight;
+            if weight <= 0.0 {
+                continue;
+            }
+            let entry = by_account
+                .entry(sample.counter_account.clone())
+                .or_insert(Acc {
+                    weight_sum: 0.0,
+                    count: 0,
+                    last_seen: sample.date,
+                });
+            entry.weight_sum += weight;
+            entry.count += 1;
+            if sample.date > entry.last_seen {
+                entry.last_seen = sample.date;
+            }
+        }
+
+        let total_weight: f64 = by_account.values().map(|a| a.weight_sum).sum();
+        if total_weight <= 0.0 {
+            return Vec::new();
+        }
+        let mut suggestions: Vec<Suggestion> = by_account
+            .into_iter()
+            .map(|(account, acc)| Suggestion {
+                account,
+                confidence: acc.weight_sum / total_weight,
+                sample_count: acc.count,
+                last_seen: acc.last_seen,
+            })
+            .collect();
+        suggestions.sort_by(|a, b| {
+            b.confidence
+                .partial_cmp(&a.confidence)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        suggestions
+    }
+}
+
+fn exact_match_candidates(bucket: &KnownAccountBucket, normalized: &str) -> Vec<(usize, f64)> {
+    bucket
+        .by_payee
+        .get(normalized)
+        .map(|idxs| idxs.iter().map(|&i| (i, 1.0)).collect())
+        .unwrap_or_default()
+}
+
+fn token_idf_candidates(
+    index: &Index,
+    bucket: &KnownAccountBucket,
+    normalized: &str,
+    df_threshold: u32,
+) -> Vec<(usize, f64)> {
+    let q_tokens: HashSet<&str> = normalized.split_whitespace().collect();
+    if q_tokens.is_empty() {
+        return Vec::new();
+    }
+    let total_payees = index.total_payees as f64;
+    let mut out = Vec::new();
+    for (i, sample) in bucket.samples.iter().enumerate() {
+        let mut score = 0.0;
+        let s_tokens: HashSet<&str> = sample.payee_tokens.iter().map(String::as_str).collect();
+        for tok in q_tokens.intersection(&s_tokens) {
+            let df = index.token_df.get(*tok).copied().unwrap_or(0);
+            if df == 0 || df >= df_threshold {
+                continue;
+            }
+            score += (total_payees / df as f64).ln();
+        }
+        if score > 0.0 {
+            out.push((i, score));
+        }
+    }
+    out
+}
+
+fn log_abs(d: Decimal) -> Option<f64> {
+    let f = d.abs().to_f64()?;
+    if f > 0.0 { Some(f.ln()) } else { None }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::index::Sample;
+    use crate::normalize::DefaultNormalizer;
+    use chrono::NaiveDate;
+    use rust_decimal_macros::dec;
+    use std::collections::HashMap;
+
+    fn d(year: i32, month: u32, day: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(year, month, day).unwrap()
+    }
+
+    fn sample(counter: &str, amount: Decimal, date: NaiveDate, tokens: &[&str]) -> Sample {
+        Sample {
+            counter_account: counter.to_string(),
+            amount,
+            date,
+            payee_tokens: tokens.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    /// A synthetic Index built without going through `Index::build`. Useful
+    /// for testing `rank_candidates` and the candidate functions in
+    /// isolation, without depending on Journal-fixture plumbing.
+    fn build_synthetic_index(
+        bucket_samples: Vec<Sample>,
+        by_payee: HashMap<String, Vec<usize>>,
+        token_df: HashMap<String, u32>,
+        total_payees: u32,
+    ) -> (Index, KnownAccountBucket) {
+        let bucket = KnownAccountBucket {
+            samples: bucket_samples,
+            by_payee,
+        };
+        let mut by_known = HashMap::new();
+        by_known.insert(
+            "Liabilities:Visa".to_string(),
+            KnownAccountBucket {
+                samples: bucket.samples.clone(),
+                by_payee: bucket.by_payee.clone(),
+            },
+        );
+        let index = Index {
+            by_known,
+            token_df,
+            total_payees,
+            normalizer: Box::new(DefaultNormalizer),
+        };
+        (index, bucket)
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // log_abs
+    // ──────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn log_abs_positive_matches_ln() {
+        // log_abs(e) == 1.0
+        let e: Decimal = dec!(2.71828182845904523536);
+        let v = log_abs(e).unwrap();
+        assert!((v - 1.0).abs() < 1e-9, "log_abs(e) ≈ 1.0, got {v}");
+    }
+
+    #[test]
+    fn log_abs_negative_uses_absolute_value() {
+        // log_abs(-x) == log_abs(x): the sign is meant to be filtered separately.
+        let pos = log_abs(dec!(7.58)).unwrap();
+        let neg = log_abs(dec!(-7.58)).unwrap();
+        assert!((pos - neg).abs() < 1e-12);
+    }
+
+    #[test]
+    fn log_abs_zero_returns_none() {
+        assert!(log_abs(Decimal::ZERO).is_none());
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // exact_match_candidates
+    // ──────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn exact_match_miss_returns_empty() {
+        let bucket = KnownAccountBucket::default();
+        assert!(exact_match_candidates(&bucket, "starbucks").is_empty());
+    }
+
+    #[test]
+    fn exact_match_hit_returns_unit_weights() {
+        let mut by_payee = HashMap::new();
+        by_payee.insert("starbucks".to_string(), vec![0usize, 2, 5]);
+        let bucket = KnownAccountBucket {
+            samples: Vec::new(),
+            by_payee,
+        };
+        let cands = exact_match_candidates(&bucket, "starbucks");
+        // Order of HashMap-keyed lookup is preserved: this is just the Vec
+        // stored under the key.
+        assert_eq!(cands, vec![(0, 1.0), (2, 1.0), (5, 1.0)]);
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // token_idf_candidates
+    // ──────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn token_idf_empty_query_returns_empty() {
+        let (index, bucket) = build_synthetic_index(
+            vec![sample(
+                "Expenses:Coffee",
+                dec!(7.58),
+                d(2024, 1, 1),
+                &["starbucks"],
+            )],
+            HashMap::new(),
+            HashMap::from([("starbucks".to_string(), 1u32)]),
+            1,
+        );
+        assert!(token_idf_candidates(&index, &bucket, "", 50).is_empty());
+        assert!(token_idf_candidates(&index, &bucket, "   ", 50).is_empty());
+    }
+
+    #[test]
+    fn token_idf_skips_tokens_at_or_above_df_threshold() {
+        // 2 distinct payees; "seattle" appears in both (df=2), "starbucks"
+        // only in one (df=1). With df_threshold=2, "seattle" is excluded;
+        // only "starbucks" contributes.
+        let samples = vec![
+            sample(
+                "Expenses:Coffee",
+                dec!(7.58),
+                d(2024, 1, 1),
+                &["starbucks", "seattle"],
+            ),
+            sample(
+                "Expenses:Dining",
+                dec!(30.00),
+                d(2024, 1, 2),
+                &["bistro", "seattle"],
+            ),
+        ];
+        let token_df = HashMap::from([
+            ("starbucks".to_string(), 1u32),
+            ("bistro".to_string(), 1u32),
+            ("seattle".to_string(), 2u32),
+        ]);
+        let (index, bucket) = build_synthetic_index(samples, HashMap::new(), token_df, 2);
+        let cands = token_idf_candidates(&index, &bucket, "starbucks seattle", 2);
+        // Only sample 0 ("starbucks seattle") shares a non-filtered token.
+        // Sample 1 ("bistro seattle") shares only "seattle", which is filtered.
+        assert_eq!(cands.len(), 1);
+        assert_eq!(cands[0].0, 0);
+        // Score = ln(N / df("starbucks")) = ln(2/1) = ln(2)
+        let expected = (2.0_f64 / 1.0).ln();
+        assert!((cands[0].1 - expected).abs() < 1e-9);
+    }
+
+    #[test]
+    fn token_idf_no_shared_tokens_yields_no_candidates() {
+        let samples = vec![sample(
+            "Expenses:Coffee",
+            dec!(7.58),
+            d(2024, 1, 1),
+            &["starbucks"],
+        )];
+        let token_df = HashMap::from([("starbucks".to_string(), 1u32)]);
+        let (index, bucket) = build_synthetic_index(samples, HashMap::new(), token_df, 1);
+        // Query has no tokens that overlap the sample.
+        assert!(token_idf_candidates(&index, &bucket, "comcast", 50).is_empty());
+    }
+
+    #[test]
+    fn token_idf_unknown_token_in_df_table_skipped() {
+        // Sample carries a token "starbucks" that isn't in token_df. The
+        // function uses df=0 as the unknown-token fallback and must skip it.
+        let samples = vec![sample(
+            "Expenses:Coffee",
+            dec!(7.58),
+            d(2024, 1, 1),
+            &["starbucks"],
+        )];
+        let (index, bucket) = build_synthetic_index(samples, HashMap::new(), HashMap::new(), 1);
+        let cands = token_idf_candidates(&index, &bucket, "starbucks", 50);
+        assert!(
+            cands.is_empty(),
+            "df=0 token should not contribute (would divide by zero)"
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // suggest end-to-end (rank_candidates aggregation)
+    // ──────────────────────────────────────────────────────────────────
+
+    fn install_bucket(index: &mut Index, key: &str, bucket: KnownAccountBucket) {
+        index.by_known.insert(key.to_string(), bucket);
+    }
+
+    #[test]
+    fn sign_filter_excludes_opposite_sign_samples() {
+        // Two samples for the same exact-match key, opposite signs.
+        let mut by_payee = HashMap::new();
+        by_payee.insert("starbucks".to_string(), vec![0usize, 1]);
+        let bucket = KnownAccountBucket {
+            samples: vec![
+                sample(
+                    "Expenses:Coffee",
+                    dec!(-7.58),
+                    d(2024, 1, 1),
+                    &["starbucks"],
+                ),
+                sample("Income:Refunds", dec!(7.58), d(2024, 1, 2), &["starbucks"]),
+            ],
+            by_payee,
+        };
+        let mut index = Index {
+            by_known: HashMap::new(),
+            token_df: HashMap::from([("starbucks".to_string(), 1u32)]),
+            total_payees: 1,
+            normalizer: Box::new(DefaultNormalizer),
+        };
+        install_bucket(&mut index, "Liabilities:Visa", bucket);
+        // Negative query: charges only.
+        let q = Query {
+            date: d(2024, 2, 1),
+            payee: "Starbucks".into(),
+            amount: dec!(-7.58),
+            known_account: "Liabilities:Visa".into(),
+        };
+        let s = index.suggest(&q, &Config::default());
+        assert_eq!(s.len(), 1);
+        assert_eq!(s[0].account, "Expenses:Coffee");
+    }
+
+    #[test]
+    fn confidence_sums_to_one_across_returned_suggestions() {
+        // Three samples, three different counter accounts, all exact-match.
+        // Confidence is per-account weight share; the per-strategy match
+        // weight is uniform (1.0 from ExactMatch), and amount weighting is
+        // disabled to make weights uniform across all samples.
+        let mut by_payee = HashMap::new();
+        by_payee.insert("acme".to_string(), vec![0usize, 1, 2]);
+        let bucket = KnownAccountBucket {
+            samples: vec![
+                sample("Expenses:A", dec!(-10.00), d(2024, 1, 1), &["acme"]),
+                sample("Expenses:B", dec!(-10.00), d(2024, 1, 2), &["acme"]),
+                sample("Expenses:C", dec!(-10.00), d(2024, 1, 3), &["acme"]),
+            ],
+            by_payee,
+        };
+        let mut index = Index {
+            by_known: HashMap::new(),
+            token_df: HashMap::from([("acme".to_string(), 1u32)]),
+            total_payees: 1,
+            normalizer: Box::new(DefaultNormalizer),
+        };
+        install_bucket(&mut index, "Liabilities:Visa", bucket);
+        let q = Query {
+            date: d(2024, 2, 1),
+            payee: "Acme".into(),
+            amount: dec!(-10.00),
+            known_account: "Liabilities:Visa".into(),
+        };
+        let cfg = Config {
+            use_amount_weighting: false,
+            strategy: ScoringStrategy::ExactMatch,
+        };
+        let s = index.suggest(&q, &cfg);
+        assert_eq!(s.len(), 3);
+        let total: f64 = s.iter().map(|x| x.confidence).sum();
+        assert!(
+            (total - 1.0).abs() < 1e-9,
+            "confidence sum = {total}, expected ~1.0"
+        );
+        // Every account got exactly one sample, so confidences are equal.
+        for sug in &s {
+            assert!((sug.confidence - 1.0 / 3.0).abs() < 1e-9);
+        }
+    }
+
+    #[test]
+    fn rank_orders_by_confidence_descending() {
+        // 3 samples → Expenses:Common, 1 sample → Expenses:Rare.
+        // Common should rank first.
+        let mut by_payee = HashMap::new();
+        by_payee.insert("acme".to_string(), vec![0usize, 1, 2, 3]);
+        let bucket = KnownAccountBucket {
+            samples: vec![
+                sample("Expenses:Common", dec!(-10.00), d(2024, 1, 1), &["acme"]),
+                sample("Expenses:Common", dec!(-10.00), d(2024, 1, 2), &["acme"]),
+                sample("Expenses:Common", dec!(-10.00), d(2024, 1, 3), &["acme"]),
+                sample("Expenses:Rare", dec!(-10.00), d(2024, 1, 4), &["acme"]),
+            ],
+            by_payee,
+        };
+        let mut index = Index {
+            by_known: HashMap::new(),
+            token_df: HashMap::from([("acme".to_string(), 1u32)]),
+            total_payees: 1,
+            normalizer: Box::new(DefaultNormalizer),
+        };
+        install_bucket(&mut index, "Liabilities:Visa", bucket);
+        let q = Query {
+            date: d(2024, 2, 1),
+            payee: "Acme".into(),
+            amount: dec!(-10.00),
+            known_account: "Liabilities:Visa".into(),
+        };
+        let s = index.suggest(&q, &Config::default());
+        assert_eq!(s.len(), 2);
+        assert_eq!(s[0].account, "Expenses:Common");
+        assert_eq!(s[0].sample_count, 3);
+        assert_eq!(s[1].account, "Expenses:Rare");
+        assert_eq!(s[1].sample_count, 1);
+        assert!(s[0].confidence > s[1].confidence);
+    }
+
+    #[test]
+    fn last_seen_tracks_most_recent_sample_date() {
+        // Three samples for the same counter, on three different dates;
+        // last_seen should be the maximum.
+        let mut by_payee = HashMap::new();
+        by_payee.insert("acme".to_string(), vec![0usize, 1, 2]);
+        let bucket = KnownAccountBucket {
+            samples: vec![
+                sample("Expenses:A", dec!(-10.00), d(2024, 1, 5), &["acme"]),
+                sample("Expenses:A", dec!(-10.00), d(2024, 3, 1), &["acme"]), // newest
+                sample("Expenses:A", dec!(-10.00), d(2024, 2, 14), &["acme"]),
+            ],
+            by_payee,
+        };
+        let mut index = Index {
+            by_known: HashMap::new(),
+            token_df: HashMap::from([("acme".to_string(), 1u32)]),
+            total_payees: 1,
+            normalizer: Box::new(DefaultNormalizer),
+        };
+        install_bucket(&mut index, "Liabilities:Visa", bucket);
+        let q = Query {
+            date: d(2024, 4, 1),
+            payee: "Acme".into(),
+            amount: dec!(-10.00),
+            known_account: "Liabilities:Visa".into(),
+        };
+        let s = index.suggest(&q, &Config::default());
+        assert_eq!(s.len(), 1);
+        assert_eq!(s[0].last_seen, d(2024, 3, 1));
+        assert_eq!(s[0].sample_count, 3);
+    }
+
+    #[test]
+    fn amount_weighting_decays_with_log_distance() {
+        // Two samples for the same counter — one at $10, one at $1000.
+        // Querying at $10 should give the $10 sample much more weight than
+        // the $1000 sample, since |ln(10) - ln(1000)| = ln(100) ≈ 4.6.
+        // With amount weighting on, sample_count is still 2 but the
+        // confidence is dominated by the close sample. With weighting off,
+        // both samples contribute equally.
+        let mut by_payee = HashMap::new();
+        by_payee.insert("acme".to_string(), vec![0usize, 1]);
+        let bucket = KnownAccountBucket {
+            samples: vec![
+                sample("Expenses:Match", dec!(-10.00), d(2024, 1, 1), &["acme"]),
+                sample("Expenses:Other", dec!(-1000.00), d(2024, 1, 2), &["acme"]),
+            ],
+            by_payee,
+        };
+        let mut index = Index {
+            by_known: HashMap::new(),
+            token_df: HashMap::from([("acme".to_string(), 1u32)]),
+            total_payees: 1,
+            normalizer: Box::new(DefaultNormalizer),
+        };
+        install_bucket(&mut index, "Liabilities:Visa", bucket);
+        let q = Query {
+            date: d(2024, 2, 1),
+            payee: "Acme".into(),
+            amount: dec!(-10.00),
+            known_account: "Liabilities:Visa".into(),
+        };
+
+        // Weighting on: Match >> Other.
+        let s_on = index.suggest(&q, &Config::default());
+        assert_eq!(s_on.len(), 2);
+        assert_eq!(s_on[0].account, "Expenses:Match");
+        let ratio = s_on[0].confidence / s_on[1].confidence;
+        // 1.0 / (1.0 + 0) = 1.0 for the close sample, vs
+        // 1.0 / (1.0 + ln(100)) ≈ 0.179 for the far sample → ratio ≈ 5.6.
+        assert!(
+            ratio > 4.0,
+            "amount weighting should heavily favor the close sample, ratio={ratio}"
+        );
+
+        // Weighting off: equal confidences.
+        let s_off = index.suggest(
+            &q,
+            &Config {
+                use_amount_weighting: false,
+                ..Config::default()
+            },
+        );
+        assert_eq!(s_off.len(), 2);
+        assert!((s_off[0].confidence - s_off[1].confidence).abs() < 1e-9);
+    }
+
+    #[test]
+    fn zero_query_amount_returns_empty_when_weighted() {
+        // log_abs(0) = None, so when amount weighting is on, every sample
+        // gets weight 0 and the result is empty.
+        let mut by_payee = HashMap::new();
+        by_payee.insert("acme".to_string(), vec![0usize]);
+        let bucket = KnownAccountBucket {
+            samples: vec![sample("Expenses:A", dec!(-10.00), d(2024, 1, 1), &["acme"])],
+            by_payee,
+        };
+        let mut index = Index {
+            by_known: HashMap::new(),
+            token_df: HashMap::from([("acme".to_string(), 1u32)]),
+            total_payees: 1,
+            normalizer: Box::new(DefaultNormalizer),
+        };
+        install_bucket(&mut index, "Liabilities:Visa", bucket);
+        let q = Query {
+            date: d(2024, 2, 1),
+            payee: "Acme".into(),
+            amount: Decimal::ZERO,
+            known_account: "Liabilities:Visa".into(),
+        };
+        // Sign of 0 is non-negative, so the sign filter excludes the
+        // negative sample anyway. Use a positive-amount sample to isolate
+        // the log_abs(0) → 0-weight path.
+        let mut by_payee_pos = HashMap::new();
+        by_payee_pos.insert("acme".to_string(), vec![0usize]);
+        let bucket_pos = KnownAccountBucket {
+            samples: vec![sample("Income:A", dec!(10.00), d(2024, 1, 1), &["acme"])],
+            by_payee: by_payee_pos,
+        };
+        index.by_known.insert("Liabilities:Visa".into(), bucket_pos);
+        let s = index.suggest(&q, &Config::default());
+        assert!(
+            s.is_empty(),
+            "zero query amount with weighting on should yield no suggestions"
+        );
+    }
+
+    #[test]
+    fn unknown_known_account_returns_empty() {
+        let index = Index {
+            by_known: HashMap::new(),
+            token_df: HashMap::new(),
+            total_payees: 0,
+            normalizer: Box::new(DefaultNormalizer),
+        };
+        let q = Query {
+            date: d(2024, 1, 1),
+            payee: "Anything".into(),
+            amount: dec!(-1.00),
+            known_account: "Liabilities:Nope".into(),
+        };
+        assert!(index.suggest(&q, &Config::default()).is_empty());
+    }
+
+    #[test]
+    fn hybrid_falls_through_to_token_idf_when_exact_misses() {
+        // No exact-match key, but the sample shares a rare token with the
+        // query. Hybrid should fall back to TokenIdf and recover.
+        // total_payees=2 with df=1 for "starbucks" gives ln(2) > 0; if the
+        // token's df equalled total_payees, IDF would be ln(1)=0 and the
+        // candidate would score zero.
+        let bucket = KnownAccountBucket {
+            samples: vec![sample(
+                "Expenses:Coffee",
+                dec!(-7.58),
+                d(2024, 1, 1),
+                &["starbucks", "seattle"],
+            )],
+            // by_payee is empty: no exact-match candidates available.
+            by_payee: HashMap::new(),
+        };
+        let mut index = Index {
+            by_known: HashMap::new(),
+            token_df: HashMap::from([
+                ("starbucks".to_string(), 1u32),
+                ("seattle".to_string(), 1u32),
+            ]),
+            total_payees: 2,
+            normalizer: Box::new(DefaultNormalizer),
+        };
+        install_bucket(&mut index, "Liabilities:Visa", bucket);
+        let q = Query {
+            date: d(2024, 2, 1),
+            payee: "starbucks portland".into(),
+            amount: dec!(-6.00),
+            known_account: "Liabilities:Visa".into(),
+        };
+        let s = index.suggest(&q, &Config::default());
+        assert_eq!(s.len(), 1);
+        assert_eq!(s[0].account, "Expenses:Coffee");
+    }
+}

--- a/crates/doppio-categorize/tests/integration.rs
+++ b/crates/doppio-categorize/tests/integration.rs
@@ -1,0 +1,554 @@
+//! Integration tests that build small `doppio::elaboration::Journal` fixtures
+//! by hand (using the prost-generated proto shape) and exercise the full
+//! `Index::build` / `Index::suggest` path.
+
+use chrono::NaiveDate;
+use doppio::elaboration::{
+    Amount, Decimal as ProtoDecimal, Journal, Posting, Transaction, TransactionState,
+};
+use doppio_categorize::{Config, DefaultNormalizer, Index, Query, ScoringStrategy};
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use std::collections::BTreeMap;
+
+fn epoch_days(year: i32, month: u32, day: u32) -> i32 {
+    let date = NaiveDate::from_ymd_opt(year, month, day).unwrap();
+    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+    (date - epoch).num_days() as i32
+}
+
+fn date(year: i32, month: u32, day: u32) -> NaiveDate {
+    NaiveDate::from_ymd_opt(year, month, day).unwrap()
+}
+
+fn proto_decimal(d: Decimal) -> ProtoDecimal {
+    let mantissa = d.mantissa();
+    ProtoDecimal {
+        mantissa_low: mantissa as u64,
+        mantissa_high: (mantissa >> 64) as i64,
+        scale: d.scale(),
+    }
+}
+
+fn amount(d: Decimal, commodity: &str) -> Amount {
+    let mut by_commodity = BTreeMap::new();
+    by_commodity.insert(commodity.to_string(), proto_decimal(d));
+    Amount { by_commodity }
+}
+
+fn posting(account: &str, payee: &str, amt: Decimal) -> Posting {
+    Posting {
+        account: account.to_string(),
+        payee: payee.to_string(),
+        amount: Some(amount(amt, "$")),
+        state: TransactionState::Uncleared as i32,
+        tags: Vec::new(),
+        metadata: BTreeMap::new(),
+    }
+}
+
+fn txn(date_ymd: (i32, u32, u32), description: &str, postings: Vec<Posting>) -> Transaction {
+    Transaction {
+        date: epoch_days(date_ymd.0, date_ymd.1, date_ymd.2),
+        secondary_date: None,
+        state: TransactionState::Uncleared as i32,
+        code: None,
+        description: description.to_string(),
+        tags: Vec::new(),
+        metadata: BTreeMap::new(),
+        postings,
+    }
+}
+
+fn empty_journal() -> Journal {
+    Journal::default()
+}
+
+#[test]
+fn empty_journal_returns_no_suggestions() {
+    let j = empty_journal();
+    let idx = Index::build(&j, DefaultNormalizer);
+    let q = Query {
+        date: date(2024, 1, 15),
+        payee: "Starbucks".into(),
+        amount: dec!(-7.58),
+        known_account: "Liabilities:Visa".into(),
+    };
+    assert!(idx.suggest(&q, &Config::default()).is_empty());
+}
+
+#[test]
+fn single_payee_single_account_confidence_one() {
+    let mut j = empty_journal();
+    for day in 1..=10 {
+        j.transactions.push(txn(
+            (2024, 1, day),
+            "Starbucks",
+            vec![
+                posting("Liabilities:Visa", "Starbucks", dec!(-7.58)),
+                posting("Expenses:Coffee", "Starbucks", dec!(7.58)),
+            ],
+        ));
+    }
+    let idx = Index::build(&j, DefaultNormalizer);
+    let q = Query {
+        date: date(2024, 2, 1),
+        payee: "Starbucks".into(),
+        amount: dec!(-7.58),
+        known_account: "Liabilities:Visa".into(),
+    };
+    let s = idx.suggest(&q, &Config::default());
+    assert_eq!(s.len(), 1);
+    assert_eq!(s[0].account, "Expenses:Coffee");
+    assert!((s[0].confidence - 1.0).abs() < 1e-9);
+    assert_eq!(s[0].sample_count, 10);
+    assert_eq!(s[0].last_seen, date(2024, 1, 10));
+}
+
+#[test]
+fn two_payee_history_concentrates_on_dominant_counter() {
+    // 8 Starbucks → Coffee, 2 Local Coffee → Coffee. All on Visa.
+    // Querying with payee "Starbucks" should only see Starbucks samples;
+    // sample_count=8, confidence=1.0 (single counter_account).
+    let mut j = empty_journal();
+    for day in 1..=8 {
+        j.transactions.push(txn(
+            (2024, 1, day),
+            "Starbucks",
+            vec![
+                posting("Liabilities:Visa", "Starbucks", dec!(-7.58)),
+                posting("Expenses:Coffee", "Starbucks", dec!(7.58)),
+            ],
+        ));
+    }
+    for day in 9..=10 {
+        j.transactions.push(txn(
+            (2024, 1, day),
+            "Local Coffee",
+            vec![
+                posting("Liabilities:Visa", "Local Coffee", dec!(-5.00)),
+                posting("Expenses:Coffee", "Local Coffee", dec!(5.00)),
+            ],
+        ));
+    }
+    let idx = Index::build(&j, DefaultNormalizer);
+    let q = Query {
+        date: date(2024, 2, 1),
+        payee: "Starbucks".into(),
+        amount: dec!(-7.58),
+        known_account: "Liabilities:Visa".into(),
+    };
+    let s = idx.suggest(&q, &Config::default());
+    assert_eq!(s.len(), 1);
+    assert_eq!(s[0].account, "Expenses:Coffee");
+    assert_eq!(s[0].sample_count, 8);
+}
+
+#[test]
+fn pcc_amount_split_picks_correct_cluster() {
+    // Half the history: PCC $14 → Expenses:PreparedFoods (lunch from prepared bar)
+    // Half the history: PCC $200 → Expenses:Groceries
+    let mut j = empty_journal();
+    for day in 1..=8 {
+        j.transactions.push(txn(
+            (2024, 1, day),
+            "PCC",
+            vec![
+                posting("Liabilities:Visa", "PCC", dec!(-14.00)),
+                posting("Expenses:PreparedFoods", "PCC", dec!(14.00)),
+            ],
+        ));
+    }
+    for day in 9..=16 {
+        j.transactions.push(txn(
+            (2024, 1, day),
+            "PCC",
+            vec![
+                posting("Liabilities:Visa", "PCC", dec!(-200.00)),
+                posting("Expenses:Groceries", "PCC", dec!(200.00)),
+            ],
+        ));
+    }
+    let idx = Index::build(&j, DefaultNormalizer);
+
+    // Query at $14 → PreparedFoods rank 1
+    let q14 = Query {
+        date: date(2024, 2, 1),
+        payee: "PCC".into(),
+        amount: dec!(-14.00),
+        known_account: "Liabilities:Visa".into(),
+    };
+    let s14 = idx.suggest(&q14, &Config::default());
+    assert_eq!(s14.len(), 2, "both clusters should contribute, but ranked");
+    assert_eq!(s14[0].account, "Expenses:PreparedFoods");
+    assert!(
+        s14[0].confidence > s14[1].confidence,
+        "PreparedFoods should outrank Groceries at $14: {:?}",
+        s14
+    );
+
+    // Query at $200 → Groceries rank 1
+    let q200 = Query {
+        date: date(2024, 2, 1),
+        payee: "PCC".into(),
+        amount: dec!(-200.00),
+        known_account: "Liabilities:Visa".into(),
+    };
+    let s200 = idx.suggest(&q200, &Config::default());
+    assert_eq!(s200.len(), 2);
+    assert_eq!(s200[0].account, "Expenses:Groceries");
+    assert!(
+        s200[0].confidence > s200[1].confidence,
+        "Groceries should outrank PreparedFoods at $200: {:?}",
+        s200
+    );
+}
+
+#[test]
+fn sign_filter_separates_charges_and_refunds() {
+    // 5 charges: Visa -7.58 → Expenses:Coffee
+    // 1 refund: Visa +7.58 → Income:Refunds
+    let mut j = empty_journal();
+    for day in 1..=5 {
+        j.transactions.push(txn(
+            (2024, 1, day),
+            "Starbucks",
+            vec![
+                posting("Liabilities:Visa", "Starbucks", dec!(-7.58)),
+                posting("Expenses:Coffee", "Starbucks", dec!(7.58)),
+            ],
+        ));
+    }
+    j.transactions.push(txn(
+        (2024, 1, 10),
+        "Starbucks",
+        vec![
+            posting("Liabilities:Visa", "Starbucks", dec!(7.58)),
+            posting("Income:Refunds", "Starbucks", dec!(-7.58)),
+        ],
+    ));
+    let idx = Index::build(&j, DefaultNormalizer);
+
+    // Refund query (positive amount on Visa side)
+    let q_refund = Query {
+        date: date(2024, 2, 1),
+        payee: "Starbucks".into(),
+        amount: dec!(7.58),
+        known_account: "Liabilities:Visa".into(),
+    };
+    let s_refund = idx.suggest(&q_refund, &Config::default());
+    assert_eq!(s_refund.len(), 1, "only refund samples should survive");
+    assert_eq!(s_refund[0].account, "Income:Refunds");
+
+    // Charge query (negative amount on Visa side)
+    let q_charge = Query {
+        date: date(2024, 2, 1),
+        payee: "Starbucks".into(),
+        amount: dec!(-7.58),
+        known_account: "Liabilities:Visa".into(),
+    };
+    let s_charge = idx.suggest(&q_charge, &Config::default());
+    assert_eq!(s_charge.len(), 1, "only charge samples should survive");
+    assert_eq!(s_charge[0].account, "Expenses:Coffee");
+}
+
+#[test]
+fn cold_start_returns_empty() {
+    let mut j = empty_journal();
+    j.transactions.push(txn(
+        (2024, 1, 1),
+        "Starbucks",
+        vec![
+            posting("Liabilities:Visa", "Starbucks", dec!(-7.58)),
+            posting("Expenses:Coffee", "Starbucks", dec!(7.58)),
+        ],
+    ));
+    let idx = Index::build(&j, DefaultNormalizer);
+    let q = Query {
+        date: date(2024, 2, 1),
+        payee: "Brand New Vendor".into(),
+        amount: dec!(-50.00),
+        known_account: "Liabilities:Visa".into(),
+    };
+    assert!(idx.suggest(&q, &Config::default()).is_empty());
+}
+
+#[test]
+fn unknown_known_account_returns_empty() {
+    let mut j = empty_journal();
+    j.transactions.push(txn(
+        (2024, 1, 1),
+        "Starbucks",
+        vec![
+            posting("Liabilities:Visa", "Starbucks", dec!(-7.58)),
+            posting("Expenses:Coffee", "Starbucks", dec!(7.58)),
+        ],
+    ));
+    let idx = Index::build(&j, DefaultNormalizer);
+    // Same payee, different known_account
+    let q = Query {
+        date: date(2024, 2, 1),
+        payee: "Starbucks".into(),
+        amount: dec!(-7.58),
+        known_account: "Liabilities:OtherCard".into(),
+    };
+    assert!(idx.suggest(&q, &Config::default()).is_empty());
+}
+
+#[test]
+fn payee_normalization_collides_starbucks_variants() {
+    let mut j = empty_journal();
+    j.transactions.push(txn(
+        (2024, 1, 1),
+        "STARBUCKS #1234 SEATTLE WA",
+        vec![
+            posting(
+                "Liabilities:Visa",
+                "STARBUCKS #1234 SEATTLE WA",
+                dec!(-7.58),
+            ),
+            posting("Expenses:Coffee", "STARBUCKS #1234 SEATTLE WA", dec!(7.58)),
+        ],
+    ));
+    let idx = Index::build(&j, DefaultNormalizer);
+    // Different store number, different formatting — same normalized payee.
+    let q = Query {
+        date: date(2024, 2, 1),
+        payee: "Starbucks #5678 Seattle WA".into(),
+        amount: dec!(-7.58),
+        known_account: "Liabilities:Visa".into(),
+    };
+    let s = idx.suggest(&q, &Config::default());
+    assert_eq!(s.len(), 1);
+    assert_eq!(s[0].account, "Expenses:Coffee");
+}
+
+#[test]
+fn use_amount_weighting_disabled_makes_clusters_equal() {
+    // Same as pcc_amount_split, but with use_amount_weighting=false.
+    // Without amount weighting, both clusters tie on the $14 query
+    // (both contribute weight 1.0 per sample, equal counts).
+    let mut j = empty_journal();
+    for day in 1..=8 {
+        j.transactions.push(txn(
+            (2024, 1, day),
+            "PCC",
+            vec![
+                posting("Liabilities:Visa", "PCC", dec!(-14.00)),
+                posting("Expenses:PreparedFoods", "PCC", dec!(14.00)),
+            ],
+        ));
+    }
+    for day in 9..=16 {
+        j.transactions.push(txn(
+            (2024, 1, day),
+            "PCC",
+            vec![
+                posting("Liabilities:Visa", "PCC", dec!(-200.00)),
+                posting("Expenses:Groceries", "PCC", dec!(200.00)),
+            ],
+        ));
+    }
+    let idx = Index::build(&j, DefaultNormalizer);
+
+    let q14 = Query {
+        date: date(2024, 2, 1),
+        payee: "PCC".into(),
+        amount: dec!(-14.00),
+        known_account: "Liabilities:Visa".into(),
+    };
+    let cfg = Config {
+        use_amount_weighting: false,
+        ..Config::default()
+    };
+    let s = idx.suggest(&q14, &cfg);
+    assert_eq!(s.len(), 2);
+    // With equal counts and uniform weight, confidences are equal.
+    assert!((s[0].confidence - s[1].confidence).abs() < 1e-9);
+}
+
+#[test]
+fn token_idf_rescues_unseen_payee_variant() {
+    // Training: Starbucks Seattle WA, multiple times.
+    // Query: Starbucks Portland OR — no exact normalized match.
+    // Default Hybrid strategy should fall back to token-IDF, which sees
+    // the shared "starbucks" token (rare-ish, since the rest of the corpus
+    // doesn't use it) and recovers the right counter.
+    let mut j = empty_journal();
+    for day in 1..=10 {
+        j.transactions.push(txn(
+            (2024, 1, day),
+            "STARBUCKS SEATTLE WA",
+            vec![
+                posting("Liabilities:Visa", "STARBUCKS SEATTLE WA", dec!(-7.58)),
+                posting("Expenses:Coffee", "STARBUCKS SEATTLE WA", dec!(7.58)),
+            ],
+        ));
+    }
+    // A few unrelated transactions on the same known_account, to test that
+    // token-IDF doesn't accidentally match on common tokens.
+    for day in 11..=15 {
+        j.transactions.push(txn(
+            (2024, 1, day),
+            "Comcast Cable",
+            vec![
+                posting("Liabilities:Visa", "Comcast Cable", dec!(-89.95)),
+                posting("Expenses:Internet", "Comcast Cable", dec!(89.95)),
+            ],
+        ));
+    }
+    let idx = Index::build(&j, DefaultNormalizer);
+
+    // Variant query — "starbucks portland or" doesn't appear in training.
+    let q = Query {
+        date: date(2024, 2, 1),
+        payee: "Starbucks Portland OR".into(),
+        amount: dec!(-6.42),
+        known_account: "Liabilities:Visa".into(),
+    };
+
+    // Under ExactMatch strategy, this is a cold-start: nothing matches.
+    let cfg_exact = Config {
+        strategy: ScoringStrategy::ExactMatch,
+        ..Config::default()
+    };
+    assert!(
+        idx.suggest(&q, &cfg_exact).is_empty(),
+        "ExactMatch should not find a Portland variant"
+    );
+
+    // Under default Hybrid, token-IDF rescues it via the shared "starbucks" token.
+    let s = idx.suggest(&q, &Config::default());
+    assert!(!s.is_empty(), "Hybrid should recover via token-IDF");
+    assert_eq!(s[0].account, "Expenses:Coffee");
+}
+
+#[test]
+fn token_idf_filters_high_df_tokens() {
+    // Three distinct vendors:
+    //   - "MEGA RETAILER SEATTLE WA" (10x) → Shopping
+    //   - "RESTAURANT A SEATTLE WA"   (2x)  → Dining
+    //   - "GUSTO PAYROLL"             (5x)  → Wages (no Seattle)
+    //
+    // Distinct normalized payees: 3. The token "seattle" appears in 2 of 3
+    // (df=2), as does "wa" (df=2). The non-geographic tokens have df=1.
+    let mut j = empty_journal();
+    for day in 1..=10 {
+        j.transactions.push(txn(
+            (2024, 1, day),
+            "MEGA RETAILER SEATTLE WA",
+            vec![
+                posting("Liabilities:Visa", "MEGA RETAILER SEATTLE WA", dec!(-50.00)),
+                posting("Expenses:Shopping", "MEGA RETAILER SEATTLE WA", dec!(50.00)),
+            ],
+        ));
+    }
+    for day in 11..=12 {
+        j.transactions.push(txn(
+            (2024, 1, day),
+            "RESTAURANT A SEATTLE WA",
+            vec![
+                posting("Liabilities:Visa", "RESTAURANT A SEATTLE WA", dec!(-30.00)),
+                posting("Expenses:Dining", "RESTAURANT A SEATTLE WA", dec!(30.00)),
+            ],
+        ));
+    }
+    for day in 13..=17 {
+        j.transactions.push(txn(
+            (2024, 1, day),
+            "GUSTO PAYROLL",
+            vec![
+                posting("Liabilities:Visa", "GUSTO PAYROLL", dec!(2000.00)),
+                posting("Income:Wages", "GUSTO PAYROLL", dec!(-2000.00)),
+            ],
+        ));
+    }
+    let idx = Index::build(&j, DefaultNormalizer);
+
+    // Query: a brand-new vendor in Seattle. The only tokens it shares with
+    // training are "seattle" and "wa".
+    let q = Query {
+        date: date(2024, 2, 1),
+        payee: "BRAND NEW SHOP SEATTLE WA".into(),
+        amount: dec!(-15.00),
+        known_account: "Liabilities:Visa".into(),
+    };
+
+    // df_threshold=2: filters "seattle" and "wa" (df=2 >= threshold).
+    // No other shared tokens → cold-start.
+    let cfg_strict = Config {
+        strategy: ScoringStrategy::TokenIdf { df_threshold: 2 },
+        ..Config::default()
+    };
+    assert!(
+        idx.suggest(&q, &cfg_strict).is_empty(),
+        "geographic-only overlap should be filtered by a tight df threshold"
+    );
+
+    // df_threshold=3: includes "seattle" and "wa" (df=2 < 3). They do have
+    // non-zero IDF (ln(3/2) ≈ 0.405 each) since gusto-payroll lacks them.
+    // Query then matches 12 samples (10 mega + 2 restaurant). Mega's
+    // counter (Shopping) wins on volume.
+    let cfg_loose = Config {
+        strategy: ScoringStrategy::TokenIdf { df_threshold: 3 },
+        ..Config::default()
+    };
+    let s = idx.suggest(&q, &cfg_loose);
+    assert!(
+        !s.is_empty(),
+        "with a permissive df threshold, geographic tokens propagate matches"
+    );
+}
+
+#[test]
+fn posting_with_no_amount_is_skipped() {
+    // proto3 makes Posting.amount Option<Amount>. doppio elaboration always
+    // populates Some, but a hand-built or wire-decoded fixture could carry a
+    // None. Index::build must tolerate that gracefully (skip the posting,
+    // don't panic) since `posting.amounts()` yields nothing in that case.
+    let mut j = empty_journal();
+    j.transactions.push(Transaction {
+        date: epoch_days(2024, 1, 1),
+        secondary_date: None,
+        state: TransactionState::Uncleared as i32,
+        code: None,
+        description: "Mystery".to_string(),
+        tags: Vec::new(),
+        metadata: BTreeMap::new(),
+        postings: vec![
+            Posting {
+                account: "Liabilities:Visa".to_string(),
+                payee: "Mystery".to_string(),
+                amount: None,
+                state: TransactionState::Uncleared as i32,
+                tags: Vec::new(),
+                metadata: BTreeMap::new(),
+            },
+            posting("Expenses:Unknown", "Mystery", dec!(10.00)),
+        ],
+    });
+    // Add a normal-shaped Mystery transaction so there is something for the
+    // index to learn from.
+    j.transactions.push(txn(
+        (2024, 1, 2),
+        "Mystery",
+        vec![
+            posting("Liabilities:Visa", "Mystery", dec!(-10.00)),
+            posting("Expenses:Misc", "Mystery", dec!(10.00)),
+        ],
+    ));
+    let idx = Index::build(&j, DefaultNormalizer);
+    let q = Query {
+        date: date(2024, 2, 1),
+        payee: "Mystery".into(),
+        amount: dec!(-10.00),
+        known_account: "Liabilities:Visa".into(),
+    };
+    let s = idx.suggest(&q, &Config::default());
+    // Only the second transaction's Visa posting contributes a known sample
+    // for "Liabilities:Visa". The first transaction's Visa-side amount was
+    // None and must have been skipped.
+    assert_eq!(s.len(), 1);
+    assert_eq!(s[0].account, "Expenses:Misc");
+    assert_eq!(s[0].sample_count, 1);
+}


### PR DESCRIPTION
## Summary

Graduate the counter-account prediction library out of `alevy/doppio-research/prototypes/doppio-categorize` into a workspace member at `crates/doppio-categorize/` (v0.1.0). After Phase C closed the dual-path elaboration/proto split — `Index::build_from_proto`/`--use-proto` are gone, schema is the prost-shaped `elaboration::Journal` — the prototype's gating concerns are resolved and downstream consumers (bb-ledger, bookie) have validated the public API end-to-end.

This PR brings in the post-cleanup prototype source from doppio-research@d25f463:

- **schema rewrite for v0.4**: tests/integration.rs reauthored against `Transaction { date: i32 epoch_days, postings: Vec<Posting>, ... }` + `Posting { amount: Option<Amount>, ... }` + (mantissa_low, mantissa_high, scale) Decimal wire shape
- **dual-path PoC residue removed**: `Index::build_from_proto`, `--use-proto`, and the build_from_proto parity test are deleted; open-coded `epoch_days_to_date` swapped for `txn.date_naive()`
- **17 new query.rs unit tests** covering log_abs, exact_match_candidates, token_idf_candidates, and the rank_candidates aggregation (sign filter, amount-similarity weighting, ranking, last_seen, hybrid fallback)

Surface:

- `Index::build(&Journal, normalizer)` builds per-known-account sample buckets + per-token DF in two passes
- `Index::suggest(&Query, &Config) -> Vec<Suggestion>` returns ranked suggestions
- Pluggable `ScoringStrategy { ExactMatch, TokenIdf { df_threshold }, Hybrid { df_threshold, .. } }`
- `DefaultNormalizer` + the `Normalizer` trait for payee normalization
- `examples/eval_holdout.rs` preserved for real-data benchmarking

40 tests pass (28 unit + 12 integration). Released at v0.1.0 — fresh semver line; the prototype's 0.2.0 was a private API number not visible on crates.io.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace` (40 categorizer + all doppio + doppio-cli tests pass)
- [x] `cargo bench --no-run --workspace`
- [x] `cargo build --target wasm32-unknown-unknown -p doppio --lib`
- [x] CI green (Test + WASM library build)

## Follow-ups (not in this PR)

- Tombstone the prototype directory in alevy/doppio-research with a redirect README
- Roadmap items deferred per NOTES/README: recency weighting (v0.3), custom-normalizer end-to-end coverage, multi-posting pattern recognition, online-learning hook (`Index::observe`), Naive Bayes (deferred indefinitely — cold-start dominates classification error on real corpora and token-IDF closed most of that gap)