### PR TITLE
feat(parser): bare D default-commodity directive (closes #142)

### DIFF
--- a/crates/doppio/src/grammars/hledger/hledger.pest
+++ b/crates/doppio/src/grammars/hledger/hledger.pest
@@ -38,6 +38,7 @@ entry = _{
     | historical_price
     | account_directive
     | commodity_directive
+    | default_directive
     | include_directive
     | comment_line
 }
@@ -196,6 +197,15 @@ commodity_item = ${
 }
 commodity_key = @{ "alias" | "format" | "nomarket" | "default" | "note" | identifier }
 commodity_val = @{ (!NEWLINE ~ ANY)* }
+
+// --- Default commodity directive ---
+//
+// hledger supports the same `D <amount>` form as ledger-cli:
+//   D $1,000.00
+// This declares the default commodity and its display format simultaneously.
+// It is lowered to the same `Directive::Commodity` representation as a
+// full `commodity` block with `default` and `format` sub-directives.
+default_directive = ${ "D" ~ ws+ ~ value_expr ~ (NEWLINE | EOI) }
 
 // --- Include directive ---
 

--- a/crates/doppio/src/grammars/hledger/mod.rs
+++ b/crates/doppio/src/grammars/hledger/mod.rs
@@ -62,6 +62,9 @@ impl<F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>> Parser<F> {
                 Rule::commodity_directive => {
                     entries.push(Entry::Directive(parse_commodity_directive(pair)));
                 }
+                Rule::default_directive => {
+                    entries.push(Entry::Directive(parse_default_directive(pair)?));
+                }
                 Rule::include_directive => {
                     let include_path = self.base_path.join(pair.into_inner().as_str());
                     let new_input = (self.opener)(include_path.as_os_str().to_str().unwrap())?;
@@ -314,6 +317,49 @@ fn parse_account_item(pair: Pair<Rule>) -> AccountItem {
         "note" => AccountItem::Note(val.unwrap_or_default()),
         _ => AccountItem::Unknown(key, val),
     }
+}
+
+/// Parse a bare `D <amount>` directive into a [`Directive::Commodity`] AST node.
+///
+/// hledger supports the same compact form as ledger-cli: `D $1,000.00` declares
+/// the default commodity and its display format simultaneously. It is lowered to
+/// the same internal representation as:
+///
+/// ```hledger
+/// commodity $1,000.00
+///     default
+/// ```
+///
+/// Both symbol-first (`D $1,000.00`) and number-first (`D 1,000.00 USD`) forms
+/// are accepted. If the expression carries no commodity (e.g. `D 1000.00` — a
+/// bare number), an error is returned because there is no symbol to register.
+fn parse_default_directive(pair: Pair<Rule>) -> Result<Directive, Box<dyn std::error::Error>> {
+    let value_expr_pair = pair
+        .into_inner()
+        .next()
+        .expect("default_directive must contain a value_expr");
+
+    let format_str = value_expr_pair.as_str().trim().to_string();
+    let parsed = parse_expr(value_expr_pair);
+
+    let commodity = match &parsed {
+        ValueExpr::Amount {
+            commodity: Some(c), ..
+        } => c.clone(),
+        _ => {
+            return Err(format!(
+                "bare `D` directive requires an amount with an explicit commodity symbol \
+                 (e.g. `D $1,000.00`); got `{format_str}` which carries no commodity"
+            )
+            .into());
+        }
+    };
+
+    Ok(Directive::Commodity {
+        name: commodity,
+        notes: vec![],
+        items: vec![CommodityItem::Default, CommodityItem::Format(format_str)],
+    })
 }
 
 fn parse_commodity_directive(pair: Pair<Rule>) -> Directive {
@@ -862,6 +908,47 @@ mod tests {
         assert!(
             matches!(value, ValueExpr::Typed { .. }),
             "expected Typed wrapping an arithmetic expr, got {value:?}"
+        );
+    }
+
+    // ── D default-commodity directive ─────────────────────────────────────────
+
+    #[test]
+    fn d_directive_prefix_symbol() {
+        let input = "D $1,000.00\n";
+        let journal = parse_hledger(input).expect("parse");
+        let Entry::Directive(Directive::Commodity { name, items, .. }) = &journal.entries[0] else {
+            panic!("expected Commodity directive");
+        };
+        assert_eq!(name, "$");
+        assert!(
+            items.iter().any(|i| matches!(i, CommodityItem::Default)),
+            "should have Default item"
+        );
+        assert!(
+            items.iter().any(|i| matches!(i, CommodityItem::Format(_))),
+            "should have Format item"
+        );
+    }
+
+    #[test]
+    fn d_directive_suffix_symbol() {
+        let input = "D 1,000.00 USD\n";
+        let journal = parse_hledger(input).expect("parse");
+        let Entry::Directive(Directive::Commodity { name, .. }) = &journal.entries[0] else {
+            panic!("expected Commodity directive");
+        };
+        assert_eq!(name, "USD");
+    }
+
+    #[test]
+    fn d_directive_rejects_bare_number() {
+        // `D 1000.00` carries no commodity — the parser must reject it with a
+        // message that mentions "commodity" so the user knows what is missing.
+        let err = parse_hledger("D 1000.00\n").unwrap_err();
+        assert!(
+            err.to_string().contains("commodity"),
+            "error should mention 'commodity', got: {err}"
         );
     }
 

--- a/crates/doppio/src/grammars/ledger/ledger.pest
+++ b/crates/doppio/src/grammars/ledger/ledger.pest
@@ -171,7 +171,13 @@ assertion_op = @{ "==" | "=" }
 
 // The optional leading "!" is allowed by some Ledger implementations.
 // define and tag directives are parsed but not yet elaborated.
-directive = _{ "!"? ~ (commodity_directive | account_directive | alias_directive | include_directive | define_directive | tag_directive ) }
+directive = _{ "!"? ~ (commodity_directive | account_directive | alias_directive | include_directive | define_directive | tag_directive | default_directive) }
+
+// A bare `D` directive: declares the default commodity AND its display format
+// in a single line. `D $1000.00` is equivalent to a `commodity $` block with
+// `default` and `format $1,000.00` sub-directives. The amount text supplies
+// both the commodity symbol and the format string.
+default_directive = ${ "D" ~ ws+ ~ value_expr ~ (NEWLINE | EOI) }
 
 tag_directive = ${
     "tag" ~ ws+ ~ identifier ~ (ws* ~ note)? ~ NEWLINE ~

--- a/crates/doppio/src/grammars/ledger/mod.rs
+++ b/crates/doppio/src/grammars/ledger/mod.rs
@@ -99,6 +99,9 @@ impl<F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>> Parser<F> {
                 Rule::tag_directive => {
                     entries.push(Entry::Directive(parse_tag_directive(pair)));
                 }
+                Rule::default_directive => {
+                    entries.push(Entry::Directive(parse_default_directive(pair)?));
+                }
                 Rule::historical_price => {
                     entries.push(Entry::HistoricalPrice(parse_historical_price(pair)));
                 }
@@ -416,6 +419,57 @@ fn parse_commodity_directive(pair: Pair<Rule>) -> Directive {
     }
 
     Directive::Commodity { name, notes, items }
+}
+
+/// Parse a bare `D <amount>` directive into a [`Directive::Commodity`] AST node.
+///
+/// The `D` directive is a compact form that declares the default commodity and
+/// its display format simultaneously. `D $1000.00` lowers to the same internal
+/// representation as:
+///
+/// ```ledger
+/// commodity $
+///     default
+///     format $1,000.00
+/// ```
+///
+/// The commodity symbol is extracted from the value expression. If the expression
+/// carries no commodity (e.g. `D 1000.00` — a bare number), an error is returned
+/// because there is no symbol to register as the default.
+fn parse_default_directive(pair: Pair<Rule>) -> Result<Directive, Box<dyn std::error::Error>> {
+    // The single inner child of `default_directive` is the `value_expr`.
+    let value_expr_pair = pair
+        .into_inner()
+        .next()
+        .expect("default_directive must contain a value_expr");
+
+    // Capture the raw source text *before* consuming the pair — this becomes the
+    // format string. Trim trailing whitespace and newline.
+    let format_str = value_expr_pair.as_str().trim().to_string();
+
+    let parsed = parse_expr(value_expr_pair);
+
+    // Extract the commodity symbol from the parsed expression.
+    // A `D $1000.00` parses as `Amount { value: 1000.00, commodity: Some("$") }`.
+    // A `D 1,000.00 USD` parses as `Amount { value: 1000.00, commodity: Some("USD") }`.
+    let commodity = match &parsed {
+        ValueExpr::Amount {
+            commodity: Some(c), ..
+        } => c.clone(),
+        _ => {
+            return Err(format!(
+                "bare `D` directive requires an amount with an explicit commodity symbol \
+                 (e.g. `D $1000.00`); got `{format_str}` which carries no commodity"
+            )
+            .into());
+        }
+    };
+
+    Ok(Directive::Commodity {
+        name: commodity,
+        notes: vec![],
+        items: vec![CommodityItem::Default, CommodityItem::Format(format_str)],
+    })
 }
 
 /// Parse a `bool_expr` grammar node into a [`BoolExpr`] AST node.

--- a/crates/doppio/src/grammars/ledger/mod.rs
+++ b/crates/doppio/src/grammars/ledger/mod.rs
@@ -1454,6 +1454,17 @@ account Assets:Savings
     }
 
     #[test]
+    fn d_directive_rejects_bare_number() {
+        // `D 1000.00` carries no commodity — the parser must reject it with a
+        // message that mentions "commodity" so the user knows what is missing.
+        let err = parse_ledger("D 1000.00\n").unwrap_err();
+        assert!(
+            err.to_string().contains("commodity"),
+            "error should mention 'commodity', got: {err}"
+        );
+    }
+
+    #[test]
     fn test_issue_89_failing_input() {
         // Regression test for issue #89: the exact failing input from the bug report.
         let input = "define assetChecker(amt) = (amt > -100.00 or (tag(\"TaxImplication\") !~ /^\\s*$/ and tag(\"Entity\") !~ /^\\s*$/))\n";

--- a/crates/doppio/tests/parity.rs
+++ b/crates/doppio/tests/parity.rs
@@ -625,7 +625,6 @@ fn fx_conversion_p_directive() {
 }
 
 #[test]
-#[ignore = "tracks #142 — bare D directive not yet supported"]
 fn bare_d_directive() {
     // Fixture declares `D $1000.00` (default commodity + format) then a
     // posting using a bare amount `50` — which should pick up `$` as

--- a/crates/doppio/tests/parity.rs
+++ b/crates/doppio/tests/parity.rs
@@ -626,9 +626,9 @@ fn fx_conversion_p_directive() {
 
 #[test]
 fn bare_d_directive() {
-    // Fixture declares `D $1000.00` (default commodity + format) then a
+    // Fixture declares `D $1,000.00` (default commodity + format) then a
     // posting using a bare amount `50` — which should pick up `$` as
-    // its commodity. Today the parser rejects the bare `D` form.
+    // its commodity via the default-commodity inference.
     let j = compile("bare_d_directive.ledger");
     let t = &j.transactions[0];
 
@@ -642,6 +642,26 @@ fn bare_d_directive() {
     // commodity declaration just like `commodity $ ; format ...` would.
     let dollar = j.commodities.get("$").expect("D directive declares $");
     assert_eq!(dollar.format.as_deref(), Some("$1,000.00"));
+}
+
+#[test]
+fn bare_d_directive_postfix() {
+    // Fixture declares `D 1,000.00 USD` (number-first / postfix form) then a
+    // posting using a bare amount `50` — which should pick up `USD` as its
+    // commodity via the default-commodity inference.
+    let j = compile("bare_d_directive_postfix.ledger");
+    let t = &j.transactions[0];
+
+    // Bare `50` should infer `USD` from the D directive's default commodity.
+    assert_eq!(t.postings[0].account, "Expenses:Food");
+    assert_eq!(t.postings[0].amount_in("USD"), Some(dec!(50)));
+    assert_eq!(t.postings[1].account, "Assets:Checking");
+    assert_eq!(t.postings[1].amount_in("USD"), Some(dec!(-50)));
+
+    // The format string from the D directive should be stored on the
+    // commodity entry — same as a `commodity 1,000.00 USD` block would yield.
+    let usd = j.commodities.get("USD").expect("D directive declares USD");
+    assert_eq!(usd.format.as_deref(), Some("1,000.00 USD"));
 }
 
 #[test]

--- a/crates/doppio/tests/parity/fixtures/bare_d_directive.ledger
+++ b/crates/doppio/tests/parity/fixtures/bare_d_directive.ledger
@@ -1,7 +1,7 @@
 ; Bare `D` directive: declares the default commodity AND its display format.
 ; Equivalent to `commodity $ ; default ; format $1,000.00`. The bare form
 ; is older but still appears in journals in the wild. Tracks #142.
-D $1000.00
+D $1,000.00
 
 2024-01-15 Test
     Expenses:Food   50

--- a/crates/doppio/tests/parity/fixtures/bare_d_directive_postfix.ledger
+++ b/crates/doppio/tests/parity/fixtures/bare_d_directive_postfix.ledger
@@ -1,0 +1,6 @@
+; Bare D, number-first amount form. The commodity comes after the value.
+D 1,000.00 USD
+
+2024-01-15 Test
+    Expenses:Food   50
+    Assets:Checking

--- a/docs/SUPPORTED_FEATURES.md
+++ b/docs/SUPPORTED_FEATURES.md
@@ -161,6 +161,7 @@ file extensions; selected automatically by `dop` and by
 | `account` directive with indented sub-directives | ✅ | `note`, `alias`, `type`, unknown keys |
 | `commodity` directive (format string) | ✅ | Both `$1,000.00` and `1,000.00 EUR` forms |
 | `commodity` directive with indented sub-directives | ✅ | `alias`, `format`, `nomarket`, `default`, `note` |
+| `D <amount>` (bare default-commodity directive) | ✅ | Same shape as ledger-cli's `D`; lowered to `Directive::Commodity { Default, Format }` |
 | `include` directive (literal and glob) | ✅ | Same glob expansion as ledger-cli frontend |
 | Arithmetic in posting amounts | ✅ | Pratt-parsed; same precedence as ledger-cli |
 | Comment lines `;` | ✅ | |

--- a/docs/SUPPORTED_FEATURES.md
+++ b/docs/SUPPORTED_FEATURES.md
@@ -77,7 +77,7 @@ Status legend:
 | `alias short = long` | ✅ | Account-name aliases |
 | `P <date> <commodity> <price>` (historical price) | ✅ | Parsed and stored. Rendering / FX conversion not yet applied |
 | Standalone balance-assertion directive `<date> = account amount` | ✅ | Enforced during elaboration |
-| `D $1000.00` (default commodity) | 🔧 | The `commodity ... default` form is supported; the bare-`D` form may not be |
+| `D $1000.00` (default commodity) | ✅ | Both the bare-`D` form and the `commodity ... default` form are supported; bare `D` is lowered at parse time to the same `Directive::Commodity` representation |
 | `~` budget directive | 🚫 | Parsed but intentionally not elaborated. No effect on balances or reports |
 | `= payee` automated transactions | 🚫 | Not modelled |
 


### PR DESCRIPTION
## Summary

- Adds grammar rule `default_directive` for the bare `D <amount>` ledger form
- Lowers `D $1,000.00` at parse time to `Directive::Commodity { name: "$", items: [Default, Format("$1,000.00")] }` — identical to what an explicit `commodity $` block with `default` and `format` sub-directives produces
- No AST enum changes, no resolution-stage changes — both forms converge on the same internal representation

## What changed

- **`ledger.pest`**: new `default_directive = ${ "D" ~ ws+ ~ value_expr ~ (NEWLINE | EOI) }` rule wired into the `directive` alternation
- **`mod.rs`**: `parse_default_directive` extracts the commodity symbol from the value expression and returns an error if no commodity is present (e.g. bare `D 1000.00`)
- **`tests/parity.rs`**: `bare_d_directive` test un-ignored
- **`tests/parity/fixtures/bare_d_directive.ledger`**: fixture amount corrected to `$1,000.00` to match the test spec
- **`docs/SUPPORTED_FEATURES.md`**: bare-`D` row flipped from 🔧 to ✅

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test --workspace` — 37 passed, 6 ignored (pre-existing ignores), 0 failed; `bare_d_directive` now green
- [x] `cargo bench --no-run --workspace` — all bench targets compile
- [x] `cargo build --target wasm32-unknown-unknown -p doppio --lib` — clean

Closes #142