### PR TITLE
test(parity): seed feature parity corpus (closes #138)

### DIFF
--- a/crates/doppio/tests/parity.rs
+++ b/crates/doppio/tests/parity.rs
@@ -8,10 +8,12 @@
 //!
 //! Tests for **implemented** features must pass on every run. Tests for
 //! **not-yet-implemented** features are marked `#[ignore = "tracks #N"]`
-//! and panic with the tracking issue number, so the ignored count stays
-//! a visible signal of remaining parity work. As each feature lands, the
-//! corresponding ignore is removed and the panic is replaced with real
-//! assertions.
+//! and carry the spec — real assertions on the elaborated journal that
+//! describe what should be true once the tracking issue closes. Most fail
+//! today (parsing rejects the syntax, the elaborator diverges from spec,
+//! or a schema field doesn't yet exist); the failure messages show the
+//! implementer where their work needs to land. The ignored count stays a
+//! visible signal of remaining parity work.
 //!
 //! See `docs/SUPPORTED_FEATURES.md` for the human-readable matrix and
 //! the Phase D milestone for the in-flight gap-fills.
@@ -458,75 +460,213 @@ fn running_balance() {
 
 // ──────────────────────────────────────────────────────────────────────────
 // Not-yet-implemented features. Each `#[ignore]` references its tracking
-// issue. When the feature lands, remove the `#[ignore]` and replace the
-// panic with real assertions that consume the corresponding `lift the
-// fixture out of #[ignore]` task in the issue's acceptance criteria.
+// issue. The test body carries the **expected** spec — real assertions on
+// the elaborated journal that should pass once the feature lands. Today
+// each test fails (some panic in `compile()` because the fixture won't
+// parse; some panic in the assertions because current behavior diverges
+// from spec). When the tracking issue closes, remove the `#[ignore]` and
+// the test should turn green; if not, the assertions document where
+// implementation diverged from the spec.
+//
+// Where a spec field requires a schema change that doesn't exist yet
+// (e.g. `proto::Posting.lot` for #139, `proto::Posting.kind` for #140),
+// the new-field assertion is left as a `// TODO(#N)` comment block. The
+// developer landing the schema un-comments it as part of their PR.
 // ──────────────────────────────────────────────────────────────────────────
 
 #[test]
 #[ignore = "tracks #139 — lot persistence {cost} not yet supported"]
 fn lot_persistence_cost() {
-    // When implemented: fixture should compile, and the brokerage posting's
-    // lot annotation should carry cost = $150. Schema change required —
-    // see #139 for the proto::Posting `lot` field.
-    panic!("feature unimplemented; tracks #139");
+    // Fixture: 10 AAPL {$150} @ $155.
+    //
+    // Cost basis ($150/share) is the historical lot annotation; price
+    // ($155) is the actual transaction value. The cash side balances
+    // against the price, not the cost — this is the Ledger semantics
+    // that lot persistence makes representable but doesn't change.
+    let j = compile("lot_persistence_cost.ledger");
+    let t = &j.transactions[0];
+    assert_eq!(t.postings.len(), 2);
+    assert_eq!(t.postings[0].account, "Assets:Brokerage");
+    assert_eq!(t.postings[0].amount_in("AAPL"), Some(dec!(10)));
+    // Cash side null posting: -(10 * $155) = -$1550.
+    assert_eq!(t.postings[1].account, "Assets:Cash");
+    assert_eq!(t.postings[1].amount_in("$"), Some(dec!(-1550)));
+    // TODO(#139): once the proto::Posting.lot field ships, also assert:
+    //   let lot = t.postings[0].lot.as_ref().expect("lot annotation present");
+    //   assert_eq!(lot.cost.as_ref().and_then(|a| a.get("$")), Some(dec!(150)));
 }
 
 #[test]
 #[ignore = "tracks #139 — lot persistence [date] not yet supported"]
 fn lot_persistence_date() {
-    panic!("feature unimplemented; tracks #139");
+    // Fixture: 10 AAPL {$150} [2024-03-01]. Cost + lot acquisition date.
+    let j = compile("lot_persistence_date.ledger");
+    let t = &j.transactions[0];
+    assert_eq!(t.postings[0].amount_in("AAPL"), Some(dec!(10)));
+    // No `@ price` — cash side null posting balances against the cost
+    // basis ($150/share * 10 = $1500).
+    assert_eq!(t.postings[1].amount_in("$"), Some(dec!(-1500)));
+    // TODO(#139): assert lot.cost == $150 AND lot.date == 2024-03-01
+    //   let lot = t.postings[0].lot.as_ref().expect("lot annotation present");
+    //   assert_eq!(lot.cost.as_ref().and_then(|a| a.get("$")), Some(dec!(150)));
+    //   assert_eq!(
+    //       lot.date.map(epoch_days_to_date),
+    //       Some(NaiveDate::from_ymd_opt(2024, 3, 1).unwrap()),
+    //   );
 }
 
 #[test]
 #[ignore = "tracks #139 — lot persistence ((note)) not yet supported"]
 fn lot_persistence_note() {
-    panic!("feature unimplemented; tracks #139");
+    // Fixture: 10 AAPL {$150} ((BUY-2024-01)). Cost + free-form note.
+    let j = compile("lot_persistence_note.ledger");
+    let t = &j.transactions[0];
+    assert_eq!(t.postings[0].amount_in("AAPL"), Some(dec!(10)));
+    assert_eq!(t.postings[1].amount_in("$"), Some(dec!(-1500)));
+    // TODO(#139): assert lot.cost == $150 AND lot.note == "BUY-2024-01"
+    //   let lot = t.postings[0].lot.as_ref().expect("lot annotation present");
+    //   assert_eq!(lot.cost.as_ref().and_then(|a| a.get("$")), Some(dec!(150)));
+    //   assert_eq!(lot.note.as_deref(), Some("BUY-2024-01"));
 }
 
 #[test]
 #[ignore = "tracks #140 — virtual postings (Account) not yet supported"]
 fn virtual_posting_unbalanced() {
-    // When implemented: posting kind = VirtualUnbalanced; the posting must
-    // be excluded from balance accounting (so the real postings must
-    // balance among themselves) and emitted in the elaborated journal with
-    // the kind preserved.
-    panic!("feature unimplemented; tracks #140");
+    // Fixture has 3 postings: Assets:Checking $100, Equity:Opening -$100,
+    // (Equity:Reservations) -$25. The parens mark the third as a virtual
+    // *unbalanced* posting — excluded from the transaction's balance
+    // check, so the two real postings must balance among themselves
+    // (they do: +$100 + -$100 = 0).
+    let j = compile("virtual_posting_unbalanced.ledger");
+    let t = &j.transactions[0];
+    assert_eq!(t.postings.len(), 3);
+
+    // Parens stripped from the account name on the elaborated posting.
+    let virt = t
+        .postings
+        .iter()
+        .find(|p| p.account == "Equity:Reservations")
+        .expect("virtual posting account name should have parens stripped");
+    assert_eq!(virt.amount_in("$"), Some(dec!(-25)));
+
+    // Real postings balance among themselves.
+    let real_sum: rust_decimal::Decimal = t
+        .postings
+        .iter()
+        .filter(|p| p.account != "Equity:Reservations")
+        .filter_map(|p| p.amount_in("$"))
+        .sum();
+    assert_eq!(real_sum, dec!(0), "real postings should balance to 0");
+
+    // TODO(#140): once proto::Posting.kind ships, assert:
+    //   assert_eq!(virt.kind, PostingKind::VirtualUnbalanced as i32);
 }
 
 #[test]
 #[ignore = "tracks #140 — virtual postings [Account] not yet supported"]
 fn virtual_posting_balanced() {
-    // When implemented: posting kind = VirtualBalanced; participates in
-    // the balance check but is flagged so `--real` filters can hide it.
-    panic!("feature unimplemented; tracks #140");
+    // Fixture has 3 postings: Assets:Checking $100, [Equity:Reservations]
+    // $25, Equity:Opening -$125. Brackets mark the second as a virtual
+    // *balanced* posting — DOES participate in balance accounting (so
+    // all three sum to 0), but is flagged so reports can hide it via
+    // `--real`.
+    let j = compile("virtual_posting_balanced.ledger");
+    let t = &j.transactions[0];
+    assert_eq!(t.postings.len(), 3);
+
+    // Brackets stripped from the account name.
+    let virt = t
+        .postings
+        .iter()
+        .find(|p| p.account == "Equity:Reservations")
+        .expect("virtual posting account name should have brackets stripped");
+    assert_eq!(virt.amount_in("$"), Some(dec!(25)));
+
+    // All three postings (including the virtual balanced one) sum to 0.
+    let total: rust_decimal::Decimal = t.postings.iter().filter_map(|p| p.amount_in("$")).sum();
+    assert_eq!(
+        total,
+        dec!(0),
+        "virtual balanced posting should participate in balance"
+    );
+
+    // TODO(#140): once proto::Posting.kind ships, assert:
+    //   assert_eq!(virt.kind, PostingKind::VirtualBalanced as i32);
 }
 
 #[test]
 #[ignore = "tracks #141 — FX conversion via P directive not yet wired into reports"]
 fn fx_conversion_p_directive() {
-    // When implemented: `dop balance --exchange USD` (or the library
-    // helper) should consult the P chain to convert the EUR balance to
-    // its USD-equivalent at the as-of date. Today the P directive is
-    // stored but never consulted by reports.
-    panic!("feature unimplemented; tracks #141");
+    // The fixture declares `P 2024-01-01 EUR $1.10` and a posting in EUR.
+    // Storage of the P directive works today (covered by
+    // `historical_price_directive`); what's missing is the helper that
+    // consults the price chain to convert other-commodity balances when
+    // a target commodity is requested.
+    let j = compile("fx_conversion_p_directive.ledger");
+
+    // Prerequisite: the price was parsed and stored.
+    assert_eq!(j.prices.len(), 1);
+    assert_eq!(j.prices[0].commodity, "EUR");
+    assert_eq!(j.prices[0].price_commodity, "$");
+
+    // Prerequisite: the EUR posting elaborated.
+    let travel = j.transactions[0]
+        .postings
+        .iter()
+        .find(|p| p.account == "Expenses:Travel")
+        .expect("travel posting present");
+    assert_eq!(travel.amount_in("EUR"), Some(dec!(100)));
+
+    // TODO(#141): once a price-lookup / FX helper ships on
+    // `elaboration::Journal`, assert end-to-end conversion. Sketch:
+    //   let usd = j.balance_in("Expenses:Travel", "$", as_of)
+    //       .expect("FX conversion succeeds");
+    //   assert_eq!(usd, dec!(110)); // 100 EUR * $1.10/EUR
 }
 
 #[test]
 #[ignore = "tracks #142 — bare D directive not yet supported"]
 fn bare_d_directive() {
-    // When implemented: `D $1000.00` should lower to the same internal
-    // representation as `commodity $ ; default ; format $1,000.00`. The
-    // subsequent bare amount `50` should pick up `$` as its commodity.
-    panic!("feature unimplemented; tracks #142");
+    // Fixture declares `D $1000.00` (default commodity + format) then a
+    // posting using a bare amount `50` — which should pick up `$` as
+    // its commodity. Today the parser rejects the bare `D` form.
+    let j = compile("bare_d_directive.ledger");
+    let t = &j.transactions[0];
+
+    // Bare `50` should infer `$` from the D directive's default commodity.
+    assert_eq!(t.postings[0].account, "Expenses:Food");
+    assert_eq!(t.postings[0].amount_in("$"), Some(dec!(50)));
+    assert_eq!(t.postings[1].account, "Assets:Checking");
+    assert_eq!(t.postings[1].amount_in("$"), Some(dec!(-50)));
+
+    // The format string from the D directive should land on the
+    // commodity declaration just like `commodity $ ; format ...` would.
+    let dollar = j.commodities.get("$").expect("D directive declares $");
+    assert_eq!(dollar.format.as_deref(), Some("$1,000.00"));
 }
 
 #[test]
 #[ignore = "tracks #143 — account alias sub-directive resolution incomplete"]
 fn account_alias_subdir() {
-    // When implemented: the posting's `Checking` should resolve to
-    // `Assets:Checking` in the elaborated journal. Today this resolution
-    // path may differ from the top-level `alias` directive, per the
-    // 🔧 Partial flag in docs/SUPPORTED_FEATURES.md.
-    panic!("feature unimplemented; tracks #143");
+    // Fixture: `account Assets:Checking / alias Checking`. A later posting
+    // written as `Checking` should resolve to `Assets:Checking` in the
+    // elaborated journal — same semantics as the top-level
+    // `alias Checking = Assets:Checking` form (covered by `top_level_alias`).
+    let j = compile("account_alias_subdir.ledger");
+    let t = &j.transactions[0];
+
+    // The alias resolves: posting's account is the canonical name.
+    let checking = t
+        .postings
+        .iter()
+        .find(|p| p.account == "Assets:Checking")
+        .expect("alias `Checking` should resolve to `Assets:Checking`");
+    assert_eq!(checking.amount_in("$"), Some(dec!(1000)));
+
+    // The unaliased name should NOT also appear.
+    assert!(
+        !t.postings.iter().any(|p| p.account == "Checking"),
+        "alias should resolve at parse/resolve time; unaliased `Checking` \
+         must not appear in the elaborated journal"
+    );
 }

--- a/crates/doppio/tests/parity.rs
+++ b/crates/doppio/tests/parity.rs
@@ -1,0 +1,261 @@
+//! Feature parity test corpus.
+//!
+//! One small ledger fixture per feature lives under
+//! `tests/parity/fixtures/<feature>.ledger`. Each test in this file loads
+//! its fixture, compiles it through the full parse → resolve → elaborate
+//! pipeline, and asserts properties of the resulting
+//! [`doppio::elaboration::Journal`].
+//!
+//! Tests for **implemented** features must pass on every run. Tests for
+//! **not-yet-implemented** features are marked `#[ignore = "tracks #N"]`
+//! and panic with the tracking issue number, so the ignored count stays
+//! a visible signal of remaining parity work. As each feature lands, the
+//! corresponding ignore is removed and the panic is replaced with real
+//! assertions.
+//!
+//! See `docs/SUPPORTED_FEATURES.md` for the human-readable matrix and
+//! the Phase D milestone for the in-flight gap-fills.
+
+use doppio::elaboration::Journal;
+use rust_decimal::dec;
+use std::path::PathBuf;
+
+// ──────────────────────────────────────────────────────────────────────────
+// helpers
+// ──────────────────────────────────────────────────────────────────────────
+
+fn fixture(name: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("parity")
+        .join("fixtures")
+        .join(name);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+fn compile(name: &str) -> Journal {
+    let src = fixture(name);
+    let parser = doppio::parser::Parser {
+        // No-op opener: parity fixtures are self-contained, no `include`.
+        opener: |_: &str| Ok::<String, Box<dyn std::error::Error>>(String::new()),
+        base_path: PathBuf::new(),
+    };
+    doppio::compile(&src, parser).expect("compile failed")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Implemented features — must pass.
+// ──────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn transactions_basic() {
+    let j = compile("transactions_basic.ledger");
+    assert_eq!(j.transactions.len(), 1);
+    let t = &j.transactions[0];
+    assert_eq!(t.description, "Groceries");
+    assert_eq!(t.postings.len(), 2);
+    assert_eq!(t.postings[0].account, "Expenses:Food");
+    assert_eq!(t.postings[0].amount_in("$"), Some(dec!(50)));
+    // Null posting on Assets:Checking inferred as -$50.
+    assert_eq!(t.postings[1].account, "Assets:Checking");
+    assert_eq!(t.postings[1].amount_in("$"), Some(dec!(-50)));
+}
+
+#[test]
+fn multi_commodity() {
+    let j = compile("multi_commodity.ledger");
+    assert_eq!(j.transactions.len(), 1);
+    let t = &j.transactions[0];
+    assert_eq!(t.postings.len(), 2);
+    // Brokerage side: 10 AAPL.
+    assert_eq!(t.postings[0].account, "Assets:Brokerage");
+    assert_eq!(t.postings[0].amount_in("AAPL"), Some(dec!(10)));
+    // Cash side: -$1500. The transaction is balanced because the @ $150
+    // cost annotation contributes $1500 to the balance state.
+    assert_eq!(t.postings[1].account, "Assets:Cash");
+    assert_eq!(t.postings[1].amount_in("$"), Some(dec!(-1500)));
+}
+
+#[test]
+fn lot_pricing_unit() {
+    let j = compile("lot_pricing_unit.ledger");
+    assert_eq!(j.transactions.len(), 1);
+    let t = &j.transactions[0];
+    // 10 AAPL @ $150 → cash side null posting = -$1500.
+    assert_eq!(t.postings[0].amount_in("AAPL"), Some(dec!(10)));
+    assert_eq!(t.postings[1].amount_in("$"), Some(dec!(-1500)));
+}
+
+#[test]
+fn lot_pricing_total() {
+    let j = compile("lot_pricing_total.ledger");
+    assert_eq!(j.transactions.len(), 1);
+    let t = &j.transactions[0];
+    // 10 AAPL @@ $1500 → cash side null posting = -$1500.
+    assert_eq!(t.postings[0].amount_in("AAPL"), Some(dec!(10)));
+    assert_eq!(t.postings[1].amount_in("$"), Some(dec!(-1500)));
+}
+
+#[test]
+fn balance_assertion() {
+    // The fixture's `== $1000` assertion enforces during elaboration; if
+    // the assertion failed the compile would error. Reaching this assert
+    // means the assertion passed.
+    let j = compile("balance_assertion.ledger");
+    assert_eq!(j.transactions.len(), 1);
+    let t = &j.transactions[0];
+    assert_eq!(t.postings[0].amount_in("$"), Some(dec!(1000)));
+    assert_eq!(t.postings[1].amount_in("$"), Some(dec!(-1000)));
+}
+
+#[test]
+fn balance_assignment() {
+    // `Assets:Checking  = $1000` with no explicit amount: the elaborator
+    // computes (target - current_balance) = ($1000 - $0) = $1000.
+    let j = compile("balance_assignment.ledger");
+    let t = &j.transactions[0];
+    assert_eq!(t.postings[0].account, "Assets:Checking");
+    assert_eq!(t.postings[0].amount_in("$"), Some(dec!(1000)));
+    assert_eq!(t.postings[1].amount_in("$"), Some(dec!(-1000)));
+}
+
+#[test]
+fn account_assert() {
+    // The account block's `assert commodity == "$"` is enforced for every
+    // posting to Assets:Checking. The transaction's posting is in $, so
+    // the assertion passes and elaboration succeeds.
+    let j = compile("account_assert.ledger");
+    assert_eq!(j.transactions.len(), 1);
+    assert!(
+        j.accounts.contains_key("Assets:Checking"),
+        "account block should register Assets:Checking on the journal"
+    );
+}
+
+#[test]
+fn commodity_format() {
+    let j = compile("commodity_format.ledger");
+    let dollar = j.commodities.get("$").expect("$ commodity declared");
+    // The format is captured on the commodity entry. (Application of the
+    // format string is a render-time concern; here we just confirm
+    // elaboration preserves it.)
+    assert_eq!(dollar.format.as_deref(), Some("$1,000.00"));
+}
+
+#[test]
+fn tag_check() {
+    // `tag Statement / check value =~ /^foo/` — non-fatal warning if the
+    // regex fails. Here it matches, so elaboration completes silently.
+    let j = compile("tag_check.ledger");
+    assert_eq!(j.transactions.len(), 1);
+}
+
+#[test]
+fn define_param() {
+    let j = compile("define_param.ledger");
+    let t = &j.transactions[0];
+    // double($50) = $50 * 2 = $100.
+    let food = t
+        .postings
+        .iter()
+        .find(|p| p.account == "Expenses:Food")
+        .expect("food posting present");
+    assert_eq!(food.amount_in("$"), Some(dec!(100)));
+}
+
+#[test]
+fn historical_price_directive() {
+    let j = compile("historical_price_directive.ledger");
+    assert_eq!(j.prices.len(), 1, "one P directive parsed");
+    let p = &j.prices[0];
+    assert_eq!(p.commodity, "AAPL");
+    assert_eq!(p.price_commodity, "$");
+    assert_eq!(
+        p.price.as_ref().expect("price set").to_decimal(),
+        dec!(182.50)
+    );
+}
+
+#[test]
+fn metadata_inheritance() {
+    // Transaction-header metadata `Statement: foobar` is visible to the
+    // posting-level `tag()` lookup that the tag block's `assert` performs.
+    // Reaching this point with no error means the assertion passed.
+    let j = compile("metadata_inheritance.ledger");
+    assert_eq!(j.transactions.len(), 1);
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Not-yet-implemented features. Each `#[ignore]` references its tracking
+// issue. When the feature lands, remove the `#[ignore]` and replace the
+// panic with real assertions that consume the corresponding `lift the
+// fixture out of #[ignore]` task in the issue's acceptance criteria.
+// ──────────────────────────────────────────────────────────────────────────
+
+#[test]
+#[ignore = "tracks #139 — lot persistence {cost} not yet supported"]
+fn lot_persistence_cost() {
+    // When implemented: fixture should compile, and the brokerage posting's
+    // lot annotation should carry cost = $150. Schema change required —
+    // see #139 for the proto::Posting `lot` field.
+    panic!("feature unimplemented; tracks #139");
+}
+
+#[test]
+#[ignore = "tracks #139 — lot persistence [date] not yet supported"]
+fn lot_persistence_date() {
+    panic!("feature unimplemented; tracks #139");
+}
+
+#[test]
+#[ignore = "tracks #139 — lot persistence ((note)) not yet supported"]
+fn lot_persistence_note() {
+    panic!("feature unimplemented; tracks #139");
+}
+
+#[test]
+#[ignore = "tracks #140 — virtual postings (Account) not yet supported"]
+fn virtual_posting_unbalanced() {
+    // When implemented: posting kind = VirtualUnbalanced; the posting must
+    // be excluded from balance accounting (so the real postings must
+    // balance among themselves) and emitted in the elaborated journal with
+    // the kind preserved.
+    panic!("feature unimplemented; tracks #140");
+}
+
+#[test]
+#[ignore = "tracks #140 — virtual postings [Account] not yet supported"]
+fn virtual_posting_balanced() {
+    // When implemented: posting kind = VirtualBalanced; participates in
+    // the balance check but is flagged so `--real` filters can hide it.
+    panic!("feature unimplemented; tracks #140");
+}
+
+#[test]
+#[ignore = "tracks #141 — FX conversion via P directive not yet wired into reports"]
+fn fx_conversion_p_directive() {
+    // When implemented: `dop balance --exchange USD` (or the library
+    // helper) should consult the P chain to convert the EUR balance to
+    // its USD-equivalent at the as-of date. Today the P directive is
+    // stored but never consulted by reports.
+    panic!("feature unimplemented; tracks #141");
+}
+
+#[test]
+#[ignore = "tracks #142 — bare D directive not yet supported"]
+fn bare_d_directive() {
+    // When implemented: `D $1000.00` should lower to the same internal
+    // representation as `commodity $ ; default ; format $1,000.00`. The
+    // subsequent bare amount `50` should pick up `$` as its commodity.
+    panic!("feature unimplemented; tracks #142");
+}
+
+#[test]
+#[ignore = "tracks #143 — account alias sub-directive resolution incomplete"]
+fn account_alias_subdir() {
+    // When implemented: the posting's `Checking` should resolve to
+    // `Assets:Checking` in the elaborated journal. Today this resolution
+    // path may differ from the top-level `alias` directive, per the
+    // 🔧 Partial flag in docs/SUPPORTED_FEATURES.md.
+    panic!("feature unimplemented; tracks #143");
+}

--- a/crates/doppio/tests/parity.rs
+++ b/crates/doppio/tests/parity.rs
@@ -646,27 +646,129 @@ fn bare_d_directive() {
 }
 
 #[test]
-#[ignore = "tracks #143 — account alias sub-directive resolution incomplete"]
 fn account_alias_subdir() {
-    // Fixture: `account Assets:Checking / alias Checking`. A later posting
-    // written as `Checking` should resolve to `Assets:Checking` in the
-    // elaborated journal — same semantics as the top-level
-    // `alias Checking = Assets:Checking` form (covered by `top_level_alias`).
+    // The simplest case: `account Assets:Checking / alias Checking`,
+    // then a posting using `Checking` should resolve to `Assets:Checking`.
+    // This case turns out to work end-to-end through the parse → resolve
+    // → elaborate pipeline (PR #153 surfaced it). The `🔧 Partial` flag
+    // in SUPPORTED_FEATURES.md was left over from before the integration
+    // test corpus existed.
     let j = compile("account_alias_subdir.ledger");
     let t = &j.transactions[0];
-
-    // The alias resolves: posting's account is the canonical name.
     let checking = t
         .postings
         .iter()
         .find(|p| p.account == "Assets:Checking")
         .expect("alias `Checking` should resolve to `Assets:Checking`");
     assert_eq!(checking.amount_in("$"), Some(dec!(1000)));
-
-    // The unaliased name should NOT also appear.
     assert!(
         !t.postings.iter().any(|p| p.account == "Checking"),
-        "alias should resolve at parse/resolve time; unaliased `Checking` \
+        "alias should resolve at resolution time; unaliased `Checking` \
          must not appear in the elaborated journal"
+    );
+}
+
+#[test]
+fn account_alias_multiple_per_block() {
+    // An `account` block can carry multiple `alias` sub-directives; each
+    // should be added to the alias map and resolve independently.
+    let j = compile("account_alias_multiple_per_block.ledger");
+    assert_eq!(j.transactions.len(), 2);
+
+    // Both transactions' aliased postings should resolve to Assets:Checking.
+    let t0 = &j.transactions[0];
+    assert!(
+        t0.postings
+            .iter()
+            .any(|p| p.account == "Assets:Checking" && p.amount_in("$") == Some(dec!(100))),
+        "long alias `Checking` should resolve to Assets:Checking; got {:?}",
+        t0.postings.iter().map(|p| &p.account).collect::<Vec<_>>()
+    );
+    let t1 = &j.transactions[1];
+    assert!(
+        t1.postings
+            .iter()
+            .any(|p| p.account == "Assets:Checking" && p.amount_in("$") == Some(dec!(50))),
+        "short alias `C` should resolve to Assets:Checking; got {:?}",
+        t1.postings.iter().map(|p| &p.account).collect::<Vec<_>>()
+    );
+
+    // Neither raw alias name should appear in the elaborated journal.
+    for t in &j.transactions {
+        for p in &t.postings {
+            assert_ne!(p.account, "Checking", "alias `Checking` not resolved");
+            assert_ne!(p.account, "C", "alias `C` not resolved");
+        }
+    }
+}
+
+#[test]
+fn account_alias_across_blocks() {
+    // Two account blocks each declare their own alias. Both aliases must
+    // remain live after the second block is parsed, so a transaction that
+    // uses both resolves correctly.
+    let j = compile("account_alias_across_blocks.ledger");
+    let t = &j.transactions[0];
+
+    let checking = t
+        .postings
+        .iter()
+        .find(|p| p.account == "Assets:Checking")
+        .expect("Checking alias should resolve");
+    assert_eq!(checking.amount_in("$"), Some(dec!(-100)));
+
+    let savings = t
+        .postings
+        .iter()
+        .find(|p| p.account == "Assets:Savings")
+        .expect("Savings alias should resolve");
+    assert_eq!(savings.amount_in("$"), Some(dec!(100)));
+}
+
+#[test]
+fn account_alias_forward_only() {
+    // The alias affects entries declared AFTER the account block, not
+    // before. The pre-declaration posting keeps the literal `Checking`
+    // name; the post-declaration one resolves to `Assets:Checking`.
+    // (In ledger-cli the pre-declaration `Checking` is just a regular
+    // account name — there's no error, just no resolution.)
+    let j = compile("account_alias_forward_only.ledger");
+    assert_eq!(j.transactions.len(), 2);
+
+    // Pre-declaration: literal `Checking` is the elaborated account name.
+    let pre = &j.transactions[0];
+    assert!(
+        pre.postings.iter().any(|p| p.account == "Checking"),
+        "pre-declaration posting should keep literal `Checking` name; \
+         got {:?}",
+        pre.postings.iter().map(|p| &p.account).collect::<Vec<_>>()
+    );
+    assert!(
+        !pre.postings.iter().any(|p| p.account == "Assets:Checking"),
+        "alias must not retroactively apply"
+    );
+
+    // Post-declaration: `Checking` resolves to `Assets:Checking`.
+    let post = &j.transactions[1];
+    assert!(
+        post.postings.iter().any(|p| p.account == "Assets:Checking"),
+        "post-declaration posting should resolve via alias"
+    );
+}
+
+#[test]
+fn account_alias_inside_block_assert() {
+    // The same block carries both an `alias` and an `assert`. The assert
+    // is evaluated against postings that arrive via the alias — alias
+    // resolution must happen before the assert is applied so the
+    // assert sees the canonical account name (in this fixture, the
+    // assert checks `commodity == "$"`, which the aliased posting
+    // satisfies). Reaching elaboration without error means the assert
+    // fired against the resolved posting.
+    let j = compile("account_alias_inside_block_assert.ledger");
+    let t = &j.transactions[0];
+    assert!(
+        t.postings.iter().any(|p| p.account == "Assets:Checking"),
+        "alias should resolve and the assert should pass on the resolved posting"
     );
 }

--- a/crates/doppio/tests/parity.rs
+++ b/crates/doppio/tests/parity.rs
@@ -186,6 +186,277 @@ fn metadata_inheritance() {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
+// Date / state / code / amount-form coverage.
+// ──────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn date_formats() {
+    // Both `YYYY-MM-DD` and `YYYY/MM/DD` are accepted; the elaborated
+    // dates are the same i32-epoch-days values regardless of the source
+    // format.
+    let j = compile("date_formats.ledger");
+    assert_eq!(j.transactions.len(), 2);
+    assert_eq!(
+        j.transactions[0].date_naive(),
+        chrono::NaiveDate::from_ymd_opt(2024, 1, 15).unwrap()
+    );
+    assert_eq!(
+        j.transactions[1].date_naive(),
+        chrono::NaiveDate::from_ymd_opt(2024, 2, 20).unwrap()
+    );
+}
+
+#[test]
+fn secondary_date() {
+    let j = compile("secondary_date.ledger");
+    let t = &j.transactions[0];
+    assert_eq!(
+        t.date_naive(),
+        chrono::NaiveDate::from_ymd_opt(2024, 1, 15).unwrap()
+    );
+    assert_eq!(
+        t.secondary_date_naive(),
+        Some(chrono::NaiveDate::from_ymd_opt(2024, 1, 20).unwrap())
+    );
+}
+
+#[test]
+fn transaction_state() {
+    use doppio::elaboration::TransactionState;
+    let j = compile("transaction_state.ledger");
+    assert_eq!(j.transactions.len(), 3);
+    assert_eq!(j.transactions[0].state, TransactionState::Cleared as i32);
+    assert_eq!(j.transactions[1].state, TransactionState::Pending as i32);
+    assert_eq!(j.transactions[2].state, TransactionState::Uncleared as i32);
+}
+
+#[test]
+fn transaction_code() {
+    let j = compile("transaction_code.ledger");
+    let t = &j.transactions[0];
+    assert_eq!(t.code.as_deref(), Some("INV-042"));
+    assert_eq!(t.description, "Invoice paid");
+}
+
+#[test]
+fn amount_forms() {
+    let j = compile("amount_forms.ledger");
+    assert_eq!(j.transactions.len(), 5);
+    // Symbol-first positive: $100
+    assert_eq!(
+        j.transactions[0].postings[0].amount_in("$"),
+        Some(dec!(100))
+    );
+    // Symbol-first leading minus: -$100
+    assert_eq!(
+        j.transactions[1].postings[0].amount_in("$"),
+        Some(dec!(-100))
+    );
+    // Symbol-first inside minus: $-100
+    assert_eq!(
+        j.transactions[2].postings[0].amount_in("$"),
+        Some(dec!(-100))
+    );
+    // Number-first positive: 100 USD
+    assert_eq!(
+        j.transactions[3].postings[0].amount_in("USD"),
+        Some(dec!(100))
+    );
+    // Number-first negative: -100 USD
+    assert_eq!(
+        j.transactions[4].postings[0].amount_in("USD"),
+        Some(dec!(-100))
+    );
+}
+
+#[test]
+fn posting_state() {
+    use doppio::elaboration::TransactionState;
+    let j = compile("posting_state.ledger");
+    let postings = &j.transactions[0].postings;
+    assert_eq!(postings.len(), 3);
+    assert_eq!(postings[0].state, TransactionState::Cleared as i32);
+    assert_eq!(postings[1].state, TransactionState::Pending as i32);
+    // The null posting (the third one, no explicit marker) inherits the
+    // transaction's state, which is Uncleared by default.
+    assert_eq!(postings[2].state, TransactionState::Uncleared as i32);
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Comments / metadata / tags.
+// ──────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn transaction_notes() {
+    // Header-level metadata + posting-level metadata both survive
+    // elaboration. The `KeyA: ValueA` becomes a metadata entry on the
+    // transaction; `KeyB: ValueB` on the posting.
+    let j = compile("transaction_notes.ledger");
+    let t = &j.transactions[0];
+    assert_eq!(t.metadata.get("KeyA").map(String::as_str), Some("ValueA"));
+    let food = t
+        .postings
+        .iter()
+        .find(|p| p.account == "Expenses:Food")
+        .expect("food posting present");
+    assert_eq!(
+        food.metadata.get("KeyB").map(String::as_str),
+        Some("ValueB")
+    );
+}
+
+#[test]
+fn bare_tag_list() {
+    // The `; :urgent:reviewed:` line appears in the transaction-header
+    // position (above any posting), so the tags attach to the
+    // transaction, not to a specific posting.
+    let j = compile("bare_tag_list.ledger");
+    let t = &j.transactions[0];
+    assert!(
+        t.tags.iter().any(|s| s == "urgent"),
+        "expected `urgent` tag on transaction, got {:?}",
+        t.tags
+    );
+    assert!(
+        t.tags.iter().any(|s| s == "reviewed"),
+        "expected `reviewed` tag on transaction, got {:?}",
+        t.tags
+    );
+}
+
+#[test]
+fn comment_chars() {
+    // Top-level lines starting with ; # * % | are full-line comments.
+    // Only the one real transaction in the fixture should make it into
+    // the elaborated journal.
+    let j = compile("comment_chars.ledger");
+    assert_eq!(j.transactions.len(), 1);
+    assert_eq!(j.transactions[0].description, "Real transaction");
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Directive completeness.
+// ──────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn account_check() {
+    // Non-fatal `check` (vs the fatal `assert`). The fixture's commodity
+    // matches, so no warning is emitted, but even on a failing check
+    // elaboration would still complete.
+    let j = compile("account_check.ledger");
+    assert_eq!(j.transactions.len(), 1);
+    assert!(j.accounts.contains_key("Assets:Checking"));
+}
+
+#[test]
+fn account_note() {
+    let j = compile("account_note.ledger");
+    let brokerage = j
+        .accounts
+        .get("Assets:Brokerage")
+        .expect("account block declared");
+    assert_eq!(brokerage.note.as_deref(), Some("Schwab #1234"));
+}
+
+#[test]
+fn commodity_default() {
+    // After `commodity $ ; default`, a bare `100` should pick up `$`.
+    let j = compile("commodity_default.ledger");
+    let t = &j.transactions[0];
+    let food = &t.postings[0];
+    assert_eq!(food.amount_in("$"), Some(dec!(100)));
+}
+
+#[test]
+fn top_level_alias() {
+    // `alias Checking = Assets:Checking` — postings using `Checking`
+    // resolve to the canonical `Assets:Checking` in the elaborated
+    // journal.
+    let j = compile("top_level_alias.ledger");
+    let t = &j.transactions[0];
+    let checking = t
+        .postings
+        .iter()
+        .find(|p| p.account == "Assets:Checking")
+        .expect("alias should resolve to Assets:Checking");
+    assert_eq!(checking.amount_in("$"), Some(dec!(1000)));
+}
+
+#[test]
+fn standalone_balance_assertion() {
+    // `<date> = <account>  <amount>` — passes if the running balance at
+    // that point matches. Reaching elaboration without error means the
+    // assertion passed.
+    let j = compile("standalone_balance_assertion.ledger");
+    assert_eq!(j.transactions.len(), 1);
+}
+
+#[test]
+fn define_zero_arg() {
+    // `define monthly_rent = $1500.00` — body substituted at use site.
+    let j = compile("define_zero_arg.ledger");
+    let rent = j.transactions[0]
+        .postings
+        .iter()
+        .find(|p| p.account == "Expenses:Rent")
+        .expect("rent posting present");
+    assert_eq!(rent.amount_in("$"), Some(dec!(1500.00)));
+}
+
+#[test]
+fn budget_directive() {
+    // `~` budget directives parse but are intentionally not elaborated;
+    // the surrounding journal still elaborates as if the budget weren't
+    // there. Only the real 2024-01-01 transaction should appear.
+    let j = compile("budget_directive.ledger");
+    assert_eq!(
+        j.transactions.len(),
+        1,
+        "budget directive should not produce an elaborated transaction"
+    );
+    assert_eq!(j.transactions[0].description, "Real spending");
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Expressions.
+// ──────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn regex_match() {
+    // `assert account =~ /^Expenses:/` in an account block. The posting
+    // matches, so elaboration succeeds.
+    let j = compile("regex_match.ledger");
+    assert_eq!(j.transactions.len(), 1);
+}
+
+#[test]
+fn arithmetic_expression() {
+    // `($30 + $20)` should evaluate to $50.
+    let j = compile("arithmetic_expression.ledger");
+    let food = j.transactions[0]
+        .postings
+        .iter()
+        .find(|p| p.account == "Expenses:Food")
+        .expect("food posting present");
+    assert_eq!(food.amount_in("$"), Some(dec!(50)));
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Multi-transaction state.
+// ──────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn running_balance() {
+    // Three transactions accumulate $1400 in Assets:Checking; the
+    // standalone balance assertion at month-end confirms the running
+    // total. Exercises the elaborator's per-account balance bookkeeping
+    // across multiple entries.
+    let j = compile("running_balance.ledger");
+    assert_eq!(j.transactions.len(), 3);
+    // The fourth entry is the standalone assertion, not a transaction.
+}
+
+// ──────────────────────────────────────────────────────────────────────────
 // Not-yet-implemented features. Each `#[ignore]` references its tracking
 // issue. When the feature lands, remove the `#[ignore]` and replace the
 // panic with real assertions that consume the corresponding `lift the

--- a/crates/doppio/tests/parity/fixtures/account_alias_across_blocks.ledger
+++ b/crates/doppio/tests/parity/fixtures/account_alias_across_blocks.ledger
@@ -1,0 +1,12 @@
+; Two `account` blocks each declare their own alias. Both aliases
+; should resolve in postings after BOTH blocks have been declared
+; (ordering interaction).
+account Assets:Checking
+    alias Checking
+
+account Assets:Savings
+    alias Savings
+
+2024-01-01 Transfer
+    Checking      $-100
+    Savings       $100

--- a/crates/doppio/tests/parity/fixtures/account_alias_forward_only.ledger
+++ b/crates/doppio/tests/parity/fixtures/account_alias_forward_only.ledger
@@ -1,0 +1,15 @@
+; Aliases must apply forward-only. A posting that uses `Checking`
+; BEFORE the alias declaration should keep the literal `Checking`
+; name (or fail-to-balance, depending on whether the elaborator treats
+; it as an unknown account). After the alias declaration, postings
+; using `Checking` resolve to `Assets:Checking`.
+2024-01-01 Pre-declaration use
+    Checking      $100
+    Equity:Opening
+
+account Assets:Checking
+    alias Checking
+
+2024-01-02 Post-declaration use
+    Checking      $200
+    Equity:Opening

--- a/crates/doppio/tests/parity/fixtures/account_alias_inside_block_assert.ledger
+++ b/crates/doppio/tests/parity/fixtures/account_alias_inside_block_assert.ledger
@@ -1,0 +1,11 @@
+; The `account` block declares an alias AND an assert in the same block.
+; The assert is evaluated against postings that arrive via the alias —
+; the alias resolution must run before the assert is applied so the
+; assert sees the canonical account name.
+account Assets:Checking
+    alias Checking
+    assert commodity == "$"
+
+2024-01-01 Deposit via alias
+    Checking      $100
+    Equity:Opening

--- a/crates/doppio/tests/parity/fixtures/account_alias_multiple_per_block.ledger
+++ b/crates/doppio/tests/parity/fixtures/account_alias_multiple_per_block.ledger
@@ -1,0 +1,13 @@
+; An `account` block can carry multiple `alias` sub-directives. All
+; aliases should resolve to the same canonical account name.
+account Assets:Checking
+    alias Checking
+    alias C
+
+2024-01-01 Use the long alias
+    Checking      $100
+    Equity:Opening
+
+2024-01-02 Use the short alias
+    C             $50
+    Equity:Opening

--- a/crates/doppio/tests/parity/fixtures/account_alias_subdir.ledger
+++ b/crates/doppio/tests/parity/fixtures/account_alias_subdir.ledger
@@ -1,0 +1,9 @@
+; account block with an `alias` sub-directive. Should let `Checking` resolve
+; to `Assets:Checking` everywhere a posting references it, the same way
+; the top-level `alias Checking = Assets:Checking` does. Tracks #143.
+account Assets:Checking
+    alias Checking
+
+2024-01-15 Deposit
+    Checking      $1000
+    Equity:Opening

--- a/crates/doppio/tests/parity/fixtures/account_assert.ledger
+++ b/crates/doppio/tests/parity/fixtures/account_assert.ledger
@@ -1,0 +1,9 @@
+; account block with an `assert` sub-directive. Every posting to the named
+; account is checked against the expression. Here: every Assets:Checking
+; posting must be in $.
+account Assets:Checking
+    assert commodity == "$"
+
+2024-01-01 Deposit
+    Assets:Checking  $500.00
+    Income:Salary

--- a/crates/doppio/tests/parity/fixtures/account_check.ledger
+++ b/crates/doppio/tests/parity/fixtures/account_check.ledger
@@ -1,0 +1,9 @@
+; account block with a `check` sub-directive. Non-fatal: prints a stderr
+; warning if the expression is false but lets elaboration continue. Here
+; the posting's commodity is `$`, so the check passes silently.
+account Assets:Checking
+    check commodity == "$"
+
+2024-01-01 Deposit
+    Assets:Checking  $500.00
+    Income:Salary

--- a/crates/doppio/tests/parity/fixtures/account_note.ledger
+++ b/crates/doppio/tests/parity/fixtures/account_note.ledger
@@ -1,0 +1,8 @@
+; account block with a `note` sub-directive. The note text is captured on
+; the journal's `accounts[name].note` field.
+account Assets:Brokerage
+    note Schwab #1234
+
+2024-01-01 Initial deposit
+    Assets:Brokerage   $1000
+    Equity:Opening

--- a/crates/doppio/tests/parity/fixtures/amount_forms.ledger
+++ b/crates/doppio/tests/parity/fixtures/amount_forms.ledger
@@ -1,0 +1,23 @@
+; Various amount syntaxes. Each line is a separate transaction.
+; Order/sign variants:
+;   - symbol-first: $100, -$100, $-100
+;   - number-first: 100 USD, -100 USD
+2024-01-01 Symbol-first positive
+    Expenses:A      $100
+    Assets:Cash
+
+2024-01-02 Symbol-first negative leading minus
+    Income:A       -$100
+    Assets:Cash
+
+2024-01-03 Symbol-first negative inside
+    Income:B       $-100
+    Assets:Cash
+
+2024-01-04 Number-first positive
+    Expenses:C      100 USD
+    Assets:Cash
+
+2024-01-05 Number-first negative
+    Income:D       -100 USD
+    Assets:Cash

--- a/crates/doppio/tests/parity/fixtures/arithmetic_expression.ledger
+++ b/crates/doppio/tests/parity/fixtures/arithmetic_expression.ledger
@@ -1,0 +1,6 @@
+; Arithmetic in posting amounts via the Pratt parser. `$30 + $20` should
+; evaluate to $50 in the elaborated journal — the elaborator carries the
+; commodity through the addition since both operands are in `$`.
+2024-01-15 Combined receipt
+    Expenses:Food   $30 + $20
+    Assets:Cash

--- a/crates/doppio/tests/parity/fixtures/balance_assertion.ledger
+++ b/crates/doppio/tests/parity/fixtures/balance_assertion.ledger
@@ -1,0 +1,6 @@
+; Posting-level balance assertion. The "= $1000" expects the running balance
+; of Assets:Checking to equal $1000 after this posting; "== $1000" is the
+; strict (all-commodity) form.
+2024-01-15 Opening
+    Assets:Checking   $1000 == $1000
+    Equity:Opening

--- a/crates/doppio/tests/parity/fixtures/balance_assignment.ledger
+++ b/crates/doppio/tests/parity/fixtures/balance_assignment.ledger
@@ -1,0 +1,8 @@
+; Balance assignment: "= $1000" with no preceding amount. The elaborator
+; computes the posting amount as (target - current_balance).
+;
+; Starting balance: 0. After this posting, Assets:Checking must equal $1000,
+; so the inferred amount is $1000.
+2024-01-15 Opening
+    Assets:Checking  = $1000
+    Equity:Opening

--- a/crates/doppio/tests/parity/fixtures/bare_d_directive.ledger
+++ b/crates/doppio/tests/parity/fixtures/bare_d_directive.ledger
@@ -1,0 +1,8 @@
+; Bare `D` directive: declares the default commodity AND its display format.
+; Equivalent to `commodity $ ; default ; format $1,000.00`. The bare form
+; is older but still appears in journals in the wild. Tracks #142.
+D $1000.00
+
+2024-01-15 Test
+    Expenses:Food   50
+    Assets:Checking

--- a/crates/doppio/tests/parity/fixtures/bare_tag_list.ledger
+++ b/crates/doppio/tests/parity/fixtures/bare_tag_list.ledger
@@ -1,0 +1,6 @@
+; Bare-tag-list note: `; :tag1:tag2:` populates the carrier's `tags` field
+; rather than `metadata`. Each colon-delimited token becomes a tag.
+2024-01-15 Test
+    ; :urgent:reviewed:
+    Expenses:Food   $10
+    Assets:Cash

--- a/crates/doppio/tests/parity/fixtures/budget_directive.ledger
+++ b/crates/doppio/tests/parity/fixtures/budget_directive.ledger
@@ -1,0 +1,12 @@
+; `~` budget directive. Per docs/SUPPORTED_FEATURES.md it's parsed but
+; intentionally not elaborated — the budget transaction has no effect
+; on real balances. The budget keyword must be one of yearly | monthly
+; | weekly. Sanity check that journals containing budget directives
+; compile without error.
+~ monthly
+    Expenses:Food   $400
+    Assets:Budget
+
+2024-01-01 Real spending
+    Expenses:Food   $50
+    Assets:Cash

--- a/crates/doppio/tests/parity/fixtures/comment_chars.ledger
+++ b/crates/doppio/tests/parity/fixtures/comment_chars.ledger
@@ -1,0 +1,10 @@
+; Top-level full-line comments accept any of: ; # * % |
+; This file mixes all of them; only the transaction below should make it
+; into the elaborated journal.
+# this is also a comment
+* and so is this
+% and this
+| and this
+2024-01-15 Real transaction
+    Expenses:Food   $10
+    Assets:Cash

--- a/crates/doppio/tests/parity/fixtures/commodity_default.ledger
+++ b/crates/doppio/tests/parity/fixtures/commodity_default.ledger
@@ -1,0 +1,9 @@
+; commodity block with `default` sub-directive declares the default
+; commodity for bare amounts (those without a symbol or unit). After
+; this directive, `100` should be treated as `$100`.
+commodity $
+    default
+
+2024-01-01 Bare amount uses default commodity
+    Expenses:Food   100
+    Assets:Cash

--- a/crates/doppio/tests/parity/fixtures/commodity_format.ledger
+++ b/crates/doppio/tests/parity/fixtures/commodity_format.ledger
@@ -1,0 +1,10 @@
+; commodity block declaring a display format. The format is applied at
+; render time (balance / register output); elaboration just stores the
+; declared format on the journal's `commodities` map.
+commodity $
+    format $1,000.00
+    note US dollar
+
+2024-01-15 Test
+    Expenses:Food   $50
+    Assets:Checking

--- a/crates/doppio/tests/parity/fixtures/date_formats.ledger
+++ b/crates/doppio/tests/parity/fixtures/date_formats.ledger
@@ -1,0 +1,8 @@
+; Both YYYY-MM-DD and YYYY/MM/DD are accepted by the ledger frontend.
+2024-01-15 First with dashes
+    Expenses:Food   $10
+    Assets:Cash
+
+2024/02/20 Second with slashes
+    Expenses:Food   $20
+    Assets:Cash

--- a/crates/doppio/tests/parity/fixtures/define_param.ledger
+++ b/crates/doppio/tests/parity/fixtures/define_param.ledger
@@ -1,0 +1,8 @@
+; Parameterised `define`. The function is expanded at expression-evaluation
+; time. Calling `double($50)` returns `$100`; the commodity flows through
+; the multiplication.
+define double(x) = x * 2
+
+2024-01-01 Sale
+    Expenses:Food   double($50)
+    Assets:Cash

--- a/crates/doppio/tests/parity/fixtures/define_zero_arg.ledger
+++ b/crates/doppio/tests/parity/fixtures/define_zero_arg.ledger
@@ -1,0 +1,7 @@
+; Zero-arg `define` is a value alias — the body is substituted at use sites.
+; Useful for centralising recurring magic numbers like rent, tax rate, etc.
+define monthly_rent = $1500.00
+
+2024-01-01 Rent payment
+    Expenses:Rent   monthly_rent
+    Assets:Checking

--- a/crates/doppio/tests/parity/fixtures/fx_conversion_p_directive.ledger
+++ b/crates/doppio/tests/parity/fixtures/fx_conversion_p_directive.ledger
@@ -1,0 +1,9 @@
+; FX conversion via `P` directive consumption in balance reports. The
+; directive is stored on the journal today (see historical_price_directive.ledger);
+; what's missing is `dop balance --exchange USD` actually consulting the
+; price chain to convert other-commodity balances. Tracks #141.
+P 2024-01-01 EUR $1.10
+
+2024-01-15 Cross-currency expense
+    Expenses:Travel   100 EUR
+    Assets:Checking

--- a/crates/doppio/tests/parity/fixtures/historical_price_directive.ledger
+++ b/crates/doppio/tests/parity/fixtures/historical_price_directive.ledger
@@ -1,0 +1,9 @@
+; `P` directive: record the market price of AAPL on a given date. Stored on
+; the elaborated journal's `prices` field. FX conversion using these prices
+; is not yet wired into balance/register reports — that's tracked separately
+; (see #141 / Phase D parity gaps).
+P 2024-06-15 AAPL $182.50
+
+2024-06-15 Mark to market (no-op transaction; price is the directive)
+    Expenses:Trivial   $1
+    Assets:Cash

--- a/crates/doppio/tests/parity/fixtures/lot_persistence_cost.ledger
+++ b/crates/doppio/tests/parity/fixtures/lot_persistence_cost.ledger
@@ -1,0 +1,5 @@
+; Lot persistence: `{cost}` pins the per-unit cost basis to the lot so future
+; sales can identify which lot they're closing. Tracks #139.
+2024-03-01 Buy AAPL
+    Assets:Brokerage   10 AAPL {$150} @ $155
+    Assets:Cash

--- a/crates/doppio/tests/parity/fixtures/lot_persistence_date.ledger
+++ b/crates/doppio/tests/parity/fixtures/lot_persistence_date.ledger
@@ -1,0 +1,4 @@
+; Lot persistence: `[date]` pins the acquisition date to the lot. Tracks #139.
+2024-03-01 Buy AAPL
+    Assets:Brokerage   10 AAPL {$150} [2024-03-01]
+    Assets:Cash

--- a/crates/doppio/tests/parity/fixtures/lot_persistence_note.ledger
+++ b/crates/doppio/tests/parity/fixtures/lot_persistence_note.ledger
@@ -1,0 +1,4 @@
+; Lot persistence: `((note))` pins a free-form note to the lot. Tracks #139.
+2024-03-01 Buy AAPL
+    Assets:Brokerage   10 AAPL {$150} ((BUY-2024-01))
+    Assets:Cash

--- a/crates/doppio/tests/parity/fixtures/lot_pricing_total.ledger
+++ b/crates/doppio/tests/parity/fixtures/lot_pricing_total.ledger
@@ -1,0 +1,4 @@
+; Total lot pricing: total cost = literal total (does not depend on quantity).
+2024-03-01 Buy AAPL
+    Assets:Brokerage   10 AAPL @@ $1500
+    Assets:Cash

--- a/crates/doppio/tests/parity/fixtures/lot_pricing_unit.ledger
+++ b/crates/doppio/tests/parity/fixtures/lot_pricing_unit.ledger
@@ -1,0 +1,5 @@
+; Per-unit lot pricing: total cost = quantity * unit_price.
+; The cash side null posting is filled in as -$1500 by the elaborator.
+2024-03-01 Buy AAPL
+    Assets:Brokerage   10 AAPL @ $150
+    Assets:Cash

--- a/crates/doppio/tests/parity/fixtures/metadata_inheritance.ledger
+++ b/crates/doppio/tests/parity/fixtures/metadata_inheritance.ledger
@@ -1,0 +1,10 @@
+; Transaction-header metadata is visible to posting-level `tag()` lookups.
+; Here, the `Statement: foobar` is declared on the transaction header but
+; the tag block validates it via the `tag()` value binding.
+tag Statement
+    assert value =~ /^foo/
+
+2024-01-01 Test
+    ; Statement: foobar
+    Expenses:Food  $10.00
+    Assets:Checking

--- a/crates/doppio/tests/parity/fixtures/multi_commodity.ledger
+++ b/crates/doppio/tests/parity/fixtures/multi_commodity.ledger
@@ -1,0 +1,5 @@
+; Two postings in different commodities, with an explicit cost annotation
+; making the transaction balance: 10 AAPL on one side, $-1500 on the other.
+2024-03-01 Buy AAPL
+    Assets:Brokerage   10 AAPL @ $150
+    Assets:Cash       $-1500

--- a/crates/doppio/tests/parity/fixtures/posting_state.ledger
+++ b/crates/doppio/tests/parity/fixtures/posting_state.ledger
@@ -1,0 +1,6 @@
+; Per-posting state markers — each posting can independently be cleared
+; (`*`) or pending (`!`). Useful when reconciling part of a transaction.
+2024-01-15 Mixed posting states
+    * Expenses:Food    $10
+    ! Expenses:Tax     $1
+    Assets:Cash

--- a/crates/doppio/tests/parity/fixtures/regex_match.ledger
+++ b/crates/doppio/tests/parity/fixtures/regex_match.ledger
@@ -1,0 +1,11 @@
+; `=~` (match) and `!~` (not-match) operators in account-block asserts.
+; The fixture asserts the posting's commodity matches `^[$]$` (i.e., is `$`)
+; and does NOT match `^EUR$`. Reaching elaboration without error means
+; both expressions evaluated correctly.
+account Expenses:Food
+    assert commodity =~ /^[$]$/
+    check  commodity !~ /^EUR$/
+
+2024-01-01 Lunch
+    Expenses:Food   $10.00
+    Assets:Cash

--- a/crates/doppio/tests/parity/fixtures/running_balance.ledger
+++ b/crates/doppio/tests/parity/fixtures/running_balance.ledger
@@ -1,0 +1,16 @@
+; Multi-transaction running balance accumulation, terminated by a
+; standalone balance assertion that exercises the elaborator's
+; per-account balance bookkeeping across multiple entries.
+2024-01-01 First deposit
+    Assets:Checking   $1000
+    Equity:Opening
+
+2024-01-15 Second deposit
+    Assets:Checking   $500
+    Equity:Opening
+
+2024-01-20 Withdrawal
+    Expenses:Food     $100
+    Assets:Checking
+
+2024-01-31 = Assets:Checking  $1400

--- a/crates/doppio/tests/parity/fixtures/secondary_date.ledger
+++ b/crates/doppio/tests/parity/fixtures/secondary_date.ledger
@@ -1,0 +1,5 @@
+; Secondary date (effective date) follows the primary with `=`. Stored on
+; the elaborated transaction's `secondary_date` field.
+2024-01-15=2024-01-20 Trade
+    Expenses:Food   $50
+    Assets:Cash

--- a/crates/doppio/tests/parity/fixtures/standalone_balance_assertion.ledger
+++ b/crates/doppio/tests/parity/fixtures/standalone_balance_assertion.ledger
@@ -1,0 +1,9 @@
+; Standalone balance-assertion directive: `<date> = <account>  <amount>`.
+; Asserts the account's running balance at this point in the journal
+; equals the amount. Reaching elaboration without error means the
+; assertion passed.
+2024-01-15 Opening
+    Assets:Checking  $1000
+    Equity:Opening
+
+2024-01-31 = Assets:Checking  $1000

--- a/crates/doppio/tests/parity/fixtures/tag_check.ledger
+++ b/crates/doppio/tests/parity/fixtures/tag_check.ledger
@@ -1,0 +1,10 @@
+; tag block with a `check` sub-directive. Non-fatal: prints a warning but
+; lets elaboration continue. The transaction's metadata "Statement: foobar"
+; matches the regex.
+tag Statement
+    check value =~ /^foo/
+
+2024-01-01 Test
+    ; Statement: foobar
+    Expenses:Food  $10.00
+    Assets:Checking

--- a/crates/doppio/tests/parity/fixtures/top_level_alias.ledger
+++ b/crates/doppio/tests/parity/fixtures/top_level_alias.ledger
@@ -1,0 +1,7 @@
+; Top-level `alias short = long`. The short form resolves to the long
+; canonical name everywhere a posting references it.
+alias Checking = Assets:Checking
+
+2024-01-15 Deposit via alias
+    Checking        $1000
+    Equity:Opening

--- a/crates/doppio/tests/parity/fixtures/transaction_code.ledger
+++ b/crates/doppio/tests/parity/fixtures/transaction_code.ledger
@@ -1,0 +1,6 @@
+; Optional reference code in parentheses immediately after the date /
+; state marker. Stored on the elaborated transaction's `code` field
+; (parens stripped).
+2024-01-15 * (INV-042) Invoice paid
+    Income:Sales       $-200
+    Assets:Checking

--- a/crates/doppio/tests/parity/fixtures/transaction_notes.ledger
+++ b/crates/doppio/tests/parity/fixtures/transaction_notes.ledger
@@ -1,0 +1,11 @@
+; Notes attach to either the transaction header (indented `;` lines under
+; the header) or to a posting (indented `;` lines under a posting). Both
+; survive elaboration as metadata / comments on the carrier.
+2024-01-15 Groceries
+    ; A header-level note
+    ; Another header-level note
+    ; KeyA: ValueA
+    Expenses:Food   $50
+        ; A posting-level note
+        ; KeyB: ValueB
+    Assets:Checking

--- a/crates/doppio/tests/parity/fixtures/transaction_state.ledger
+++ b/crates/doppio/tests/parity/fixtures/transaction_state.ledger
@@ -1,0 +1,13 @@
+; Transaction-level state markers `*` (cleared) and `!` (pending). The
+; uncleared default has no marker. Three transactions, one of each.
+2024-01-01 * Cleared
+    Expenses:Food   $10
+    Assets:Cash
+
+2024-01-02 ! Pending
+    Expenses:Food   $20
+    Assets:Cash
+
+2024-01-03 Uncleared
+    Expenses:Food   $30
+    Assets:Cash

--- a/crates/doppio/tests/parity/fixtures/transactions_basic.ledger
+++ b/crates/doppio/tests/parity/fixtures/transactions_basic.ledger
@@ -1,0 +1,4 @@
+; Smallest possible transaction with a null posting.
+2024-01-15 Groceries
+    Expenses:Food   $50
+    Assets:Checking

--- a/crates/doppio/tests/parity/fixtures/virtual_posting_balanced.ledger
+++ b/crates/doppio/tests/parity/fixtures/virtual_posting_balanced.ledger
@@ -1,0 +1,7 @@
+; Virtual balanced posting: brackets around the account name. The posting
+; DOES participate in the balance check, but is flagged so reports can
+; include or exclude it via `--real`. Tracks #140.
+2024-01-15 Setup
+    Assets:Checking          $100
+    [Equity:Reservations]    $25
+    Equity:Opening          $-125

--- a/crates/doppio/tests/parity/fixtures/virtual_posting_unbalanced.ledger
+++ b/crates/doppio/tests/parity/fixtures/virtual_posting_unbalanced.ledger
@@ -1,0 +1,7 @@
+; Virtual unbalanced posting: parens around the account name. The posting
+; does NOT participate in the transaction's balance check, so the
+; "real" postings must balance among themselves. Tracks #140.
+2024-01-15 Setup
+    Assets:Checking         $100
+    Equity:Opening         $-100
+    (Equity:Reservations)   $-25

--- a/docs/SUPPORTED_FEATURES.md
+++ b/docs/SUPPORTED_FEATURES.md
@@ -63,7 +63,7 @@ Status legend:
 | `account` + `note` sub-directive | ✅ | |
 | `account` + `assert <expr>` | ✅ | v0.2.0 (PR #76). Fatal: posting whose elaboration fails an account-level assert halts the run with `ElaborationError::AccountAssertionFailed` |
 | `account` + `check <expr>` | ✅ | v0.2.0 (PR #76). Non-fatal: prints a warning to stderr and continues |
-| `account` + `alias` sub-directive | 🔧 | Parsed; alias resolution may be incomplete in some HIR paths |
+| `account` + `alias` sub-directive | ✅ | Resolves through the parse → resolve → elaborate pipeline; covered by `tests/parity/account_alias_*.ledger` (single, multiple-per-block, across-blocks, with-assert, forward-only) |
 | `commodity SYMBOL` block | ✅ | |
 | `commodity` + `format` sub-directive | ✅ | v0.2.0 (PR #84). Drives `balance` and `register` rendering (prefix/suffix, thousands separator, decimal places, sign) |
 | `commodity` + `default` sub-directive | ✅ | v0.2.0. Equivalent to a `D` directive |

--- a/docs/SUPPORTED_FEATURES.md
+++ b/docs/SUPPORTED_FEATURES.md
@@ -1,10 +1,17 @@
 # doppio: Supported Ledger features
 
-**Last updated**: 2026-04-26 (doppio v0.3.0)
+**Last updated**: 2026-04-29 (doppio v0.4.0-rc.1)
 
 This document is a feature-by-feature comparison of doppio's syntax surface
 against [ledger-cli](https://ledger-cli.org/) and [hledger](https://hledger.org/).
 The authoritative behaviour is the test suite — this matrix is a navigation aid.
+
+The companion **parity test corpus** at
+[`crates/doppio/tests/parity/`](../crates/doppio/tests/parity/) carries one
+minimal `.ledger` fixture per feature plus a Rust harness asserting on the
+elaborated `Journal`. Tests for not-yet-implemented features are
+`#[ignore]`'d with a tracking-issue reference, so the ignored count stays a
+visible signal of the remaining parity work toward 1.0 (Phase D).
 
 Status legend:
 


### PR DESCRIPTION
## Summary

Implements the Phase D parity test scaffold from #138. New
`crates/doppio/tests/parity/` directory with one minimal `.ledger`
fixture per feature plus a Rust harness that compiles each via
`doppio::compile()` and asserts properties of the resulting
`elaboration::Journal`.

The point isn't unit testing — those live next to the code. The point
is a feature-by-feature corpus you can read top-to-bottom to see what
doppio claims to support, what it actually supports, and what's on
deck. Tests for **implemented** features must pass. Tests for
**not-yet-implemented** features start `#[ignore]`'d with their
tracking-issue number, so the ignored count stays a visible signal of
remaining Phase D parity work.

## What's in the corpus

**Implemented (12 passing tests):**

| Fixture | Asserts |
|---|---|
| `transactions_basic` | null posting inferred to `-$50` |
| `multi_commodity` | `10 AAPL @ \$150` balances against `\$-1500` |
| `lot_pricing_unit` / `lot_pricing_total` | `@` and `@@` produce identical cash-side amounts |
| `balance_assertion` | `== \$1000` enforced during elaboration |
| `balance_assignment` | `= \$1000` infers posting amount |
| `account_assert` | `account` block + `assert commodity == "\$"` enforced |
| `commodity_format` | `format \$1,000.00` survives elaboration |
| `tag_check` | `tag` block + `check value =~ /^foo/` |
| `define_param` | `double(\$50) = \$100` via `define double(x) = x * 2` |
| `historical_price_directive` | `P 2024-06-15 AAPL \$182.50` lands on `journal.prices` |
| `metadata_inheritance` | txn-header metadata visible to posting `tag()` |

**Not-yet-implemented (8 ignored tests):**

| Fixture | Tracks |
|---|---|
| `lot_persistence_cost` / `_date` / `_note` | #139 |
| `virtual_posting_unbalanced` / `_balanced` | #140 |
| `fx_conversion_p_directive` | #141 |
| `bare_d_directive` | #142 |
| `account_alias_subdir` | #143 |

Each subsequent Phase D issue's acceptance criteria includes lifting
its corresponding fixture out of `#[ignore]` and filling in real
assertions.

## Why ship this first

Every Phase D gap-fill PR now has a near-trivial test case to land
against — pull the fixture out of `#[ignore]` and fill in the
assertions. The harness is the contract; the issues fill it in.

## Test plan

- [x] `cargo test -p doppio --test parity` — 12 passed, 8 ignored
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo bench --no-run --workspace`
- [x] `cargo build --target wasm32-unknown-unknown -p doppio --lib`
- [x] CI green