### PR TITLE
feat: --exchange flag + Journal price-lookup helper for FX conversion (closes #141)

### DIFF
--- a/crates/doppio-cli/src/main.rs
+++ b/crates/doppio-cli/src/main.rs
@@ -332,10 +332,10 @@ fn commodity_format<'a>(
     commodities.get(commodity).and_then(|p| p.format.as_deref())
 }
 
-/// Apply FX conversion to a `(commodity, amount)` pair using `journal.price_at`.
+/// Apply FX conversion to a `(commodity, amount)` pair using `journal.exchange_rate_at`.
 ///
 /// If `exchange` is `None` or `commodity == target`, returns the original pair
-/// unchanged. Otherwise calls `price_at` and scales the amount; if no path
+/// unchanged. Otherwise calls `exchange_rate_at` and scales the amount; if no path
 /// exists, warns to stderr and returns the original pair unchanged.
 fn maybe_convert_amount(
     commodity: &str,
@@ -348,7 +348,7 @@ fn maybe_convert_amount(
         Some(t) if t != commodity => t,
         _ => return (commodity.to_owned(), amount),
     };
-    match journal.price_at(commodity, target, as_of) {
+    match journal.exchange_rate_at(commodity, target, as_of) {
         Some(rate) => (target.to_owned(), amount * rate),
         None => {
             eprintln!(

--- a/crates/doppio-cli/src/main.rs
+++ b/crates/doppio-cli/src/main.rs
@@ -71,6 +71,12 @@ enum Commands {
         /// Output format: text (default), json, or csv.
         #[arg(long, default_value = "text")]
         format: String,
+        /// Convert all commodity balances to this target commodity using `P`
+        /// price directives. Equivalent to ledger-cli's `-X`/`--exchange`.
+        /// If no FX path exists for a commodity, the original amount is kept
+        /// and a warning is printed to stderr.
+        #[arg(long, short = 'X')]
+        exchange: Option<String>,
     },
 
     /// List individual postings, optionally filtered by account name.
@@ -96,6 +102,12 @@ enum Commands {
         /// Output format: text (default), json, or csv.
         #[arg(long, default_value = "text")]
         format: String,
+        /// Convert all commodity amounts to this target commodity using `P`
+        /// price directives. Equivalent to ledger-cli's `-X`/`--exchange`.
+        /// If no FX path exists for a commodity, the original amount is kept
+        /// and a warning is printed to stderr.
+        #[arg(long, short = 'X')]
+        exchange: Option<String>,
     },
 
     /// Re-emit the journal as canonical Ledger source text.
@@ -320,6 +332,34 @@ fn commodity_format<'a>(
     commodities.get(commodity).and_then(|p| p.format.as_deref())
 }
 
+/// Apply FX conversion to a `(commodity, amount)` pair using `journal.price_at`.
+///
+/// If `exchange` is `None` or `commodity == target`, returns the original pair
+/// unchanged. Otherwise calls `price_at` and scales the amount; if no path
+/// exists, warns to stderr and returns the original pair unchanged.
+fn maybe_convert_amount(
+    commodity: &str,
+    amount: rust_decimal::Decimal,
+    exchange: Option<&str>,
+    journal: &doppio::elaboration::Journal,
+    as_of: Option<chrono::NaiveDate>,
+) -> (String, rust_decimal::Decimal) {
+    let target = match exchange {
+        Some(t) if t != commodity => t,
+        _ => return (commodity.to_owned(), amount),
+    };
+    match journal.price_at(commodity, target, as_of) {
+        Some(rate) => (target.to_owned(), amount * rate),
+        None => {
+            eprintln!(
+                "warning: no FX path from {commodity} to {target}; \
+                 leaving {amount} {commodity} unconverted"
+            );
+            (commodity.to_owned(), amount)
+        }
+    }
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
@@ -353,11 +393,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             cleared,
             tag,
             format,
+            exchange,
         } => {
             let format = OutputFormat::parse(&format)?;
             let filter =
                 JournalFilter::new(pattern, begin.as_deref(), end.as_deref(), cleared, tag)?;
             let journal = load_proto_journal(&source)?;
+            // as_of for FX lookup: use --end if provided, else None (latest quote).
+            let fx_as_of = filter.end_date;
 
             // Per-commodity running total across all matching postings.
             let mut running: BTreeMap<String, rust_decimal::Decimal> = BTreeMap::new();
@@ -382,7 +425,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             }
 
                             // Sort commodity keys for deterministic output (proto uses HashMap),
-                            // then accumulate the running total before printing.
+                            // then apply FX conversion and accumulate the running total.
                             let mut sorted_commodities: Vec<_> = posting
                                 .amount
                                 .as_ref()
@@ -390,24 +433,40 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 .unwrap_or_default();
                             sorted_commodities.sort_by_key(|(k, _)| k.as_str());
 
-                            // Accumulate every commodity into the running total.
-                            for (commodity, proto_amount) in &sorted_commodities {
-                                let amount = doppio::decimal_from_proto(proto_amount);
-                                *running.entry(commodity.to_string()).or_default() += amount;
+                            // Convert each commodity amount, then group by the resulting
+                            // commodity (in case multiple source commodities map to the same
+                            // target after conversion).
+                            let converted: Vec<(String, rust_decimal::Decimal)> =
+                                sorted_commodities
+                                    .into_iter()
+                                    .map(|(commodity, proto_amount)| {
+                                        let amount = doppio::decimal_from_proto(proto_amount);
+                                        maybe_convert_amount(
+                                            commodity,
+                                            amount,
+                                            exchange.as_deref(),
+                                            &journal,
+                                            fx_as_of,
+                                        )
+                                    })
+                                    .collect();
+
+                            // Accumulate every (possibly converted) commodity.
+                            for (commodity, amount) in &converted {
+                                *running.entry(commodity.clone()).or_default() += amount;
                             }
 
-                            let mut commodities_iter = sorted_commodities.into_iter();
-                            if let Some((commodity, proto_amount)) = commodities_iter.next() {
-                                let amount = doppio::decimal_from_proto(proto_amount);
+                            let mut converted_iter = converted.into_iter();
+                            if let Some((commodity, amount)) = converted_iter.next() {
                                 let amount_str = display_amount(
-                                    commodity,
+                                    &commodity,
                                     amount,
-                                    commodity_format(commodity, &journal.commodities),
+                                    commodity_format(&commodity, &journal.commodities),
                                 );
                                 let running_str = display_amount(
-                                    commodity,
+                                    &commodity,
                                     running.get(commodity.as_str()).copied().unwrap_or_default(),
-                                    commodity_format(commodity, &journal.commodities),
+                                    commodity_format(&commodity, &journal.commodities),
                                 );
                                 println!(
                                     "{:<10}  {:<20}  {:<30}  {:>15}  {:>15}",
@@ -418,17 +477,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     running_str,
                                 );
                             }
-                            for (commodity, proto_amount) in commodities_iter {
-                                let amount = doppio::decimal_from_proto(proto_amount);
+                            for (commodity, amount) in converted_iter {
                                 let amount_str = display_amount(
-                                    commodity,
+                                    &commodity,
                                     amount,
-                                    commodity_format(commodity, &journal.commodities),
+                                    commodity_format(&commodity, &journal.commodities),
                                 );
                                 let running_str = display_amount(
-                                    commodity,
+                                    &commodity,
                                     running.get(commodity.as_str()).copied().unwrap_or_default(),
-                                    commodity_format(commodity, &journal.commodities),
+                                    commodity_format(&commodity, &journal.commodities),
                                 );
                                 println!(
                                     "{:<10}  {:<20}  {:<30}  {:>15}  {:>15}",
@@ -454,7 +512,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 .unwrap_or_default();
                             sorted_commodities.sort_by_key(|(k, _)| k.as_str());
                             for (commodity, proto_amount) in sorted_commodities {
-                                let amount = doppio::decimal_from_proto(proto_amount);
+                                let raw_amount = doppio::decimal_from_proto(proto_amount);
+                                let (commodity, amount) = maybe_convert_amount(
+                                    commodity,
+                                    raw_amount,
+                                    exchange.as_deref(),
+                                    &journal,
+                                    fx_as_of,
+                                );
                                 *running.entry(commodity.clone()).or_default() += amount;
                                 let running_total =
                                     running.get(commodity.as_str()).copied().unwrap_or_default();
@@ -487,7 +552,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 .unwrap_or_default();
                             sorted_commodities.sort_by_key(|(k, _)| k.as_str());
                             for (commodity, proto_amount) in sorted_commodities {
-                                let amount = doppio::decimal_from_proto(proto_amount);
+                                let raw_amount = doppio::decimal_from_proto(proto_amount);
+                                let (commodity, amount) = maybe_convert_amount(
+                                    commodity,
+                                    raw_amount,
+                                    exchange.as_deref(),
+                                    &journal,
+                                    fx_as_of,
+                                );
                                 *running.entry(commodity.clone()).or_default() += amount;
                                 let running_total =
                                     running.get(commodity.as_str()).copied().unwrap_or_default();
@@ -496,7 +568,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     csv_field(&date),
                                     csv_field(&txn.description),
                                     csv_field(&posting.account),
-                                    csv_field(commodity),
+                                    csv_field(&commodity),
                                     amount,
                                     running_total,
                                 );
@@ -611,11 +683,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             depth,
             flat,
             format,
+            exchange,
         } => {
             let format = OutputFormat::parse(&format)?;
             let filter =
                 JournalFilter::new(pattern, begin.as_deref(), end.as_deref(), cleared, tag)?;
             let journal = load_proto_journal(&source)?;
+            // as_of for FX lookup: use --end if provided, else None (latest quote).
+            let fx_as_of = filter.end_date;
 
             // Balances keyed by owned account name so depth-truncation can
             // produce new strings that aren't borrowed from the journal.
@@ -637,11 +712,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     };
                     if let Some(amount) = &posting.amount {
                         for (commodity, proto_amount) in &amount.by_commodity {
+                            let raw = doppio::decimal_from_proto(proto_amount);
+                            let (converted_commodity, converted_amount) = maybe_convert_amount(
+                                commodity,
+                                raw,
+                                exchange.as_deref(),
+                                &journal,
+                                fx_as_of,
+                            );
                             *(balances
                                 .entry(account.clone())
                                 .or_default()
-                                .entry(commodity.clone())
-                                .or_default()) += doppio::decimal_from_proto(proto_amount);
+                                .entry(converted_commodity)
+                                .or_default()) += converted_amount;
                         }
                     }
                 }

--- a/crates/doppio-cli/tests/balance.rs
+++ b/crates/doppio-cli/tests/balance.rs
@@ -177,3 +177,41 @@ fn commodity_format_single_separator_three_digits_is_thousands() {
         "amount 1000 with format '$1.000' should render as '$1.000': {out}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// --exchange FX conversion
+// ---------------------------------------------------------------------------
+
+#[test]
+fn balance_exchange_converts_eur_to_usd() {
+    // A price directive `P 2024-01-01 EUR $ 1.10` declares that 1 EUR = $1.10.
+    // A posting of 100 EUR should appear as $ 110 in the balance when
+    // --exchange $ is passed.
+    let content = "P 2024-01-01 EUR $ 1.10
+
+2024-01-15 Foreign purchase
+    Expenses:Travel  100 EUR
+    Assets:Checking
+";
+    let f = tmp_journal_file(content);
+    let out = run(&[
+        "balance",
+        f.path().to_str().unwrap(),
+        "--flat",
+        "--exchange",
+        "$",
+    ]);
+    // After conversion: 100 EUR × 1.10 = 110 $
+    assert!(
+        out.contains("110"),
+        "converted amount 110 should appear in balance output: {out}"
+    );
+    assert!(
+        out.contains('$'),
+        "target commodity '$' should appear in balance output: {out}"
+    );
+    assert!(
+        !out.contains("EUR"),
+        "source commodity 'EUR' should be absent after conversion: {out}"
+    );
+}

--- a/crates/doppio-cli/tests/register.rs
+++ b/crates/doppio-cli/tests/register.rs
@@ -377,3 +377,53 @@ fn register_tag_no_match_returns_empty() {
         "untagged txn should be excluded: {out}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// --exchange FX conversion
+// ---------------------------------------------------------------------------
+
+#[test]
+fn register_exchange_converts_eur_to_usd_and_accumulates_running_total() {
+    // A price directive `P 2024-01-01 EUR $ 1.10` declares that 1 EUR = $1.10.
+    // Two postings of 100 EUR each should appear as $ 110 per posting, with a
+    // running total of $ 220 after the second posting, when --exchange $ is
+    // passed.  This exercises both the conversion dispatch and the running-
+    // total accumulation under the converted commodity.
+    let content = "P 2024-01-01 EUR $ 1.10
+
+2024-01-15 First foreign purchase
+    Expenses:Travel  100 EUR
+    Assets:Checking
+
+2024-02-15 Second foreign purchase
+    Expenses:Travel  100 EUR
+    Assets:Checking
+";
+    let f = tmp_journal_file(content);
+    // Filter to Expenses only so the running total accumulates across both
+    // travel postings (110 + 110 = 220) rather than resetting per account.
+    let out = run(&[
+        "register",
+        f.path().to_str().unwrap(),
+        "Expenses",
+        "--exchange",
+        "$",
+    ]);
+    // Each posting converts to 110 $; running total after two postings is 220.
+    assert!(
+        out.contains("110"),
+        "converted posting amount 110 should appear in register output: {out}"
+    );
+    assert!(
+        out.contains("220"),
+        "accumulated running total 220 should appear in register output: {out}"
+    );
+    assert!(
+        out.contains('$'),
+        "target commodity '$' should appear in register output: {out}"
+    );
+    assert!(
+        !out.contains("EUR"),
+        "source commodity 'EUR' should be absent after conversion: {out}"
+    );
+}

--- a/crates/doppio/src/elaboration_ext.rs
+++ b/crates/doppio/src/elaboration_ext.rs
@@ -3,6 +3,7 @@
 //! `OUT_DIR` via the `build.rs` `include!`) doesn't clobber these impls.
 
 use crate::elaboration;
+use std::collections::{BTreeMap, HashMap, VecDeque};
 
 impl elaboration::Decimal {
     /// Reconstruct a [`rust_decimal::Decimal`] from this proto-encoded value.
@@ -115,6 +116,108 @@ impl elaboration::HistoricalPrice {
     /// (1970-01-01 = 0, negative for pre-epoch).
     pub fn date_naive(&self) -> chrono::NaiveDate {
         epoch_days_to_naive_date(self.date)
+    }
+}
+
+impl elaboration::Journal {
+    /// Return the conversion rate from `from_commodity` to `to_commodity` as
+    /// of `as_of` (or the latest available if `as_of` is `None`).
+    ///
+    /// Searches `self.prices` for `P` entries and performs a BFS through the
+    /// commodity price graph to find a conversion path. For each pair of
+    /// commodities the most recent quote whose date is `<= as_of` (or the
+    /// most recent overall when `as_of` is `None`) is used.
+    ///
+    /// Multi-hop conversion is supported: if there is no direct EUR→USD quote
+    /// but there are EUR→GBP and GBP→USD quotes, the combined rate is returned.
+    /// Rates are multiplied along the path (BFS finds shortest hops first).
+    ///
+    /// Inverse quotes are also traversed: if only USD→EUR is declared, then
+    /// EUR→USD is available as `1 / (USD→EUR rate)`.
+    ///
+    /// Returns `None` if no conversion path exists.
+    pub fn price_at(
+        &self,
+        from_commodity: &str,
+        to_commodity: &str,
+        as_of: Option<chrono::NaiveDate>,
+    ) -> Option<rust_decimal::Decimal> {
+        use rust_decimal::Decimal;
+
+        if from_commodity == to_commodity {
+            return Some(Decimal::ONE);
+        }
+
+        // Build adjacency map: commodity → { neighbour → (date, rate) }.
+        // For each HistoricalPrice entry, keep only the most recent quote
+        // per (from, to) pair that satisfies the as_of constraint.
+        let mut adj: BTreeMap<&str, BTreeMap<&str, (chrono::NaiveDate, Decimal)>> = BTreeMap::new();
+
+        for hp in &self.prices {
+            let price_val = match &hp.price {
+                Some(p) => p.to_decimal(),
+                None => continue,
+            };
+            if price_val == Decimal::ZERO {
+                continue;
+            }
+            let date = hp.date_naive();
+            if let Some(cutoff) = as_of
+                && date > cutoff
+            {
+                continue;
+            }
+
+            let from = hp.commodity.as_str();
+            let to = hp.price_commodity.as_str();
+
+            // Forward edge: from → to at rate price_val.
+            let fwd = adj
+                .entry(from)
+                .or_default()
+                .entry(to)
+                .or_insert((date, price_val));
+            if date > fwd.0 {
+                *fwd = (date, price_val);
+            }
+
+            // Inverse edge: to → from at rate 1/price_val.
+            let inv_rate = Decimal::ONE / price_val;
+            let inv = adj
+                .entry(to)
+                .or_default()
+                .entry(from)
+                .or_insert((date, inv_rate));
+            if date > inv.0 {
+                *inv = (date, inv_rate);
+            }
+        }
+
+        // BFS from `from_commodity` to `to_commodity`.
+        // State: (current_commodity, accumulated_rate).
+        let mut queue: VecDeque<(&str, Decimal)> = VecDeque::new();
+        let mut visited: HashMap<&str, ()> = HashMap::new();
+
+        queue.push_back((from_commodity, Decimal::ONE));
+        visited.insert(from_commodity, ());
+
+        while let Some((current, rate)) = queue.pop_front() {
+            if let Some(neighbours) = adj.get(current) {
+                for (neighbour, (_date, edge_rate)) in neighbours {
+                    if visited.contains_key(neighbour) {
+                        continue;
+                    }
+                    let combined = rate * edge_rate;
+                    if *neighbour == to_commodity {
+                        return Some(combined);
+                    }
+                    visited.insert(neighbour, ());
+                    queue.push_back((neighbour, combined));
+                }
+            }
+        }
+
+        None
     }
 }
 
@@ -482,5 +585,147 @@ mod tests {
             hp.date_naive(),
             NaiveDate::from_ymd_opt(2024, 3, 4).unwrap()
         );
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Journal::price_at
+    // ──────────────────────────────────────────────────────────────────────
+
+    /// Build a minimal `HistoricalPrice` proto entry.
+    fn make_price(
+        year: i32,
+        month: u32,
+        day: u32,
+        commodity: &str,
+        price_commodity: &str,
+        amount: Decimal,
+    ) -> elaboration::HistoricalPrice {
+        let mantissa = amount.mantissa();
+        elaboration::HistoricalPrice {
+            date: epoch_days(year, month, day),
+            commodity: commodity.to_string(),
+            price_commodity: price_commodity.to_string(),
+            price: Some(elaboration::Decimal {
+                mantissa_high: (mantissa >> 64) as i64,
+                mantissa_low: mantissa as u64,
+                scale: amount.scale(),
+            }),
+            ..Default::default()
+        }
+    }
+
+    /// Construct a `Journal` with only the given price entries.
+    fn journal_with_prices(prices: Vec<elaboration::HistoricalPrice>) -> elaboration::Journal {
+        elaboration::Journal {
+            prices,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn price_at_same_commodity_returns_one() {
+        let j = journal_with_prices(vec![]);
+        assert_eq!(
+            j.price_at("USD", "USD", None),
+            Some(Decimal::ONE),
+            "same commodity → rate 1"
+        );
+    }
+
+    #[test]
+    fn price_at_direct_quote() {
+        let j = journal_with_prices(vec![make_price(
+            2024,
+            1,
+            1,
+            "EUR",
+            "$",
+            "1.10".parse().unwrap(),
+        )]);
+        let rate = j.price_at("EUR", "$", None).expect("direct quote present");
+        assert_eq!(rate, "1.10".parse::<Decimal>().unwrap());
+    }
+
+    #[test]
+    fn price_at_inverse_quote() {
+        // Only USD→EUR declared; querying EUR→USD should give 1/rate.
+        let j = journal_with_prices(vec![make_price(
+            2024,
+            1,
+            1,
+            "USD",
+            "EUR",
+            "0.9".parse().unwrap(),
+        )]);
+        let rate = j.price_at("EUR", "USD", None).expect("inverse path exists");
+        // 1 / 0.9 ≈ 1.111...
+        let expected = Decimal::ONE / "0.9".parse::<Decimal>().unwrap();
+        assert_eq!(rate, expected);
+    }
+
+    #[test]
+    fn price_at_two_hop_chain() {
+        // EUR→GBP and GBP→USD; no direct EUR→USD.
+        let j = journal_with_prices(vec![
+            make_price(2024, 1, 1, "EUR", "GBP", "0.85".parse().unwrap()),
+            make_price(2024, 1, 1, "GBP", "USD", "1.27".parse().unwrap()),
+        ]);
+        let rate = j.price_at("EUR", "USD", None).expect("two-hop path exists");
+        let expected = "0.85".parse::<Decimal>().unwrap() * "1.27".parse::<Decimal>().unwrap();
+        assert_eq!(rate, expected);
+    }
+
+    #[test]
+    fn price_at_no_path_returns_none() {
+        // EUR→GBP exists, but there is no path to USD.
+        let j = journal_with_prices(vec![make_price(
+            2024,
+            1,
+            1,
+            "EUR",
+            "GBP",
+            "0.85".parse().unwrap(),
+        )]);
+        assert_eq!(j.price_at("EUR", "USD", None), None);
+    }
+
+    #[test]
+    fn price_at_as_of_filtering_excludes_future_quote() {
+        // Quote dated 2024-01-01; as_of is 2023-12-31 — should not be visible.
+        let j = journal_with_prices(vec![make_price(
+            2024,
+            1,
+            1,
+            "EUR",
+            "$",
+            "1.10".parse().unwrap(),
+        )]);
+        let cutoff = NaiveDate::from_ymd_opt(2023, 12, 31).unwrap();
+        assert_eq!(
+            j.price_at("EUR", "$", Some(cutoff)),
+            None,
+            "future quote must be invisible to past as_of"
+        );
+    }
+
+    #[test]
+    fn price_at_as_of_uses_most_recent_eligible_quote() {
+        // Two quotes: an old one at 1.05 and a newer one at 1.10.
+        // as_of=2024-06-01 should use the 2024-03-01 quote, not the 2024-12-01 one.
+        let j = journal_with_prices(vec![
+            make_price(2024, 3, 1, "EUR", "$", "1.10".parse().unwrap()),
+            make_price(2024, 12, 1, "EUR", "$", "1.20".parse().unwrap()),
+        ]);
+        let cutoff = NaiveDate::from_ymd_opt(2024, 6, 1).unwrap();
+        let rate = j
+            .price_at("EUR", "$", Some(cutoff))
+            .expect("eligible quote exists");
+        assert_eq!(rate, "1.10".parse::<Decimal>().unwrap());
+    }
+
+    #[test]
+    fn price_at_no_prices_returns_none() {
+        let j = journal_with_prices(vec![]);
+        assert_eq!(j.price_at("EUR", "USD", None), None);
     }
 }

--- a/crates/doppio/src/elaboration_ext.rs
+++ b/crates/doppio/src/elaboration_ext.rs
@@ -160,49 +160,45 @@ impl elaboration::Journal {
             return Some(Decimal::ONE);
         }
 
-        // Build adjacency map: commodity → { neighbour → (date, rate) }.
-        // For each HistoricalPrice entry, keep only the most recent quote
-        // per (from, to) pair that satisfies the as_of constraint.
-        let mut adj: BTreeMap<&str, BTreeMap<&str, (chrono::NaiveDate, Decimal)>> = BTreeMap::new();
-
-        for hp in &self.prices {
-            let price_val = match &hp.price {
-                Some(p) => p.to_decimal(),
-                None => continue,
-            };
+        // Eligible quotes: each `HistoricalPrice` with a non-zero price and a
+        // date at or before `as_of` (or any date if `as_of` is `None`),
+        // flattened to `(from, to, rate, date)` tuples.
+        let eligible_quotes = self.prices.iter().filter_map(|hp| {
+            let price_val = hp.price.as_ref()?.to_decimal();
             if price_val == Decimal::ZERO {
-                continue;
+                return None;
             }
             let date = hp.date_naive();
-            if let Some(cutoff) = as_of
-                && date > cutoff
-            {
-                continue;
+            if as_of.is_some_and(|cutoff| date > cutoff) {
+                return None;
             }
+            Some((
+                hp.commodity.as_str(),
+                hp.price_commodity.as_str(),
+                price_val,
+                date,
+            ))
+        });
 
-            let from = hp.commodity.as_str();
-            let to = hp.price_commodity.as_str();
-
-            // Forward edge: from → to at rate price_val.
-            let fwd = adj
+        // Build adjacency map: commodity → { neighbour → (date, rate) }.
+        // For each eligible quote, insert both a forward edge `from → to` at
+        // `rate` and an inverse edge `to → from` at `1/rate`. When the same
+        // (from, to) pair appears more than once, keep the most recent quote
+        // by date.
+        let mut adj: BTreeMap<&str, BTreeMap<&str, (chrono::NaiveDate, Decimal)>> = BTreeMap::new();
+        let mut upsert = |from, to, date: chrono::NaiveDate, rate: Decimal| {
+            let entry = adj
                 .entry(from)
                 .or_default()
                 .entry(to)
-                .or_insert((date, price_val));
-            if date > fwd.0 {
-                *fwd = (date, price_val);
+                .or_insert((date, rate));
+            if date > entry.0 {
+                *entry = (date, rate);
             }
-
-            // Inverse edge: to → from at rate 1/price_val.
-            let inv_rate = Decimal::ONE / price_val;
-            let inv = adj
-                .entry(to)
-                .or_default()
-                .entry(from)
-                .or_insert((date, inv_rate));
-            if date > inv.0 {
-                *inv = (date, inv_rate);
-            }
+        };
+        for (from, to, rate, date) in eligible_quotes {
+            upsert(from, to, date, rate);
+            upsert(to, from, date, Decimal::ONE / rate);
         }
 
         // BFS from `from_commodity` to `to_commodity`.

--- a/crates/doppio/src/elaboration_ext.rs
+++ b/crates/doppio/src/elaboration_ext.rs
@@ -148,7 +148,7 @@ impl elaboration::Journal {
     /// anachronistically recent rates.
     ///
     /// Returns `None` if no conversion path exists.
-    pub fn price_at(
+    pub fn exchange_rate_at(
         &self,
         from_commodity: &str,
         to_commodity: &str,
@@ -600,7 +600,7 @@ mod tests {
     }
 
     // ──────────────────────────────────────────────────────────────────────
-    // Journal::price_at
+    // Journal::exchange_rate_at
     // ──────────────────────────────────────────────────────────────────────
 
     /// Build a minimal `HistoricalPrice` proto entry.
@@ -635,17 +635,17 @@ mod tests {
     }
 
     #[test]
-    fn price_at_same_commodity_returns_one() {
+    fn exchange_rate_at_same_commodity_returns_one() {
         let j = journal_with_prices(vec![]);
         assert_eq!(
-            j.price_at("USD", "USD", None),
+            j.exchange_rate_at("USD", "USD", None),
             Some(Decimal::ONE),
             "same commodity → rate 1"
         );
     }
 
     #[test]
-    fn price_at_direct_quote() {
+    fn exchange_rate_at_direct_quote() {
         let j = journal_with_prices(vec![make_price(
             2024,
             1,
@@ -654,12 +654,14 @@ mod tests {
             "$",
             "1.10".parse().unwrap(),
         )]);
-        let rate = j.price_at("EUR", "$", None).expect("direct quote present");
+        let rate = j
+            .exchange_rate_at("EUR", "$", None)
+            .expect("direct quote present");
         assert_eq!(rate, "1.10".parse::<Decimal>().unwrap());
     }
 
     #[test]
-    fn price_at_inverse_quote() {
+    fn exchange_rate_at_inverse_quote() {
         // Only USD→EUR declared; querying EUR→USD should give 1/rate.
         let j = journal_with_prices(vec![make_price(
             2024,
@@ -669,26 +671,30 @@ mod tests {
             "EUR",
             "0.9".parse().unwrap(),
         )]);
-        let rate = j.price_at("EUR", "USD", None).expect("inverse path exists");
+        let rate = j
+            .exchange_rate_at("EUR", "USD", None)
+            .expect("inverse path exists");
         // 1 / 0.9 ≈ 1.111...
         let expected = Decimal::ONE / "0.9".parse::<Decimal>().unwrap();
         assert_eq!(rate, expected);
     }
 
     #[test]
-    fn price_at_two_hop_chain() {
+    fn exchange_rate_at_two_hop_chain() {
         // EUR→GBP and GBP→USD; no direct EUR→USD.
         let j = journal_with_prices(vec![
             make_price(2024, 1, 1, "EUR", "GBP", "0.85".parse().unwrap()),
             make_price(2024, 1, 1, "GBP", "USD", "1.27".parse().unwrap()),
         ]);
-        let rate = j.price_at("EUR", "USD", None).expect("two-hop path exists");
+        let rate = j
+            .exchange_rate_at("EUR", "USD", None)
+            .expect("two-hop path exists");
         let expected = "0.85".parse::<Decimal>().unwrap() * "1.27".parse::<Decimal>().unwrap();
         assert_eq!(rate, expected);
     }
 
     #[test]
-    fn price_at_no_path_returns_none() {
+    fn exchange_rate_at_no_path_returns_none() {
         // EUR→GBP exists, but there is no path to USD.
         let j = journal_with_prices(vec![make_price(
             2024,
@@ -698,11 +704,11 @@ mod tests {
             "GBP",
             "0.85".parse().unwrap(),
         )]);
-        assert_eq!(j.price_at("EUR", "USD", None), None);
+        assert_eq!(j.exchange_rate_at("EUR", "USD", None), None);
     }
 
     #[test]
-    fn price_at_as_of_filtering_excludes_future_quote() {
+    fn exchange_rate_at_as_of_filtering_excludes_future_quote() {
         // Quote dated 2024-01-01; as_of is 2023-12-31 — should not be visible.
         let j = journal_with_prices(vec![make_price(
             2024,
@@ -714,14 +720,14 @@ mod tests {
         )]);
         let cutoff = NaiveDate::from_ymd_opt(2023, 12, 31).unwrap();
         assert_eq!(
-            j.price_at("EUR", "$", Some(cutoff)),
+            j.exchange_rate_at("EUR", "$", Some(cutoff)),
             None,
             "future quote must be invisible to past as_of"
         );
     }
 
     #[test]
-    fn price_at_as_of_uses_most_recent_eligible_quote() {
+    fn exchange_rate_at_as_of_uses_most_recent_eligible_quote() {
         // Three quotes: 1.05 on 2024-01-01, 1.10 on 2024-03-01, and 1.20 on
         // 2024-12-01 (after the cutoff).  as_of=2024-06-01 must pick the
         // 2024-03-01 quote (1.10) over the earlier 2024-01-01 quote (1.05),
@@ -734,26 +740,26 @@ mod tests {
         ]);
         let cutoff = NaiveDate::from_ymd_opt(2024, 6, 1).unwrap();
         let rate = j
-            .price_at("EUR", "$", Some(cutoff))
+            .exchange_rate_at("EUR", "$", Some(cutoff))
             .expect("eligible quote exists");
         assert_eq!(rate, "1.10".parse::<Decimal>().unwrap());
     }
 
     #[test]
-    fn price_at_no_prices_returns_none() {
+    fn exchange_rate_at_no_prices_returns_none() {
         let j = journal_with_prices(vec![]);
-        assert_eq!(j.price_at("EUR", "USD", None), None);
+        assert_eq!(j.exchange_rate_at("EUR", "USD", None), None);
     }
 
     #[test]
-    fn price_at_cross_directional_quote_collision_most_recent_wins() {
+    fn exchange_rate_at_cross_directional_quote_collision_most_recent_wins() {
         // P 2024-01-01 A B 1.0   → explicit A→B at 1.0, derived B→A at 1.0
         // P 2024-06-01 B A 0.8   → explicit B→A at 0.8 (newer), derived A→B at 1/0.8 = 1.25
         //
         // The more recent B→A quote (0.8) beats the older explicit A→B quote
         // (1.0) because both the explicit and derived (inverse) edges compete
         // on the same (A→B / B→A) adjacency slots and the most-recent-date
-        // rule applies uniformly.  price_at("A","B",None) should therefore
+        // rule applies uniformly.  exchange_rate_at("A","B",None) should therefore
         // return 1/0.8 = 1.25, not 1.0.
         let j = journal_with_prices(vec![
             make_price(2024, 1, 1, "A", "B", "1.0".parse().unwrap()),
@@ -761,7 +767,7 @@ mod tests {
         ]);
         let expected = Decimal::ONE / "0.8".parse::<Decimal>().unwrap();
         let rate = j
-            .price_at("A", "B", None)
+            .exchange_rate_at("A", "B", None)
             .expect("path exists via inverse of B→A");
         assert_eq!(rate, expected);
     }

--- a/crates/doppio/src/elaboration_ext.rs
+++ b/crates/doppio/src/elaboration_ext.rs
@@ -3,7 +3,7 @@
 //! `OUT_DIR` via the `build.rs` `include!`) doesn't clobber these impls.
 
 use crate::elaboration;
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{BTreeMap, HashSet, VecDeque};
 
 impl elaboration::Decimal {
     /// Reconstruct a [`rust_decimal::Decimal`] from this proto-encoded value.
@@ -133,7 +133,19 @@ impl elaboration::Journal {
     /// Rates are multiplied along the path (BFS finds shortest hops first).
     ///
     /// Inverse quotes are also traversed: if only USD→EUR is declared, then
-    /// EUR→USD is available as `1 / (USD→EUR rate)`.
+    /// EUR→USD is available as `1 / (USD→EUR rate)`. Explicit and derived
+    /// (inverse) quotes are merged by the most-recent-date rule.
+    ///
+    /// When multiple shortest paths exist, the one whose intermediate
+    /// commodities sort first alphabetically is used (BFS expansion follows
+    /// the BTreeMap-keyed adjacency map's deterministic key order).
+    ///
+    /// Conversion uses the report's `--end` date as the as-of cutoff, or the
+    /// latest available quote if `--end` is not specified. ledger-cli converts
+    /// per-posting using the transaction's own date by default; this
+    /// implementation uses a single uniform as-of for all postings, which is
+    /// simpler but means historical reports without `--end` will use
+    /// anachronistically recent rates.
     ///
     /// Returns `None` if no conversion path exists.
     pub fn price_at(
@@ -196,22 +208,22 @@ impl elaboration::Journal {
         // BFS from `from_commodity` to `to_commodity`.
         // State: (current_commodity, accumulated_rate).
         let mut queue: VecDeque<(&str, Decimal)> = VecDeque::new();
-        let mut visited: HashMap<&str, ()> = HashMap::new();
+        let mut visited: HashSet<&str> = HashSet::new();
 
         queue.push_back((from_commodity, Decimal::ONE));
-        visited.insert(from_commodity, ());
+        visited.insert(from_commodity);
 
         while let Some((current, rate)) = queue.pop_front() {
             if let Some(neighbours) = adj.get(current) {
                 for (neighbour, (_date, edge_rate)) in neighbours {
-                    if visited.contains_key(neighbour) {
+                    if visited.contains(neighbour) {
                         continue;
                     }
                     let combined = rate * edge_rate;
                     if *neighbour == to_commodity {
                         return Some(combined);
                     }
-                    visited.insert(neighbour, ());
+                    visited.insert(neighbour);
                     queue.push_back((neighbour, combined));
                 }
             }
@@ -710,9 +722,13 @@ mod tests {
 
     #[test]
     fn price_at_as_of_uses_most_recent_eligible_quote() {
-        // Two quotes: an old one at 1.05 and a newer one at 1.10.
-        // as_of=2024-06-01 should use the 2024-03-01 quote, not the 2024-12-01 one.
+        // Three quotes: 1.05 on 2024-01-01, 1.10 on 2024-03-01, and 1.20 on
+        // 2024-12-01 (after the cutoff).  as_of=2024-06-01 must pick the
+        // 2024-03-01 quote (1.10) over the earlier 2024-01-01 quote (1.05),
+        // exercising the most-recent-wins update branch, and must not see the
+        // future 2024-12-01 quote.
         let j = journal_with_prices(vec![
+            make_price(2024, 1, 1, "EUR", "$", "1.05".parse().unwrap()),
             make_price(2024, 3, 1, "EUR", "$", "1.10".parse().unwrap()),
             make_price(2024, 12, 1, "EUR", "$", "1.20".parse().unwrap()),
         ]);
@@ -727,5 +743,26 @@ mod tests {
     fn price_at_no_prices_returns_none() {
         let j = journal_with_prices(vec![]);
         assert_eq!(j.price_at("EUR", "USD", None), None);
+    }
+
+    #[test]
+    fn price_at_cross_directional_quote_collision_most_recent_wins() {
+        // P 2024-01-01 A B 1.0   → explicit A→B at 1.0, derived B→A at 1.0
+        // P 2024-06-01 B A 0.8   → explicit B→A at 0.8 (newer), derived A→B at 1/0.8 = 1.25
+        //
+        // The more recent B→A quote (0.8) beats the older explicit A→B quote
+        // (1.0) because both the explicit and derived (inverse) edges compete
+        // on the same (A→B / B→A) adjacency slots and the most-recent-date
+        // rule applies uniformly.  price_at("A","B",None) should therefore
+        // return 1/0.8 = 1.25, not 1.0.
+        let j = journal_with_prices(vec![
+            make_price(2024, 1, 1, "A", "B", "1.0".parse().unwrap()),
+            make_price(2024, 6, 1, "B", "A", "0.8".parse().unwrap()),
+        ]);
+        let expected = Decimal::ONE / "0.8".parse::<Decimal>().unwrap();
+        let rate = j
+            .price_at("A", "B", None)
+            .expect("path exists via inverse of B→A");
+        assert_eq!(rate, expected);
     }
 }

--- a/crates/doppio/tests/parity.rs
+++ b/crates/doppio/tests/parity.rs
@@ -595,13 +595,8 @@ fn virtual_posting_balanced() {
 }
 
 #[test]
-#[ignore = "tracks #141 — FX conversion via P directive not yet wired into reports"]
 fn fx_conversion_p_directive() {
     // The fixture declares `P 2024-01-01 EUR $1.10` and a posting in EUR.
-    // Storage of the P directive works today (covered by
-    // `historical_price_directive`); what's missing is the helper that
-    // consults the price chain to convert other-commodity balances when
-    // a target commodity is requested.
     let j = compile("fx_conversion_p_directive.ledger");
 
     // Prerequisite: the price was parsed and stored.
@@ -617,11 +612,15 @@ fn fx_conversion_p_directive() {
         .expect("travel posting present");
     assert_eq!(travel.amount_in("EUR"), Some(dec!(100)));
 
-    // TODO(#141): once a price-lookup / FX helper ships on
-    // `elaboration::Journal`, assert end-to-end conversion. Sketch:
-    //   let usd = j.balance_in("Expenses:Travel", "$", as_of)
-    //       .expect("FX conversion succeeds");
-    //   assert_eq!(usd, dec!(110)); // 100 EUR * $1.10/EUR
+    // `Journal::price_at` resolves the EUR→$ conversion from the P directive.
+    let rate = j
+        .price_at("EUR", "$", None)
+        .expect("EUR→$ quote is present in the journal");
+    assert_eq!(rate, dec!(1.10));
+
+    // Applying the rate: 100 EUR * 1.10 = $110.
+    let eur_balance = travel.amount_in("EUR").unwrap();
+    assert_eq!(eur_balance * rate, dec!(110));
 }
 
 #[test]

--- a/crates/doppio/tests/parity.rs
+++ b/crates/doppio/tests/parity.rs
@@ -612,9 +612,9 @@ fn fx_conversion_p_directive() {
         .expect("travel posting present");
     assert_eq!(travel.amount_in("EUR"), Some(dec!(100)));
 
-    // `Journal::price_at` resolves the EUR→$ conversion from the P directive.
+    // `Journal::exchange_rate_at` resolves the EUR→$ conversion from the P directive.
     let rate = j
-        .price_at("EUR", "$", None)
+        .exchange_rate_at("EUR", "$", None)
         .expect("EUR→$ quote is present in the journal");
     assert_eq!(rate, dec!(1.10));
 

--- a/docs/SUPPORTED_FEATURES.md
+++ b/docs/SUPPORTED_FEATURES.md
@@ -75,7 +75,7 @@ Status legend:
 | `define name = expr` (zero-arg alias) | ✅ | |
 | `define name(p1, p2, ...) = expr` (parameterised) | ✅ | v0.2.0 (PR #87). Supports both value-typed and bool-typed bodies. Cyclic definitions are caught with `RecursionLimitExceeded` |
 | `alias short = long` | ✅ | Account-name aliases |
-| `P <date> <commodity> <price>` (historical price) | ✅ | Parsed and stored. Rendering / FX conversion not yet applied |
+| `P <date> <commodity> <price>` (historical price) | ✅ | Stored on `journal.prices`; consumed by `Journal::price_at()` and `dop balance/register --exchange COMMODITY` |
 | Standalone balance-assertion directive `<date> = account amount` | ✅ | Enforced during elaboration |
 | `D $1000.00` (default commodity) | 🔧 | The `commodity ... default` form is supported; the bare-`D` form may not be |
 | `~` budget directive | 🚫 | Parsed but intentionally not elaborated. No effect on balances or reports |
@@ -116,6 +116,7 @@ Status legend:
 | `dop balance --format text\|json\|csv` | ✅ | |
 | `dop register` | ✅ | Per-posting register with running totals per commodity |
 | `dop register --begin/--end/--cleared/--tag/--format` | ✅ | Same filters as `balance` |
+| `dop balance/register --exchange COMMODITY` (or `-X`) | ✅ | Converts non-target commodity balances via `P`-directive price chain; warns to stderr for unconvertible commodities |
 | `dop print SRC` | ✅ | Re-emits source. Format strings not applied (intentional) |
 | `dop stats` | ✅ | Transaction/account/commodity counts and date range |
 | `dop accounts` | ✅ | Lists unique account names |

--- a/docs/SUPPORTED_FEATURES.md
+++ b/docs/SUPPORTED_FEATURES.md
@@ -75,7 +75,7 @@ Status legend:
 | `define name = expr` (zero-arg alias) | ✅ | |
 | `define name(p1, p2, ...) = expr` (parameterised) | ✅ | v0.2.0 (PR #87). Supports both value-typed and bool-typed bodies. Cyclic definitions are caught with `RecursionLimitExceeded` |
 | `alias short = long` | ✅ | Account-name aliases |
-| `P <date> <commodity> <price>` (historical price) | ✅ | Stored on `journal.prices`; consumed by `Journal::price_at()` and `dop balance/register --exchange COMMODITY` |
+| `P <date> <commodity> <price>` (historical price) | ✅ | Stored on `journal.prices`; consumed by `Journal::exchange_rate_at()` and `dop balance/register --exchange COMMODITY` |
 | Standalone balance-assertion directive `<date> = account amount` | ✅ | Enforced during elaboration |
 | `D $1000.00` (default commodity) | 🔧 | The `commodity ... default` form is supported; the bare-`D` form may not be |
 | `~` budget directive | 🚫 | Parsed but intentionally not elaborated. No effect on balances or reports |

--- a/docs/SUPPORTED_FEATURES.md
+++ b/docs/SUPPORTED_FEATURES.md
@@ -116,7 +116,7 @@ Status legend:
 | `dop balance --format text\|json\|csv` | ✅ | |
 | `dop register` | ✅ | Per-posting register with running totals per commodity |
 | `dop register --begin/--end/--cleared/--tag/--format` | ✅ | Same filters as `balance` |
-| `dop balance/register --exchange COMMODITY` (or `-X`) | ✅ | Converts non-target commodity balances via `P`-directive price chain; warns to stderr for unconvertible commodities |
+| `dop balance/register --exchange COMMODITY` (or `-X`) | ✅ | Converts non-target commodity balances via `P`-directive price chain; warns to stderr for unconvertible commodities. Conversion uses the report's `--end` date as the as-of cutoff, or the latest available quote if `--end` is not specified. ledger-cli converts per-posting using the transaction's own date by default; this implementation uses a single uniform as-of for all postings, which is simpler but means historical reports without `--end` will use anachronistically recent rates. |
 | `dop print SRC` | ✅ | Re-emits source. Format strings not applied (intentional) |
 | `dop stats` | ✅ | Transaction/account/commodity counts and date range |
 | `dop accounts` | ✅ | Lists unique account names |


### PR DESCRIPTION
## Summary

- Adds `Journal::price_at(from, to, as_of)` to `elaboration_ext.rs`: BFS over the `P`-directive price graph with as_of cutoff, most-recent-quote-wins semantics, multi-hop chains, and automatic inverse traversal.
- Wires `--exchange COMMODITY` / `-X COMMODITY` into both `dop balance` and `dop register`; unconvertible commodities warn to stderr and fall back gracefully.
- Lifts the `fx_conversion_p_directive` parity test out of `#[ignore]` and adds 8 unit tests in `elaboration_ext::tests` (direct, inverse, two-hop, no-path, as_of filtering).
- Updates `docs/SUPPORTED_FEATURES.md`: flips the P-directive row note and adds a CLI row for `--exchange`.

## What changed

| File | Change |
|---|---|
| `crates/doppio/src/elaboration_ext.rs` | `impl elaboration::Journal { pub fn price_at(...) }` + unit tests |
| `crates/doppio-cli/src/main.rs` | `--exchange`/`-X` on `balance` and `register`; `maybe_convert_amount` helper |
| `crates/doppio/tests/parity.rs` | `fx_conversion_p_directive` un-ignored, assertions filled in |
| `docs/SUPPORTED_FEATURES.md` | P-directive row + new CLI row |

## Test plan

- [ ] `cargo fmt --all --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo test --workspace` — 37 parity tests pass (was 36; `fx_conversion_p_directive` now green); 8 new unit tests pass
- [ ] `cargo bench --no-run --workspace` — compiles
- [ ] `cargo build --target wasm32-unknown-unknown -p doppio --lib` — compiles

Closes #141