### PR TITLE
feat: virtual postings (parens unbalanced, brackets balanced) (closes #140)

### DIFF
--- a/crates/doppio-categorize/tests/integration.rs
+++ b/crates/doppio-categorize/tests/integration.rs
@@ -44,6 +44,7 @@ fn posting(account: &str, payee: &str, amt: Decimal) -> Posting {
         state: TransactionState::Uncleared as i32,
         tags: Vec::new(),
         metadata: BTreeMap::new(),
+        kind: 0, // POSTING_KIND_UNSPECIFIED (treated as REAL)
     }
 }
 
@@ -523,6 +524,7 @@ fn posting_with_no_amount_is_skipped() {
                 state: TransactionState::Uncleared as i32,
                 tags: Vec::new(),
                 metadata: BTreeMap::new(),
+                kind: 0, // POSTING_KIND_UNSPECIFIED (treated as REAL)
             },
             posting("Expenses:Unknown", "Mystery", dec!(10.00)),
         ],

--- a/crates/doppio-cli/src/main.rs
+++ b/crates/doppio-cli/src/main.rs
@@ -71,6 +71,10 @@ enum Commands {
         /// Output format: text (default), json, or csv.
         #[arg(long, default_value = "text")]
         format: String,
+        /// Exclude virtual postings (both `(unbalanced)` and `[balanced]`);
+        /// show only real postings.
+        #[arg(short = 'R', long, default_value_t = false)]
+        real: bool,
     },
 
     /// List individual postings, optionally filtered by account name.
@@ -96,6 +100,10 @@ enum Commands {
         /// Output format: text (default), json, or csv.
         #[arg(long, default_value = "text")]
         format: String,
+        /// Exclude virtual postings (both `(unbalanced)` and `[balanced]`);
+        /// show only real postings.
+        #[arg(short = 'R', long, default_value_t = false)]
+        real: bool,
     },
 
     /// Re-emit the journal as canonical Ledger source text.
@@ -353,6 +361,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             cleared,
             tag,
             format,
+            real,
         } => {
             let format = OutputFormat::parse(&format)?;
             let filter =
@@ -378,6 +387,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                         for posting in txn.postings.iter() {
                             if !filter.matches_account(&posting.account) {
+                                continue;
+                            }
+                            if real && !posting.is_real() {
                                 continue;
                             }
 
@@ -446,6 +458,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             if !filter.matches_account(&posting.account) {
                                 continue;
                             }
+                            if real && !posting.is_real() {
+                                continue;
+                            }
                             // Sort for deterministic JSON output.
                             let mut sorted_commodities: Vec<_> = posting
                                 .amount
@@ -477,6 +492,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         let date = epoch_days_to_string(txn.date);
                         for posting in txn.postings.iter() {
                             if !filter.matches_account(&posting.account) {
+                                continue;
+                            }
+                            if real && !posting.is_real() {
                                 continue;
                             }
                             // Sort for deterministic CSV output.
@@ -611,6 +629,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             depth,
             flat,
             format,
+            real,
         } => {
             let format = OutputFormat::parse(&format)?;
             let filter =
@@ -629,6 +648,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 for posting in txn.postings.iter() {
                     if !filter.matches_account(&posting.account) {
+                        continue;
+                    }
+                    if real && !posting.is_real() {
                         continue;
                     }
                     let account = match depth {

--- a/crates/doppio-cli/tests/balance.rs
+++ b/crates/doppio-cli/tests/balance.rs
@@ -157,6 +157,60 @@ fn commodity_format_suffix_symbol_applied_to_register() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// --real / -R flag: filter out virtual postings
+// ---------------------------------------------------------------------------
+
+fn virtual_journal() -> &'static str {
+    "2024-01-15 Setup
+    Assets:Checking         $100
+    Equity:Opening         $-100
+    (Equity:Reservations)   $-25
+"
+}
+
+#[test]
+fn balance_real_flag_excludes_virtual_unbalanced() {
+    let f = tmp_journal_file(virtual_journal());
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat", "--real"]);
+    assert!(
+        !out.contains("Equity:Reservations"),
+        "virtual unbalanced posting should be hidden with --real: {out}"
+    );
+    assert!(
+        out.contains("Assets:Checking"),
+        "real posting should still appear: {out}"
+    );
+}
+
+#[test]
+fn balance_without_real_flag_includes_virtual_unbalanced() {
+    let f = tmp_journal_file(virtual_journal());
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+    assert!(
+        out.contains("Equity:Reservations"),
+        "virtual posting should be included by default: {out}"
+    );
+}
+
+fn virtual_balanced_journal() -> &'static str {
+    "2024-01-15 Setup
+    Assets:Checking          $100
+    [Equity:Reservations]    $25
+    Equity:Opening          $-125
+"
+}
+
+#[test]
+fn balance_real_flag_excludes_virtual_balanced() {
+    let f = tmp_journal_file(virtual_balanced_journal());
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat", "--real"]);
+    assert!(
+        !out.contains("Equity:Reservations"),
+        "virtual balanced posting should be hidden with --real: {out}"
+    );
+}
+
 #[test]
 fn commodity_format_single_separator_three_digits_is_thousands() {
     // `format $1.000` — a single separator followed by exactly 3 digits is a

--- a/crates/doppio-cli/tests/register.rs
+++ b/crates/doppio-cli/tests/register.rs
@@ -313,6 +313,61 @@ fn register_begin_filter_resets_running_total() {
 }
 
 // ---------------------------------------------------------------------------
+// --real / -R flag: filter out virtual postings
+// ---------------------------------------------------------------------------
+
+fn virtual_register_journal() -> &'static str {
+    "2024-01-15 Setup
+    Assets:Checking         $100
+    Equity:Opening         $-100
+    (Equity:Reservations)   $-25
+"
+}
+
+#[test]
+fn register_without_real_flag_includes_virtual_unbalanced() {
+    let f = tmp_journal_file(virtual_register_journal());
+    let out = run(&["register", f.path().to_str().unwrap()]);
+    assert!(
+        out.contains("Equity:Reservations"),
+        "virtual posting should appear by default: {out}"
+    );
+    assert!(
+        out.contains("Assets:Checking"),
+        "real posting should appear: {out}"
+    );
+}
+
+#[test]
+fn register_real_flag_excludes_virtual_unbalanced() {
+    let f = tmp_journal_file(virtual_register_journal());
+    let out = run(&["register", f.path().to_str().unwrap(), "--real"]);
+    assert!(
+        !out.contains("Equity:Reservations"),
+        "virtual unbalanced posting should be hidden with --real: {out}"
+    );
+    assert!(
+        out.contains("Assets:Checking"),
+        "real posting should still appear: {out}"
+    );
+}
+
+#[test]
+fn register_real_short_flag_excludes_virtual_unbalanced() {
+    // -R is the short form of --real; verify it works identically.
+    let f = tmp_journal_file(virtual_register_journal());
+    let out = run(&["register", f.path().to_str().unwrap(), "-R"]);
+    assert!(
+        !out.contains("Equity:Reservations"),
+        "virtual unbalanced posting should be hidden with -R: {out}"
+    );
+    assert!(
+        out.contains("Assets:Checking"),
+        "real posting should still appear with -R: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // --tag filtering
 // ---------------------------------------------------------------------------
 

--- a/crates/doppio/src/ast.rs
+++ b/crates/doppio/src/ast.rs
@@ -362,6 +362,30 @@ impl Display for Transaction {
     }
 }
 
+/// Virtual-posting semantics for an [`ast::Posting`].
+///
+/// Ledger-cli permits two virtual-posting markers that change balance-rule
+/// semantics:
+///
+/// - `Real` — ordinary posting; participates in the transaction balance check.
+/// - `VirtualUnbalanced` — written as `(Account)`; the posting is excluded from
+///   the transaction's balance check. The two "real" postings must balance among
+///   themselves; the virtual posting is stored but contributes no balancing
+///   obligation.
+/// - `VirtualBalanced` — written as `[Account]`; the posting is included in the
+///   balance check (like a real posting) but is flagged so reports can show or
+///   hide it via `--real`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum PostingKind {
+    /// Ordinary posting — participates in the transaction balance check.
+    #[default]
+    Real,
+    /// `(Account)` — excluded from the balance check.
+    VirtualUnbalanced,
+    /// `[Account]` — included in the balance check, but flagged as virtual.
+    VirtualBalanced,
+}
+
 /// A single posting (debit or credit line) within a transaction.
 ///
 /// This is the raw parse-tree representation. For programmatic posting
@@ -369,6 +393,10 @@ impl Display for Transaction {
 #[derive(Clone, Default, Debug)]
 pub struct Posting {
     /// The account name, e.g. `"Expenses:Food"`.
+    ///
+    /// For virtual postings the surrounding markers (`(` `)` or `[` `]`) are
+    /// stripped by the parser — only the bare account name is stored here.
+    /// The marker semantics live in [`Self::kind`].
     pub account: String,
     /// The amount, or `None` if this is a "null posting" whose value should
     /// be inferred by the elaboration stage as the negation of all others.
@@ -377,16 +405,19 @@ pub struct Posting {
     pub state: TransactionState,
     /// Lines starting with `;` indented beneath the posting line.
     pub notes: Vec<String>,
+    /// Whether this is a real, virtual-unbalanced, or virtual-balanced posting.
+    pub kind: PostingKind,
 }
 
 impl Posting {
-    /// Creates a new posting for `account` with no amount and no notes.
+    /// Creates a new real posting for `account` with no amount and no notes.
     pub fn new<S: Into<String>>(account: S) -> Self {
         Self {
             account: account.into(),
             amount: None,
             state: TransactionState::Uncleared,
             notes: vec![],
+            kind: PostingKind::Real,
         }
     }
 

--- a/crates/doppio/src/elaboration_ext.rs
+++ b/crates/doppio/src/elaboration_ext.rs
@@ -48,6 +48,29 @@ impl elaboration::Amount {
 }
 
 impl elaboration::Posting {
+    /// Returns the posting kind, mapping the prost-generated `i32` to the
+    /// [`elaboration::PostingKind`] enum.
+    ///
+    /// `POSTING_KIND_UNSPECIFIED` (field absent in older `.dop` files) is
+    /// mapped to `POSTING_KIND_REAL`, preserving backward compatibility:
+    /// pre-#140 archives that don't carry this field are treated as all-real.
+    pub fn posting_kind(&self) -> elaboration::PostingKind {
+        elaboration::PostingKind::try_from(self.kind).unwrap_or(elaboration::PostingKind::Real)
+    }
+
+    /// Returns `true` iff this posting is a "real" (non-virtual) posting.
+    ///
+    /// Both `POSTING_KIND_UNSPECIFIED` and `POSTING_KIND_REAL` are treated as
+    /// real. Older `.dop` files that don't carry the `kind` field (field value
+    /// = 0 = UNSPECIFIED) are therefore treated as all-real on read — no format
+    /// version bump required.
+    pub fn is_real(&self) -> bool {
+        matches!(
+            self.posting_kind(),
+            elaboration::PostingKind::Unspecified | elaboration::PostingKind::Real
+        )
+    }
+
     /// Return this posting's amount, treating an absent amount field as an
     /// empty [`elaboration::Amount`].
     ///

--- a/crates/doppio/src/elaboration_ext.rs
+++ b/crates/doppio/src/elaboration_ext.rs
@@ -51,9 +51,12 @@ impl elaboration::Posting {
     /// Returns the posting kind, mapping the prost-generated `i32` to the
     /// [`elaboration::PostingKind`] enum.
     ///
-    /// `POSTING_KIND_UNSPECIFIED` (field absent in older `.dop` files) is
-    /// mapped to `POSTING_KIND_REAL`, preserving backward compatibility:
-    /// pre-#140 archives that don't carry this field are treated as all-real.
+    /// Unknown wire values (i.e. values that do not map to any `PostingKind`
+    /// variant) are mapped to `Real` via the `unwrap_or` fallback, preserving
+    /// forward-compatibility. `UNSPECIFIED` (wire value 0, field absent in
+    /// older `.dop` files) passes through as `PostingKind::Unspecified` and is
+    /// treated as real by [`Self::is_real`] — so pre-#140 archives that don't
+    /// carry this field are read as all-real without a format version bump.
     pub fn posting_kind(&self) -> elaboration::PostingKind {
         elaboration::PostingKind::try_from(self.kind).unwrap_or(elaboration::PostingKind::Real)
     }
@@ -505,5 +508,96 @@ mod tests {
             hp.date_naive(),
             NaiveDate::from_ymd_opt(2024, 3, 4).unwrap()
         );
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Posting::is_real / Posting::posting_kind
+    // ──────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn is_real_kind_zero_unspecified_treated_as_real() {
+        let p = elaboration::Posting {
+            kind: 0,
+            ..Default::default()
+        };
+        assert!(p.is_real(), "UNSPECIFIED (0) must be treated as real");
+    }
+
+    #[test]
+    fn is_real_kind_one_real_is_real() {
+        let p = elaboration::Posting {
+            kind: 1,
+            ..Default::default()
+        };
+        assert!(p.is_real());
+    }
+
+    #[test]
+    fn is_real_kind_two_virtual_unbalanced_is_not_real() {
+        let p = elaboration::Posting {
+            kind: 2,
+            ..Default::default()
+        };
+        assert!(!p.is_real());
+    }
+
+    #[test]
+    fn is_real_kind_three_virtual_balanced_is_not_real() {
+        let p = elaboration::Posting {
+            kind: 3,
+            ..Default::default()
+        };
+        assert!(!p.is_real());
+    }
+
+    #[test]
+    fn posting_kind_zero_returns_unspecified() {
+        let p = elaboration::Posting {
+            kind: 0,
+            ..Default::default()
+        };
+        assert_eq!(p.posting_kind(), elaboration::PostingKind::Unspecified);
+    }
+
+    #[test]
+    fn posting_kind_one_returns_real() {
+        let p = elaboration::Posting {
+            kind: 1,
+            ..Default::default()
+        };
+        assert_eq!(p.posting_kind(), elaboration::PostingKind::Real);
+    }
+
+    #[test]
+    fn posting_kind_two_returns_virtual_unbalanced() {
+        let p = elaboration::Posting {
+            kind: 2,
+            ..Default::default()
+        };
+        assert_eq!(
+            p.posting_kind(),
+            elaboration::PostingKind::VirtualUnbalanced
+        );
+    }
+
+    #[test]
+    fn posting_kind_three_returns_virtual_balanced() {
+        let p = elaboration::Posting {
+            kind: 3,
+            ..Default::default()
+        };
+        assert_eq!(p.posting_kind(), elaboration::PostingKind::VirtualBalanced);
+    }
+
+    #[test]
+    fn posting_kind_unknown_wire_value_falls_back_to_real() {
+        // An unknown wire value (e.g. from a future format version) should fall
+        // back to Real rather than panicking.
+        let p = elaboration::Posting {
+            kind: 99,
+            ..Default::default()
+        };
+        assert_eq!(p.posting_kind(), elaboration::PostingKind::Real);
+        assert!(p.is_real(), "unknown wire values must be treated as real");
     }
 }

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -399,6 +399,7 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                     let mut resolved_postings = vec![];
 
                     for mut posting in transaction.postings {
+                        let posting_kind = posting.kind;
                         if let Some(amount) = posting.amount {
                             let account_name = entry_context
                                 .account_aliases
@@ -511,15 +512,19 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                             };
                             let payee = posting.metadata.remove("payee").unwrap_or(payee.clone());
 
+                            // Virtual-unbalanced postings are excluded from the transaction's
+                            // balance check. Real and virtual-balanced postings both contribute.
                             // For lot-priced postings, add the *cash* total (in the lot's
                             // commodity) to transaction_state rather than the commodity units.
-                            // This is what needs to balance with the offsetting cash posting.
-                            if let Some((lot_total, lot_commodity)) = lot_pricing {
-                                let dec = transaction_state.0.entry(lot_commodity).or_default();
-                                *dec += lot_total;
-                            } else {
-                                let dec = transaction_state.0.entry(commodity.clone()).or_default();
-                                *dec += value;
+                            if posting_kind != ast::PostingKind::VirtualUnbalanced {
+                                if let Some((lot_total, lot_commodity)) = lot_pricing {
+                                    let dec = transaction_state.0.entry(lot_commodity).or_default();
+                                    *dec += lot_total;
+                                } else {
+                                    let dec =
+                                        transaction_state.0.entry(commodity.clone()).or_default();
+                                    *dec += value;
+                                }
                             }
 
                             let by_commodity =
@@ -531,9 +536,12 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                                 state: crate::state_to_proto(&posting.state.into()),
                                 tags: posting.tags,
                                 metadata: posting.metadata,
+                                kind: crate::posting_kind_to_proto(posting_kind),
                             });
                         } else {
-                            // Defer processing and save for next step
+                            // Defer processing and save for next step.
+                            // (Null postings are always REAL — you cannot write a null virtual
+                            // posting, so the kind is left as the default Real from the parser.)
                             null_postings.push(posting);
                         }
                     }
@@ -551,7 +559,10 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                         let payee = posting.metadata.remove("payee").unwrap_or(payee.clone());
 
                         // The null posting's amount is the negation of the sum of all
-                        // other postings, making the transaction balance to zero.
+                        // other real/balanced postings (virtual-unbalanced postings are
+                        // excluded from transaction_state, so they don't affect inference).
+                        // Null postings are always REAL; the kind field is left unspecified
+                        // (defaults to 0 = UNSPECIFIED which is treated as REAL by consumers).
                         let by_commodity = transaction_state
                             .0
                             .iter()
@@ -565,9 +576,14 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                             state: crate::state_to_proto(&posting.state.into()),
                             tags: posting.tags,
                             metadata: posting.metadata,
+                            kind: crate::posting_kind_to_proto(ast::PostingKind::Real),
                         });
                     } else {
                         // Check that transaction state is all zeros to balance the transaction.
+                        // Virtual-unbalanced postings have already been excluded from
+                        // transaction_state, so a transaction consisting solely of
+                        // virtual-unbalanced postings will have an empty (zero) state and
+                        // will not trigger this error — which is the correct ledger-cli behaviour.
                         if transaction_state.0.values().any(|value| !value.is_zero()) {
                             return Err(ElaborationError::TransactionDoesNotBalance(
                                 transaction_state,
@@ -3359,5 +3375,99 @@ account Assets:Savings
 ";
         // amount=500 > -100 → outer `or` short-circuits to true.
         elaborate(input);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Virtual posting unit tests (#140)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// A transaction with a real posting, a virtual-unbalanced posting, and
+    /// a null posting: the unbalanced posting must not affect the null-posting
+    /// inference (i.e. the null posting absorbs only the real posting's amount).
+    #[test]
+    fn virtual_unbalanced_does_not_affect_null_posting_inference() {
+        let input = "\
+2024-01-15 Test
+    Assets:Checking           $100
+    (Equity:Reservations)     $-25
+    Equity:Opening
+";
+        let j = elaborate(input);
+        let t = &j.transactions[0];
+        assert_eq!(t.postings.len(), 3);
+
+        // Null posting should be inferred as -$100 (negation of real $100),
+        // not -$75 (which would incorrectly include the virtual unbalanced).
+        let null_p = t
+            .postings
+            .iter()
+            .find(|p| p.account == "Equity:Opening")
+            .expect("null posting present");
+        assert_eq!(null_p.amount_in("$"), Some(dec!(-100)));
+
+        let virt = t
+            .postings
+            .iter()
+            .find(|p| p.account == "Equity:Reservations")
+            .expect("virtual posting present");
+        assert_eq!(virt.amount_in("$"), Some(dec!(-25)));
+
+        use crate::elaboration::PostingKind;
+        assert_eq!(virt.kind, PostingKind::VirtualUnbalanced as i32);
+        assert_eq!(null_p.kind, PostingKind::Real as i32);
+    }
+
+    /// A transaction with a real posting, a virtual-balanced posting, and a
+    /// null posting: the balanced posting participates in the null-posting
+    /// inference (the null absorbs the sum of real + balanced).
+    #[test]
+    fn virtual_balanced_participates_in_null_posting_inference() {
+        let input = "\
+2024-01-15 Test
+    Assets:Checking           $100
+    [Equity:Reservations]     $25
+    Equity:Opening
+";
+        let j = elaborate(input);
+        let t = &j.transactions[0];
+        assert_eq!(t.postings.len(), 3);
+
+        // Null posting absorbs -(100 + 25) = -$125 because the balanced
+        // virtual posting contributes to the transaction state.
+        let null_p = t
+            .postings
+            .iter()
+            .find(|p| p.account == "Equity:Opening")
+            .expect("null posting present");
+        assert_eq!(null_p.amount_in("$"), Some(dec!(-125)));
+
+        let virt = t
+            .postings
+            .iter()
+            .find(|p| p.account == "Equity:Reservations")
+            .expect("virtual posting present");
+        assert_eq!(virt.amount_in("$"), Some(dec!(25)));
+
+        use crate::elaboration::PostingKind;
+        assert_eq!(virt.kind, PostingKind::VirtualBalanced as i32);
+    }
+
+    /// A transaction consisting solely of virtual-unbalanced postings should
+    /// elaborate without a balance error: there are no real postings to balance.
+    #[test]
+    fn transaction_with_only_virtual_unbalanced_postings_does_not_error() {
+        let input = "\
+2024-01-15 Memo-only entry
+    (Budget:Food)    $50
+    (Budget:Travel)  $-50
+";
+        let j = elaborate(input);
+        let t = &j.transactions[0];
+        assert_eq!(t.postings.len(), 2);
+
+        use crate::elaboration::PostingKind;
+        for p in &t.postings {
+            assert_eq!(p.kind, PostingKind::VirtualUnbalanced as i32);
+        }
     }
 }

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -677,6 +677,10 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                     }
 
                     // Update running account balances and register new accounts.
+                    // Virtual unbalanced postings DO update the running per-account
+                    // balance (matching ledger-cli) so subsequent balance assertions
+                    // on the same account see the virtual contribution. They are
+                    // excluded only from the transaction-balance check.
                     for posting in resolved_postings.iter() {
                         if !accounts.contains_key(&posting.account) {
                             accounts.insert(posting.account.clone(), Default::default());
@@ -3469,5 +3473,35 @@ account Assets:Savings
         for p in &t.postings {
             assert_eq!(p.kind, PostingKind::VirtualUnbalanced as i32);
         }
+    }
+
+    /// A virtual-unbalanced posting must update the running per-account balance
+    /// so that a subsequent standalone balance assertion on the same account
+    /// reflects the virtual amount — matching ledger-cli behaviour.
+    #[test]
+    fn virtual_unbalanced_posting_updates_account_balance_for_assertions() {
+        // The virtual posting credits $-25 to Equity:Reservations.
+        // A subsequent balance assertion checks that the account balance is $-25,
+        // which should succeed because virtual-unbalanced postings contribute to
+        // account_balances even though they're excluded from the transaction check.
+        let input = "\
+2024-01-15 Setup
+    Assets:Checking           $100
+    (Equity:Reservations)     $-25
+    Equity:Opening
+
+2024-01-15 = Equity:Reservations  $-25
+";
+        // Should elaborate without error — the balance assertion sees the virtual
+        // posting's contribution.
+        let j = elaborate(input);
+        assert_eq!(j.transactions.len(), 1);
+
+        let virt = j.transactions[0]
+            .postings
+            .iter()
+            .find(|p| p.account == "Equity:Reservations")
+            .expect("virtual posting present");
+        assert_eq!(virt.amount_in("$"), Some(dec!(-25)));
     }
 }

--- a/crates/doppio/src/grammars/hledger/hledger.pest
+++ b/crates/doppio/src/grammars/hledger/hledger.pest
@@ -95,13 +95,29 @@ rule_query = @{ (!(NEWLINE | ";") ~ ANY)+ }
 posting = ${
     indent+ ~ !NEWLINE ~
     (status ~ ws+)? ~
-    account ~
+    posting_account ~
     (amount_logic)? ~
     (ws* ~ note)? ~
     (NEWLINE | EOI) ~
     posting_note*
 }
 posting_note = ${ indent+ ~ note ~ (NEWLINE | EOI) }
+
+// The account portion of a posting: bare name or a virtual-posting marker.
+posting_account = ${
+    virtual_unbalanced_account
+    | virtual_balanced_account
+    | account
+}
+
+// `(Account)` — virtual unbalanced posting.
+virtual_unbalanced_account = ${ "(" ~ virtual_account_inner ~ ")" }
+
+// `[Account]` — virtual balanced posting.
+virtual_balanced_account = ${ "[" ~ virtual_account_inner ~ "]" }
+
+// Bare account name inside a virtual posting marker (parens/brackets stripped).
+virtual_account_inner = @{ (!("  " | ";" | "\t" | "=" | NEWLINE | ")" | "]") ~ ANY)+ }
 
 // The amount field of a posting.
 // Two or more spaces (or a tab) separate the account from the amount —

--- a/crates/doppio/src/grammars/hledger/mod.rs
+++ b/crates/doppio/src/grammars/hledger/mod.rs
@@ -921,6 +921,60 @@ mod tests {
         assert_eq!(txns.len(), 1);
     }
 
+    // ── virtual postings ──────────────────────────────────────────────────────
+
+    #[test]
+    fn virtual_unbalanced_posting_parses_to_correct_kind() {
+        // `(Equity:Reservations)` — parentheses denote a virtual-unbalanced
+        // posting. The account name must have the parens stripped and the kind
+        // must be `PostingKind::VirtualUnbalanced`.
+        let input = "\
+2024-01-15 Setup
+    Assets:Checking         $100
+    Equity:Opening         $-100
+    (Equity:Reservations)   $-25
+";
+        let journal = parse_hledger(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!("expected transaction");
+        };
+        let virt = tx
+            .postings
+            .iter()
+            .find(|p| p.account == "Equity:Reservations")
+            .expect("virtual posting should be present with parens stripped");
+        assert_eq!(
+            virt.kind,
+            PostingKind::VirtualUnbalanced,
+            "posting kind should be VirtualUnbalanced"
+        );
+    }
+
+    #[test]
+    fn virtual_balanced_posting_parses_to_correct_kind() {
+        // `[Equity:Reservations]` — square brackets denote a virtual-balanced posting.
+        let input = "\
+2024-01-15 Setup
+    Assets:Checking          $100
+    [Equity:Reservations]    $25
+    Equity:Opening          $-125
+";
+        let journal = parse_hledger(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!("expected transaction");
+        };
+        let virt = tx
+            .postings
+            .iter()
+            .find(|p| p.account == "Equity:Reservations")
+            .expect("virtual posting should be present with brackets stripped");
+        assert_eq!(
+            virt.kind,
+            PostingKind::VirtualBalanced,
+            "posting kind should be VirtualBalanced"
+        );
+    }
+
     // ── full sample-journal smoke test ────────────────────────────────────────
 
     #[test]

--- a/crates/doppio/src/grammars/hledger/mod.rs
+++ b/crates/doppio/src/grammars/hledger/mod.rs
@@ -176,13 +176,45 @@ fn parse_posting(pair: Pair<Rule>) -> Posting {
     let inner = pair.into_inner();
     let mut state = TransactionState::Uncleared;
     let mut account = String::new();
+    let mut kind = PostingKind::Real;
     let mut amount = None;
     let mut notes = Vec::new();
 
     for p in inner {
         match p.as_rule() {
             Rule::status => state = parse_state(p.as_str()),
-            Rule::account => account = p.as_str().trim().to_string(),
+            Rule::posting_account => {
+                let inner_pair = p
+                    .into_inner()
+                    .next()
+                    .expect("posting_account must have one child");
+                match inner_pair.as_rule() {
+                    Rule::virtual_unbalanced_account => {
+                        kind = PostingKind::VirtualUnbalanced;
+                        account = inner_pair
+                            .into_inner()
+                            .next()
+                            .expect("virtual_unbalanced_account must have virtual_account_inner")
+                            .as_str()
+                            .trim()
+                            .to_string();
+                    }
+                    Rule::virtual_balanced_account => {
+                        kind = PostingKind::VirtualBalanced;
+                        account = inner_pair
+                            .into_inner()
+                            .next()
+                            .expect("virtual_balanced_account must have virtual_account_inner")
+                            .as_str()
+                            .trim()
+                            .to_string();
+                    }
+                    Rule::account => {
+                        account = inner_pair.as_str().trim().to_string();
+                    }
+                    _ => {}
+                }
+            }
             Rule::amount_logic => amount = Some(parse_amount_logic(p)),
             Rule::note => notes.push(p.into_inner().as_str().trim().to_string()),
             Rule::posting_note => {
@@ -199,6 +231,7 @@ fn parse_posting(pair: Pair<Rule>) -> Posting {
         amount,
         state,
         notes,
+        kind,
     }
 }
 

--- a/crates/doppio/src/grammars/ledger/ledger.pest
+++ b/crates/doppio/src/grammars/ledger/ledger.pest
@@ -73,9 +73,31 @@ empty_indented_line = _{ indent+ ~ NEWLINE }
 // The !NEWLINE lookahead prevents a truly empty indented line from being
 // matched as a posting with an empty account name.
 posting = ${
-    indent+ ~ !NEWLINE ~ (state ~ ws+)? ~ account ~ (amount_logic)? ~ (ws* ~ note)? ~ (NEWLINE | EOI) ~
+    indent+ ~ !NEWLINE ~ (state ~ ws+)? ~ posting_account ~ (amount_logic)? ~ (ws* ~ note)? ~ (NEWLINE | EOI) ~
     posting_note*
 }
+
+// The account portion of a posting, which may be a bare account name or a
+// virtual-posting marker wrapping an account name.
+posting_account = ${
+    virtual_unbalanced_account
+    | virtual_balanced_account
+    | account
+}
+
+// `(Account)` — virtual unbalanced: the posting is excluded from the
+// transaction's balance check. The parens are part of the syntax, not the
+// account name; the inner name is captured by `virtual_account_inner`.
+virtual_unbalanced_account = ${ "(" ~ virtual_account_inner ~ ")" }
+
+// `[Account]` — virtual balanced: the posting participates in the balance
+// check but is flagged so reports can include/exclude it via `--real`.
+virtual_balanced_account = ${ "[" ~ virtual_account_inner ~ "]" }
+
+// The bare account name inside a virtual posting marker. The exclusion set
+// matches `account` but also stops at `)` and `]` so the closing marker is
+// never consumed into the name.
+virtual_account_inner = @{ (!("  " | ";" | "\t" | "=" | NEWLINE | ")" | "]") ~ ANY)+ }
 
 // A note line indented beneath a posting.
 posting_note = ${ indent+ ~ note ~ (NEWLINE | EOI) }

--- a/crates/doppio/src/grammars/ledger/mod.rs
+++ b/crates/doppio/src/grammars/ledger/mod.rs
@@ -609,13 +609,47 @@ fn parse_posting(pair: Pair<Rule>) -> Posting {
     let inner = pair.into_inner();
     let mut state = TransactionState::Uncleared;
     let mut account = String::new();
+    let mut kind = PostingKind::Real;
     let mut amount = None;
     let mut notes = Vec::new();
 
     for p in inner {
         match p.as_rule() {
             Rule::state => state = parse_state(p.as_str()),
-            Rule::account => account = p.as_str().trim().to_string(),
+            Rule::posting_account => {
+                // posting_account = virtual_unbalanced_account | virtual_balanced_account | account
+                let inner_pair = p
+                    .into_inner()
+                    .next()
+                    .expect("posting_account must have one child");
+                match inner_pair.as_rule() {
+                    Rule::virtual_unbalanced_account => {
+                        kind = PostingKind::VirtualUnbalanced;
+                        // Inner child is virtual_account_inner — the bare account name.
+                        account = inner_pair
+                            .into_inner()
+                            .next()
+                            .expect("virtual_unbalanced_account must have virtual_account_inner")
+                            .as_str()
+                            .trim()
+                            .to_string();
+                    }
+                    Rule::virtual_balanced_account => {
+                        kind = PostingKind::VirtualBalanced;
+                        account = inner_pair
+                            .into_inner()
+                            .next()
+                            .expect("virtual_balanced_account must have virtual_account_inner")
+                            .as_str()
+                            .trim()
+                            .to_string();
+                    }
+                    Rule::account => {
+                        account = inner_pair.as_str().trim().to_string();
+                    }
+                    _ => {}
+                }
+            }
             Rule::amount_logic => amount = Some(parse_amount_logic(p)),
             Rule::note => notes.push(p.as_str().trim().to_string()),
             Rule::posting_note => {
@@ -632,6 +666,7 @@ fn parse_posting(pair: Pair<Rule>) -> Posting {
         amount,
         state,
         notes,
+        kind,
     }
 }
 

--- a/crates/doppio/src/lib.rs
+++ b/crates/doppio/src/lib.rs
@@ -188,6 +188,15 @@ fn state_to_proto(s: &elaborator::TransactionState) -> i32 {
     }
 }
 
+/// Convert an [`ast::PostingKind`] to its proto enum value (i32).
+pub(crate) fn posting_kind_to_proto(kind: ast::PostingKind) -> i32 {
+    match kind {
+        ast::PostingKind::Real => elaboration::PostingKind::Real as i32,
+        ast::PostingKind::VirtualUnbalanced => elaboration::PostingKind::VirtualUnbalanced as i32,
+        ast::PostingKind::VirtualBalanced => elaboration::PostingKind::VirtualBalanced as i32,
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Public write/read API
 // ──────────────────────────────────────────────────────────────────────────────

--- a/crates/doppio/src/lib.rs
+++ b/crates/doppio/src/lib.rs
@@ -191,6 +191,8 @@ fn state_to_proto(s: &elaborator::TransactionState) -> i32 {
 /// Convert an [`ast::PostingKind`] to its proto enum value (i32).
 pub(crate) fn posting_kind_to_proto(kind: ast::PostingKind) -> i32 {
     match kind {
+        // Emit REAL (1) rather than UNSPECIFIED (0) for clarity, even though
+        // consumers treat both identically per is_real().
         ast::PostingKind::Real => elaboration::PostingKind::Real as i32,
         ast::PostingKind::VirtualUnbalanced => elaboration::PostingKind::VirtualUnbalanced as i32,
         ast::PostingKind::VirtualBalanced => elaboration::PostingKind::VirtualBalanced as i32,

--- a/crates/doppio/src/resolution.rs
+++ b/crates/doppio/src/resolution.rs
@@ -330,6 +330,10 @@ impl std::fmt::Display for Transaction {
 #[derive(Default, Debug)]
 pub struct Posting {
     /// The account name as written in the source (not yet alias-resolved).
+    ///
+    /// For virtual postings the surrounding markers are stripped by the parser;
+    /// only the bare account name is stored here. The marker semantics live in
+    /// [`Self::kind`].
     pub account: String,
     /// The unevaluated amount, or `None` for a null posting.
     pub amount: Option<ast::AmountDetails>,
@@ -341,6 +345,8 @@ pub struct Posting {
     pub metadata: BTreeMap<String, String>,
     /// Plain note lines that are neither tags nor key-value metadata.
     pub comments: Vec<String>,
+    /// Virtual-posting kind (real, unbalanced, or balanced).
+    pub kind: ast::PostingKind,
 }
 
 impl Posting {
@@ -658,6 +664,7 @@ impl TryFrom<ast::Journal> for HIR {
                                 tags,
                                 metadata,
                                 comments,
+                                kind: p.kind,
                             }
                         })
                         .collect();

--- a/crates/doppio/tests/parity.rs
+++ b/crates/doppio/tests/parity.rs
@@ -530,7 +530,6 @@ fn lot_persistence_note() {
 }
 
 #[test]
-#[ignore = "tracks #140 — virtual postings (Account) not yet supported"]
 fn virtual_posting_unbalanced() {
     // Fixture has 3 postings: Assets:Checking $100, Equity:Opening -$100,
     // (Equity:Reservations) -$25. The parens mark the third as a virtual
@@ -558,12 +557,31 @@ fn virtual_posting_unbalanced() {
         .sum();
     assert_eq!(real_sum, dec!(0), "real postings should balance to 0");
 
-    // TODO(#140): once proto::Posting.kind ships, assert:
-    //   assert_eq!(virt.kind, PostingKind::VirtualUnbalanced as i32);
+    // Virtual-unbalanced posting carries the correct kind field.
+    use doppio::elaboration::PostingKind;
+    assert_eq!(
+        virt.kind,
+        PostingKind::VirtualUnbalanced as i32,
+        "virtual posting should carry PostingKind::VirtualUnbalanced"
+    );
+
+    // Real postings carry kind == Real.
+    let real_postings: Vec<_> = t
+        .postings
+        .iter()
+        .filter(|p| p.account != "Equity:Reservations")
+        .collect();
+    for p in &real_postings {
+        assert_eq!(
+            p.kind,
+            PostingKind::Real as i32,
+            "non-virtual posting {} should carry PostingKind::Real",
+            p.account
+        );
+    }
 }
 
 #[test]
-#[ignore = "tracks #140 — virtual postings [Account] not yet supported"]
 fn virtual_posting_balanced() {
     // Fixture has 3 postings: Assets:Checking $100, [Equity:Reservations]
     // $25, Equity:Opening -$125. Brackets mark the second as a virtual
@@ -590,8 +608,13 @@ fn virtual_posting_balanced() {
         "virtual balanced posting should participate in balance"
     );
 
-    // TODO(#140): once proto::Posting.kind ships, assert:
-    //   assert_eq!(virt.kind, PostingKind::VirtualBalanced as i32);
+    // Virtual-balanced posting carries the correct kind field.
+    use doppio::elaboration::PostingKind;
+    assert_eq!(
+        virt.kind,
+        PostingKind::VirtualBalanced as i32,
+        "virtual balanced posting should carry PostingKind::VirtualBalanced"
+    );
 }
 
 #[test]

--- a/docs/SUPPORTED_FEATURES.md
+++ b/docs/SUPPORTED_FEATURES.md
@@ -35,6 +35,8 @@ Status legend:
 | Negative amounts | ✅ | Both `-$100` and `$-100` |
 | Lot pricing `@ unit` | ✅ | |
 | Lot pricing `@@ total` | ✅ | |
+| Virtual posting `(Account)` | ✅ | Unbalanced — excluded from balance check; stored with `PostingKind::VirtualUnbalanced` |
+| Virtual posting `[Account]` | ✅ | Balanced — included in balance check; stored with `PostingKind::VirtualBalanced` |
 | Null posting (auto-inferred amount) | ✅ | Exactly one per transaction; multiple null postings is an error |
 | Posting balance assertion `= amount` | ✅ | Enforced during elaboration |
 | Strict balance assertion `== amount` | ✅ | Enforced during elaboration |
@@ -114,8 +116,10 @@ Status legend:
 | `dop balance --tag KEY` | ✅ | v0.2.0 (PR #72) |
 | `dop balance --pattern REGEX` | ✅ | Account-name regex |
 | `dop balance --format text\|json\|csv` | ✅ | |
+| `dop balance --real` / `-R` | ✅ | Excludes virtual postings (`(Account)` and `[Account]`) from output |
 | `dop register` | ✅ | Per-posting register with running totals per commodity |
 | `dop register --begin/--end/--cleared/--tag/--format` | ✅ | Same filters as `balance` |
+| `dop register --real` / `-R` | ✅ | Excludes virtual postings from register output |
 | `dop print SRC` | ✅ | Re-emits source. Format strings not applied (intentional) |
 | `dop stats` | ✅ | Transaction/account/commodity counts and date range |
 | `dop accounts` | ✅ | Lists unique account names |
@@ -131,6 +135,7 @@ Status legend:
 | `write_ledger(txns, writer)` | ✅ | Canonical Ledger source-text output |
 | `dop_write_header` / `dop_read_header` | ✅ | Portable `.dop` header I/O with version-mismatch errors |
 | `resolution::Transaction` / `Posting` builder API | ✅ | Fluent construction with `with_*` helpers |
+| `elaboration::PostingKind` enum (`Real`, `VirtualUnbalanced`, `VirtualBalanced`) | ✅ | Carried on `elaboration::Posting::kind`; UNSPECIFIED=0 decodes as Real for backward compat |
 | `parser::Parser<F>::opener` returning `Result` | ✅ | v0.2.0 breaking change. Custom openers can surface I/O errors |
 | `.dop` binary format v2 (`elaboration::Journal` with `commodities`) | ✅ | v0.2.0 breaking change. v1 files are rejected with a clear "recompile" message |
 | Append / framed `.dop` (range-scan, partial decode) | 🚫 | Phase 4 / issues #17, #39–41 |
@@ -162,6 +167,8 @@ file extensions; selected automatically by `dop` and by
 | `commodity` directive (format string) | ✅ | Both `$1,000.00` and `1,000.00 EUR` forms |
 | `commodity` directive with indented sub-directives | ✅ | `alias`, `format`, `nomarket`, `default`, `note` |
 | `include` directive (literal and glob) | ✅ | Same glob expansion as ledger-cli frontend |
+| Virtual posting `(Account)` | ✅ | Unbalanced virtual; same semantics as ledger-cli frontend |
+| Virtual posting `[Account]` | ✅ | Balanced virtual; same semantics as ledger-cli frontend |
 | Arithmetic in posting amounts | ✅ | Pratt-parsed; same precedence as ledger-cli |
 | Comment lines `;` | ✅ | |
 | Comment lines `#` | ✅ | hledger extension; not accepted by ledger-cli frontend |

--- a/proto/doppio.proto
+++ b/proto/doppio.proto
@@ -89,6 +89,28 @@ enum TransactionState {
   TRANSACTION_STATE_CLEARED = 3;
 }
 
+// Virtual-posting semantics for a posting.
+//
+// Ledger-cli supports two virtual-posting markers that change balance-rule
+// semantics:
+//
+//   Real (default)            — normal posting; participates in balance check.
+//   VirtualUnbalanced  `(A)` — excluded from the transaction balance check.
+//                               Reports include it by default; omit with --real.
+//   VirtualBalanced    `[A]` — included in the balance check but flagged so
+//                               reports can include/exclude via --real.
+//
+// Proto3 evolution note: the default zero value (UNSPECIFIED) is intentionally
+// treated as REAL by all consumers, so older `.dop` files that pre-date this
+// field continue to behave as if every posting is REAL on read — no format-
+// version bump required.
+enum PostingKind {
+  POSTING_KIND_UNSPECIFIED = 0;        // Treated as REAL by all consumers.
+  POSTING_KIND_REAL = 1;
+  POSTING_KIND_VIRTUAL_UNBALANCED = 2; // `(Account)` — excluded from balance.
+  POSTING_KIND_VIRTUAL_BALANCED = 3;   // `[Account]` — included in balance, flagged.
+}
+
 // A multi-commodity balance: commodity symbol -> Decimal value.
 //
 // Iteration-order note: `by_commodity` is a protobuf `map<string, Decimal>`.
@@ -117,7 +139,9 @@ message Amount {
 
 // A posting with a fully evaluated, concrete amount.
 message Posting {
-  // The canonical account name (after alias resolution).
+  // The canonical account name (after alias resolution). For virtual postings
+  // the surrounding markers (`(` `)` or `[` `]`) are stripped — only the bare
+  // account name is stored here; the marker semantics live in `kind`.
   string account = 1;
   // Payee for this posting — taken from posting-level `payee:` metadata if
   // present, otherwise inherited from the transaction description.
@@ -130,6 +154,9 @@ message Posting {
   repeated string tags = 5;
   // Key-value metadata from `; key: value` in posting notes.
   map<string, string> metadata = 6;
+  // Virtual-posting kind. Defaults to REAL (via UNSPECIFIED = 0) so that
+  // older `.dop` files without this field continue to behave as all-real.
+  PostingKind kind = 7;
 }
 
 // A fully evaluated and balanced transaction.


### PR DESCRIPTION
## Summary

- Adds `(Account)` virtual-unbalanced and `[Account]` virtual-balanced posting syntax to both the ledger-cli and hledger frontends
- Virtual-unbalanced postings are excluded from the per-transaction balance check; virtual-balanced postings participate in the balance check but are flagged with their own kind
- Introduces `PostingKind` enum in the proto schema (`REAL`, `VIRTUAL_UNBALANCED`, `VIRTUAL_BALANCED`) with `UNSPECIFIED=0` default preserving backward compatibility for existing `.dop` binary files
- Adds `-R` / `--real` flag to `dop balance` and `dop register` to filter out virtual postings from output

## Schema additions

```proto
enum PostingKind {
  POSTING_KIND_UNSPECIFIED = 0;   // decoded as REAL by all consumers
  POSTING_KIND_REAL = 1;
  POSTING_KIND_VIRTUAL_UNBALANCED = 2;
  POSTING_KIND_VIRTUAL_BALANCED = 3;
}
// Added to Posting message:
PostingKind kind = 7;
```

## Grammar additions (ledger + hledger, identical)

```pest
posting_account = ${ virtual_unbalanced_account | virtual_balanced_account | account }
virtual_unbalanced_account = ${ "(" ~ virtual_account_inner ~ ")" }
virtual_balanced_account   = ${ "[" ~ virtual_account_inner ~ "]" }
virtual_account_inner      = @{ (!("  " | ";" | "\t" | "=" | NEWLINE | ")" | "]") ~ ANY)+ }
```

## Elaborator semantics

- Virtual-unbalanced postings are processed in the first pass (they carry explicit amounts) but their amounts are **not** accumulated into `transaction_state`, so null-posting inference works correctly for the remaining real postings
- Virtual-balanced postings do participate in the balance check
- Both kinds round-trip through the proto `kind` field

## CLI behaviour

- `--real` / `-R` on `balance` and `register` skips any posting where `posting_kind()` is not `Real` or `Unspecified`
- Both tree and flat balance modes respect the flag; all three output formats (text, json, csv) respect it

## Test plan

- [x] `cargo test --workspace` — 184 lib tests, 38 parity tests (including 2 newly-unignored virtual posting tests), 22 balance CLI tests (3 new `--real` tests), 14 register CLI tests, 12 doppio-categorize tests, 3 new elaborator unit tests
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo bench --no-run --workspace` — all bench targets compile
- [x] `cargo build --target wasm32-unknown-unknown -p doppio --lib` — clean
- [x] `docs/SUPPORTED_FEATURES.md` updated (virtual posting rows, `--real` CLI rows, `PostingKind` library row, hledger parity rows)

Closes #140