### PR TITLE
feat: lot persistence annotations {cost} / [date] / ((note)) (closes #139)

### DIFF
--- a/crates/doppio-categorize/tests/integration.rs
+++ b/crates/doppio-categorize/tests/integration.rs
@@ -44,7 +44,7 @@ fn posting(account: &str, payee: &str, amt: Decimal) -> Posting {
         state: TransactionState::Uncleared as i32,
         tags: Vec::new(),
         metadata: BTreeMap::new(),
-        kind: 0, // POSTING_KIND_UNSPECIFIED (treated as REAL)
+        ..Default::default()
     }
 }
 
@@ -524,7 +524,7 @@ fn posting_with_no_amount_is_skipped() {
                 state: TransactionState::Uncleared as i32,
                 tags: Vec::new(),
                 metadata: BTreeMap::new(),
-                kind: 0, // POSTING_KIND_UNSPECIFIED (treated as REAL)
+                ..Default::default()
             },
             posting("Expenses:Unknown", "Mystery", dec!(10.00)),
         ],

--- a/crates/doppio/src/ast.rs
+++ b/crates/doppio/src/ast.rs
@@ -463,10 +463,12 @@ pub enum AmountDetails {
     /// A standard amount expression, with optional lot pricing and/or a
     /// balance assertion.
     ///
-    /// Example: `10 AAPL @ $150 = $1500`
+    /// Example: `10 AAPL {$150} @ $155 = $1550`
     Amount {
         /// The value expression (may be arithmetic, e.g. `(100 + 50) USD`).
         value: ValueExpr,
+        /// Lot persistence annotations: `{cost}`, `[date]`, `((note))`.
+        lot_annotation: Option<LotAnnotation>,
         /// Cost basis: `@ price_per_unit` or `@@ total_cost`.
         lot_pricing: Option<LotPricing>,
         /// If present, the account balance after this posting must equal this
@@ -482,6 +484,7 @@ impl<I: Into<ValueExpr>> From<I> for AmountDetails {
     fn from(value: I) -> Self {
         AmountDetails::Amount {
             value: value.into(),
+            lot_annotation: None,
             lot_pricing: None,
             balance_assertion: None,
         }
@@ -493,10 +496,22 @@ impl Display for AmountDetails {
         match self {
             AmountDetails::Amount {
                 value,
+                lot_annotation,
                 lot_pricing,
                 balance_assertion,
             } => {
                 write!(f, "{value}")?;
+                if let Some(ann) = lot_annotation {
+                    if let Some(cost) = &ann.cost {
+                        write!(f, " {{{cost}}}")?;
+                    }
+                    if let Some(date) = ann.date {
+                        write!(f, " [{date}]")?;
+                    }
+                    if let Some(note) = &ann.note {
+                        write!(f, " (({note}))")?;
+                    }
+                }
                 if let Some(lot_pricing) = lot_pricing {
                     match lot_pricing {
                         LotPricing::Unit(value_expr) => write!(f, " @ {value_expr}")?,
@@ -691,6 +706,22 @@ pub enum LotPricing {
     Total(ValueExpr),
 }
 
+/// Lot persistence annotations that pin per-lot metadata for capital-gains
+/// tracking and FIFO/LIFO lot selection.
+///
+/// Corresponds to the `{cost}`, `[date]`, and `((note))` annotation forms
+/// in ledger-cli syntax.  All fields are optional; the struct is present on
+/// an [`AmountDetails::Amount`] only when at least one annotation was found.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct LotAnnotation {
+    /// Per-unit cost basis.  `None` if no `{cost}` annotation was present.
+    pub cost: Option<ValueExpr>,
+    /// Acquisition date.  `None` if no `[date]` annotation was present.
+    pub date: Option<chrono::NaiveDate>,
+    /// Free-form note.  `None` if no `((note))` annotation was present.
+    pub note: Option<String>,
+}
+
 /// Cleared/pending state of a transaction or individual posting.
 #[derive(Clone, Debug, Default)]
 pub enum TransactionState {
@@ -758,6 +789,7 @@ mod tests {
                 value: Decimal::from(100),
                 commodity: Some("USD".into()),
             },
+            lot_annotation: None,
             lot_pricing: None,
             balance_assertion: None,
         });

--- a/crates/doppio/src/elaboration_ext.rs
+++ b/crates/doppio/src/elaboration_ext.rs
@@ -115,9 +115,7 @@ impl elaboration::Posting {
     pub fn amount_in(&self, commodity: &str) -> Option<rust_decimal::Decimal> {
         self.amount.as_ref()?.get(commodity)
     }
-}
 
-impl elaboration::Posting {
     /// Returns `true` iff this posting carries any lot annotation (cost, date,
     /// or note).  Returns `false` when `self.lot` is absent or all three fields
     /// are unset.
@@ -138,8 +136,7 @@ impl elaboration::Posting {
     /// `[date]` annotation was present.
     pub fn lot_date_naive(&self) -> Option<chrono::NaiveDate> {
         let days = self.lot.as_ref()?.date?;
-        let epoch = chrono::NaiveDate::from_ymd_opt(1970, 1, 1).expect("epoch is valid");
-        Some(epoch + chrono::TimeDelta::days(days as i64))
+        Some(epoch_days_to_naive_date(days))
     }
 
     /// The lot's free-form note, or `None` if no `((note))` annotation was
@@ -723,6 +720,143 @@ mod tests {
         );
     }
 
+    #[test]
+    fn posting_kind_three_returns_virtual_balanced() {
+        let p = elaboration::Posting {
+            kind: 3,
+            ..Default::default()
+        };
+        assert_eq!(p.posting_kind(), elaboration::PostingKind::VirtualBalanced);
+    }
+
+    #[test]
+    fn posting_kind_unknown_wire_value_falls_back_to_real() {
+        // An unknown wire value (e.g. from a future format version) should fall
+        // back to Real rather than panicking.
+        let p = elaboration::Posting {
+            kind: 99,
+            ..Default::default()
+        };
+        assert_eq!(p.posting_kind(), elaboration::PostingKind::Real);
+        assert!(p.is_real(), "unknown wire values must be treated as real");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Lot accessor unit tests
+    // ──────────────────────────────────────────────────────────────────────
+
+    fn posting_with_lot(lot: elaboration::Lot) -> elaboration::Posting {
+        elaboration::Posting {
+            account: "Assets:Brokerage".to_string(),
+            amount: Some(elaboration::Amount {
+                by_commodity: [("AAPL".to_string(), make_decimal(0, 10, 0))].into(),
+            }),
+            lot: Some(lot),
+            ..Default::default()
+        }
+    }
+
+    fn posting_no_lot() -> elaboration::Posting {
+        elaboration::Posting {
+            account: "Assets:Cash".to_string(),
+            amount: Some(elaboration::Amount {
+                by_commodity: [("USD".to_string(), make_decimal(0, 100, 0))].into(),
+            }),
+            lot: None,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn has_lot_returns_false_when_no_annotation() {
+        let posting = posting_no_lot();
+        assert!(!posting.has_lot());
+    }
+
+    #[test]
+    fn has_lot_returns_false_when_lot_all_none() {
+        // A lot proto message present but all fields unset.
+        let posting = posting_with_lot(elaboration::Lot {
+            cost: None,
+            date: None,
+            note: None,
+        });
+        assert!(!posting.has_lot());
+    }
+
+    #[test]
+    fn has_lot_returns_true_when_cost_set() {
+        let cost = elaboration::Amount {
+            by_commodity: [("$".to_string(), make_decimal(0, 150, 0))].into(),
+        };
+        let posting = posting_with_lot(elaboration::Lot {
+            cost: Some(cost),
+            date: None,
+            note: None,
+        });
+        assert!(posting.has_lot());
+    }
+
+    #[test]
+    fn has_lot_returns_true_when_only_date_set() {
+        let posting = posting_with_lot(elaboration::Lot {
+            cost: None,
+            date: Some(epoch_days(2024, 3, 1)),
+            note: None,
+        });
+        assert!(posting.has_lot());
+    }
+
+    #[test]
+    fn lot_cost_in_returns_decimal_when_present() {
+        let cost = elaboration::Amount {
+            by_commodity: [("$".to_string(), make_decimal(0, 150, 0))].into(),
+        };
+        let posting = posting_with_lot(elaboration::Lot {
+            cost: Some(cost),
+            date: None,
+            note: None,
+        });
+        assert_eq!(posting.lot_cost_in("$"), Some(Decimal::from(150u32)));
+    }
+
+    #[test]
+    fn lot_cost_in_returns_none_when_commodity_absent() {
+        let cost = elaboration::Amount {
+            by_commodity: [("$".to_string(), make_decimal(0, 150, 0))].into(),
+        };
+        let posting = posting_with_lot(elaboration::Lot {
+            cost: Some(cost),
+            date: None,
+            note: None,
+        });
+        // "EUR" is not in the cost amount.
+        assert_eq!(posting.lot_cost_in("EUR"), None);
+    }
+
+    #[test]
+    fn lot_date_naive_round_trips_through_epoch() {
+        let date = NaiveDate::from_ymd_opt(2024, 3, 15).unwrap();
+        let days = epoch_days(2024, 3, 15);
+        let posting = posting_with_lot(elaboration::Lot {
+            cost: None,
+            date: Some(days),
+            note: None,
+        });
+        assert_eq!(posting.lot_date_naive(), Some(date));
+    }
+
+    #[test]
+    fn lot_note_returns_str_when_present() {
+        let posting = posting_with_lot(elaboration::Lot {
+            cost: None,
+            date: None,
+            note: Some("BUY-2024-01".to_string()),
+        });
+        assert_eq!(posting.lot_note(), Some("BUY-2024-01"));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
     // Journal::exchange_rate_at
     // ──────────────────────────────────────────────────────────────────────
 
@@ -847,27 +981,6 @@ mod tests {
             None,
             "future quote must be invisible to past as_of"
         );
-    }
-
-    #[test]
-    fn posting_kind_three_returns_virtual_balanced() {
-        let p = elaboration::Posting {
-            kind: 3,
-            ..Default::default()
-        };
-        assert_eq!(p.posting_kind(), elaboration::PostingKind::VirtualBalanced);
-    }
-
-    #[test]
-    fn posting_kind_unknown_wire_value_falls_back_to_real() {
-        // An unknown wire value (e.g. from a future format version) should fall
-        // back to Real rather than panicking.
-        let p = elaboration::Posting {
-            kind: 99,
-            ..Default::default()
-        };
-        assert_eq!(p.posting_kind(), elaboration::PostingKind::Real);
-        assert!(p.is_real(), "unknown wire values must be treated as real");
     }
 
     #[test]

--- a/crates/doppio/src/elaboration_ext.rs
+++ b/crates/doppio/src/elaboration_ext.rs
@@ -117,6 +117,38 @@ impl elaboration::Posting {
     }
 }
 
+impl elaboration::Posting {
+    /// Returns `true` iff this posting carries any lot annotation (cost, date,
+    /// or note).  Returns `false` when `self.lot` is absent or all three fields
+    /// are unset.
+    pub fn has_lot(&self) -> bool {
+        self.lot
+            .as_ref()
+            .map(|l| l.cost.is_some() || l.date.is_some() || l.note.is_some())
+            .unwrap_or(false)
+    }
+
+    /// The lot's per-unit cost for `commodity`, or `None` if this posting has
+    /// no cost annotation or `commodity` is not present in the cost amount.
+    pub fn lot_cost_in(&self, commodity: &str) -> Option<rust_decimal::Decimal> {
+        self.lot.as_ref()?.cost.as_ref()?.get(commodity)
+    }
+
+    /// The lot's acquisition date as a [`chrono::NaiveDate`], or `None` if no
+    /// `[date]` annotation was present.
+    pub fn lot_date_naive(&self) -> Option<chrono::NaiveDate> {
+        let days = self.lot.as_ref()?.date?;
+        let epoch = chrono::NaiveDate::from_ymd_opt(1970, 1, 1).expect("epoch is valid");
+        Some(epoch + chrono::TimeDelta::days(days as i64))
+    }
+
+    /// The lot's free-form note, or `None` if no `((note))` annotation was
+    /// present.
+    pub fn lot_note(&self) -> Option<&str> {
+        self.lot.as_ref()?.note.as_deref()
+    }
+}
+
 impl elaboration::Transaction {
     /// Convert the epoch-days `date` field to a [`chrono::NaiveDate`].
     ///

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -3563,4 +3563,76 @@ account Assets:Savings
             .expect("virtual posting present");
         assert_eq!(virt.amount_in("$"), Some(dec!(-25)));
     }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Lot annotation elaborator tests
+    // ──────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_lot_cost_only_drives_cash_balance() {
+        // 10 AAPL {$150} (no @ price) → cash side -$1500.
+        let input = "\
+2024-03-01 Buy AAPL
+    Assets:Brokerage   10 AAPL {$150}
+    Assets:Cash
+";
+        let journal = elaborate(input);
+        let t = &journal.transactions[0];
+        assert_eq!(t.postings[0].amount_in("AAPL"), Some(dec!(10)));
+        // No @/@@, cost annotation drives the cash balance: 10 * $150 = $1500.
+        assert_eq!(
+            t.postings[1].amount_in("$"),
+            Some(dec!(-1500)),
+            "cash side should be -$1500 when lot cost drives balance"
+        );
+        // Lot cost preserved on the proto posting.
+        assert_eq!(t.postings[0].lot_cost_in("$"), Some(dec!(150)));
+    }
+
+    #[test]
+    fn test_lot_cost_and_price_price_wins_cash_cost_preserved() {
+        // 10 AAPL {$150} @ $155 → cash -$1550 (price drives balance),
+        // but lot.cost = $150 is still stored.
+        let input = "\
+2024-03-01 Buy AAPL
+    Assets:Brokerage   10 AAPL {$150} @ $155
+    Assets:Cash
+";
+        let journal = elaborate(input);
+        let t = &journal.transactions[0];
+        assert_eq!(t.postings[0].amount_in("AAPL"), Some(dec!(10)));
+        // Price wins over lot cost for cash balance: 10 * $155 = $1550.
+        assert_eq!(
+            t.postings[1].amount_in("$"),
+            Some(dec!(-1550)),
+            "cash side should be -$1550 when @ price is present"
+        );
+        // Lot cost annotation is preserved even though it didn't drive balance.
+        assert_eq!(
+            t.postings[0].lot_cost_in("$"),
+            Some(dec!(150)),
+            "lot cost should be $150, not the price $155"
+        );
+    }
+
+    #[test]
+    fn test_lot_no_cost_no_price_value_in_own_commodity() {
+        // 10 AAPL (no annotation, no price) → the null posting balances in
+        // AAPL (today's fallback: the commodity contributes itself).
+        let input = "\
+2024-03-01 Transfer
+    Assets:Brokerage   10 AAPL
+    Assets:OtherBrokerage
+";
+        let journal = elaborate(input);
+        let t = &journal.transactions[0];
+        assert_eq!(t.postings[0].amount_in("AAPL"), Some(dec!(10)));
+        // Null posting inferred as -10 AAPL.
+        assert_eq!(
+            t.postings[1].amount_in("AAPL"),
+            Some(dec!(-10)),
+            "null posting should balance as -10 AAPL when no price is given"
+        );
+        assert!(!t.postings[0].has_lot(), "no lot annotation should be set");
+    }
 }

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -407,9 +407,13 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                                 .cloned()
                                 .unwrap_or(posting.account);
                             let account_balance = state.account_balances.get(&account_name);
-                            let (value, commodity, lot_pricing) = match amount {
+                            // `lot_cash` — the (total, commodity) pair to use for
+                            // transaction balancing, along with the elaborated
+                            // lot annotation for the proto output.
+                            let (value, commodity, lot_cash, proto_lot) = match amount {
                                 AmountDetails::Amount {
                                     value,
+                                    lot_annotation,
                                     lot_pricing,
                                     balance_assertion,
                                 } => {
@@ -418,7 +422,55 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                                         entry_context,
                                         &state,
                                     )?;
-                                    let lot_pricing = match lot_pricing {
+
+                                    // Evaluate the optional lot annotation (cost/date/note).
+                                    // Preserved on the proto Posting regardless of which
+                                    // path drives the cash balance.
+                                    //
+                                    // `cost_for_balance`: the evaluated (per_unit_cost,
+                                    // cost_commodity) pair, kept separate so the
+                                    // cash-balance fallback path can use it without
+                                    // re-parsing the proto Amount.
+                                    let (proto_lot, cost_for_balance) =
+                                        if let Some(ann) = lot_annotation {
+                                            let epoch = chrono::NaiveDate::from_ymd_opt(1970, 1, 1)
+                                                .expect("epoch is valid");
+                                            let proto_date =
+                                                ann.date.map(|d| (d - epoch).num_days() as i32);
+                                            let (proto_cost, cost_pair) =
+                                                if let Some(cost_expr) = ann.cost {
+                                                    let (cv, cc) =
+                                                        evaluator::eval_and_normalize_amount(
+                                                            cost_expr,
+                                                            entry_context,
+                                                            &state,
+                                                        )?;
+                                                    let proto_amount = crate::elaboration::Amount {
+                                                        by_commodity: BTreeMap::from([(
+                                                            cc.clone(),
+                                                            crate::decimal_to_proto(cv),
+                                                        )]),
+                                                    };
+                                                    (Some(proto_amount), Some((cv, cc)))
+                                                } else {
+                                                    (None, None)
+                                                };
+                                            let lot = crate::elaboration::Lot {
+                                                cost: proto_cost,
+                                                date: proto_date,
+                                                note: ann.note,
+                                            };
+                                            (Some(lot), cost_pair)
+                                        } else {
+                                            (None, None)
+                                        };
+
+                                    // Cash-contribution priority:
+                                    // 1. lot_pricing (@/@@) present  → price drives cash (unchanged)
+                                    // 2. lot_annotation.cost present → quantity * cost_per_unit
+                                    // 3. otherwise                   → value contributes in its own
+                                    //                                  commodity (today's fallback)
+                                    let lot_cash = match lot_pricing {
                                         Some(ast::LotPricing::Total(expr)) => {
                                             let (mut v, c) = evaluator::eval_and_normalize_amount(
                                                 expr,
@@ -441,8 +493,13 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                                             )?;
                                             Some((v * value, c))
                                         }
-                                        None => None,
+                                        None => {
+                                            // No @/@@. If cost annotation is present, it drives
+                                            // the cash balance: total = quantity * cost_per_unit.
+                                            cost_for_balance.map(|(cv, cc)| (value * cv, cc))
+                                        }
                                     };
+
                                     if let Some(balance_assertion) = balance_assertion {
                                         let (baval, bacommodity) =
                                             evaluator::eval_and_normalize_amount(
@@ -464,7 +521,7 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                                             Err(ElaborationError::PostingBalanceAssertionFailed)?;
                                         }
                                     }
-                                    (value, commodity, lot_pricing)
+                                    (value, commodity, lot_cash, proto_lot)
                                 }
                                 AmountDetails::BalanceAssignment(assignment) => {
                                     // "= target_balance" — compute the delta needed to reach the
@@ -507,7 +564,7 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                                         - account_balance
                                             .and_then(|ab| ab.commodity.get(&commodity))
                                             .unwrap_or(&Decimal::ZERO);
-                                    (value, commodity, None)
+                                    (value, commodity, None, None)
                                 }
                             };
                             let payee = posting.metadata.remove("payee").unwrap_or(payee.clone());
@@ -517,7 +574,7 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                             // For lot-priced postings, add the *cash* total (in the lot's
                             // commodity) to transaction_state rather than the commodity units.
                             if posting_kind != ast::PostingKind::VirtualUnbalanced {
-                                if let Some((lot_total, lot_commodity)) = lot_pricing {
+                                if let Some((lot_total, lot_commodity)) = lot_cash {
                                     let dec = transaction_state.0.entry(lot_commodity).or_default();
                                     *dec += lot_total;
                                 } else {
@@ -537,6 +594,7 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                                 tags: posting.tags,
                                 metadata: posting.metadata,
                                 kind: crate::posting_kind_to_proto(posting_kind),
+                                lot: proto_lot,
                             });
                         } else {
                             // Defer processing and save for next step.
@@ -577,6 +635,7 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                             tags: posting.tags,
                             metadata: posting.metadata,
                             kind: crate::posting_kind_to_proto(ast::PostingKind::Real),
+                            lot: None,
                         });
                     } else {
                         // Check that transaction state is all zeros to balance the transaction.

--- a/crates/doppio/src/grammars/hledger/hledger.pest
+++ b/crates/doppio/src/grammars/hledger/hledger.pest
@@ -131,7 +131,19 @@ amount_logic = ${
     )
 }
 
-value_logic = ${ value_expr ~ (ws* ~ lot_price)? ~ (ws* ~ assertion)? }
+// A value expression, optionally followed by lot annotations and/or lot pricing
+// and/or a balance assertion check. Mirrors the ledger-cli grammar.
+value_logic = ${ value_expr ~ (ws* ~ lot_annotation_or_price)* ~ (ws* ~ assertion)? }
+lot_annotation_or_price = ${ lot_annotation | lot_price }
+lot_annotation = ${ lot_cost | lot_date | lot_note }
+// Double-brace `{{expr}}` means total cost; single-brace `{expr}` means per-unit
+// cost. Try `{{` before `{` so the longer token wins.
+lot_cost = ${ ("{{" ~ ws* ~ value_expr ~ ws* ~ "}}") | ("{" ~ ws* ~ value_expr ~ ws* ~ "}") }
+// `[date]` — lot acquisition date.
+lot_date = ${ "[" ~ date ~ "]" }
+// `((note))` — free-form lot note.
+lot_note = ${ "((" ~ lot_note_inner ~ "))" }
+lot_note_inner = @{ (!"))" ~ ANY)* }
 
 // hledger uses `==` for "all-commodity" (strict) balance assertions and `=`
 // for single-commodity assertions.  The longer token must be tried first.

--- a/crates/doppio/src/grammars/hledger/mod.rs
+++ b/crates/doppio/src/grammars/hledger/mod.rs
@@ -48,7 +48,7 @@ impl<F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>> Parser<F> {
         for pair in pairs.into_iter().next().unwrap().into_inner() {
             match pair.as_rule() {
                 Rule::transaction => {
-                    entries.push(Entry::Transaction(parse_transaction(pair)));
+                    entries.push(Entry::Transaction(parse_transaction(pair)?));
                 }
                 Rule::comment_line => {
                     entries.push(Entry::Comment(pair.as_str().to_string()));
@@ -118,7 +118,7 @@ fn parse_state(s: &str) -> TransactionState {
     }
 }
 
-fn parse_transaction(pair: Pair<Rule>) -> Transaction {
+fn parse_transaction(pair: Pair<Rule>) -> Result<Transaction, Box<dyn std::error::Error>> {
     let mut inner = pair.into_inner();
     let header_pair = inner.next().unwrap();
     let mut postings = Vec::new();
@@ -132,7 +132,7 @@ fn parse_transaction(pair: Pair<Rule>) -> Transaction {
                 }
             }
             Rule::posting => {
-                postings.push(parse_posting(p));
+                postings.push(parse_posting(p)?);
             }
             _ => {}
         }
@@ -164,7 +164,7 @@ fn parse_transaction(pair: Pair<Rule>) -> Transaction {
         }
     }
 
-    Transaction {
+    Ok(Transaction {
         date,
         secondary_date: None,
         state,
@@ -172,10 +172,10 @@ fn parse_transaction(pair: Pair<Rule>) -> Transaction {
         description,
         notes,
         postings,
-    }
+    })
 }
 
-fn parse_posting(pair: Pair<Rule>) -> Posting {
+fn parse_posting(pair: Pair<Rule>) -> Result<Posting, Box<dyn std::error::Error>> {
     let inner = pair.into_inner();
     let mut state = TransactionState::Uncleared;
     let mut account = String::new();
@@ -218,7 +218,7 @@ fn parse_posting(pair: Pair<Rule>) -> Posting {
                     _ => {}
                 }
             }
-            Rule::amount_logic => amount = Some(parse_amount_logic(p)),
+            Rule::amount_logic => amount = Some(parse_amount_logic(p)?),
             Rule::note => notes.push(p.into_inner().as_str().trim().to_string()),
             Rule::posting_note => {
                 if let Some(note_pair) = p.into_inner().next() {
@@ -229,16 +229,16 @@ fn parse_posting(pair: Pair<Rule>) -> Posting {
         }
     }
 
-    Posting {
+    Ok(Posting {
         account,
         amount,
         state,
         notes,
         kind,
-    }
+    })
 }
 
-fn parse_amount_logic(pair: Pair<Rule>) -> AmountDetails {
+fn parse_amount_logic(pair: Pair<Rule>) -> Result<AmountDetails, Box<dyn std::error::Error>> {
     let p = pair.into_inner().next().unwrap();
     match p.as_rule() {
         Rule::value_logic => {
@@ -268,7 +268,7 @@ fn parse_amount_logic(pair: Pair<Rule>) -> AmountDetails {
                             }
                             Rule::lot_annotation => {
                                 has_lot_annotation = true;
-                                parse_lot_annotation_into(child, &mut lot_annotation);
+                                parse_lot_annotation_into(child, &mut lot_annotation)?;
                             }
                             _ => unreachable!(),
                         }
@@ -286,12 +286,12 @@ fn parse_amount_logic(pair: Pair<Rule>) -> AmountDetails {
                     _ => unreachable!(),
                 }
             }
-            AmountDetails::Amount {
+            Ok(AmountDetails::Amount {
                 value: value.unwrap(),
                 lot_annotation: has_lot_annotation.then_some(lot_annotation),
                 lot_pricing,
                 balance_assertion,
-            }
+            })
         }
         Rule::assertion => {
             // The assertion rule: assertion_op ~ ws* ~ value_expr.
@@ -300,7 +300,9 @@ fn parse_amount_logic(pair: Pair<Rule>) -> AmountDetails {
                 .into_inner()
                 .find(|p| p.as_rule() == Rule::value_expr)
                 .expect("assertion must have a value_expr");
-            AmountDetails::BalanceAssignment(parse_expr(inner_expr_pair))
+            Ok(AmountDetails::BalanceAssignment(parse_expr(
+                inner_expr_pair,
+            )))
         }
         _ => unreachable!("unexpected rule in amount_logic: {:?}", p.as_rule()),
     }
@@ -309,10 +311,31 @@ fn parse_amount_logic(pair: Pair<Rule>) -> AmountDetails {
 /// Merge a single `lot_annotation` grammar node into an accumulating
 /// [`LotAnnotation`] struct.  Duplicate annotations of the same kind take the
 /// last value (matching ledger-cli behaviour).
-fn parse_lot_annotation_into(pair: Pair<Rule>, acc: &mut LotAnnotation) {
+///
+/// # Errors
+///
+/// Returns an error if a `{{total}}` double-brace lot cost is encountered.
+/// The double-brace form is syntactically accepted by the grammar but its
+/// per-lot total-cost semantics are not yet implemented.  Treating it silently
+/// as a per-unit cost would produce wrong balances (e.g. `10 AAPL {{$1500}}`
+/// would yield a cash contribution of $15 000 instead of $1 500).  Use
+/// `{cost}` for per-unit cost or `@@ total` for transient total cost instead.
+fn parse_lot_annotation_into(
+    pair: Pair<Rule>,
+    acc: &mut LotAnnotation,
+) -> Result<(), Box<dyn std::error::Error>> {
     let child = pair.into_inner().next().unwrap();
     match child.as_rule() {
         Rule::lot_cost => {
+            // Reject the `{{expr}}` double-brace form. The grammar matches it
+            // before `{expr}` so the raw token text starts with "{{".
+            if child.as_str().starts_with("{{") {
+                return Err(
+                    "double-brace `{{total}}` lot syntax is not yet implemented; \
+                     use `{cost}` for per-unit cost or `@@ total` for transient total cost"
+                        .into(),
+                );
+            }
             let expr_pair = child.into_inner().next().unwrap();
             acc.cost = Some(parse_expr(expr_pair));
         }
@@ -329,6 +352,7 @@ fn parse_lot_annotation_into(pair: Pair<Rule>, acc: &mut LotAnnotation) {
         }
         _ => unreachable!(),
     }
+    Ok(())
 }
 
 fn parse_historical_price(pair: Pair<Rule>) -> HistoricalPrice {
@@ -1148,5 +1172,102 @@ P 2024-02-15 AAPL $182.50
     assets:bank:checking        $-1825.00
 ";
         parse_hledger(input).expect("sample journal should parse without error");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Lot annotation grammar tests
+    // ──────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_lot_annotation_cost_only() {
+        let input = "2024-03-01 Buy\n    assets:brokerage   10 AAPL {$150}\n    assets:cash\n";
+        let journal = parse_hledger(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!("expected transaction")
+        };
+        let details = tx.postings[0].amount.as_ref().expect("amount present");
+        let AmountDetails::Amount { lot_annotation, .. } = details else {
+            panic!("expected Amount details")
+        };
+        let ann = lot_annotation.as_ref().expect("lot annotation present");
+        assert!(ann.cost.is_some(), "cost should be set");
+        assert!(ann.date.is_none(), "date should be absent");
+        assert!(ann.note.is_none(), "note should be absent");
+    }
+
+    #[test]
+    fn test_lot_annotation_date_only() {
+        let input =
+            "2024-03-01 Buy\n    assets:brokerage   10 AAPL [2024-01-15]\n    assets:cash\n";
+        let journal = parse_hledger(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!("expected transaction")
+        };
+        let details = tx.postings[0].amount.as_ref().expect("amount present");
+        let AmountDetails::Amount { lot_annotation, .. } = details else {
+            panic!("expected Amount details")
+        };
+        let ann = lot_annotation.as_ref().expect("lot annotation present");
+        assert!(ann.cost.is_none(), "cost should be absent");
+        assert_eq!(
+            ann.date,
+            chrono::NaiveDate::from_ymd_opt(2024, 1, 15),
+            "date should be 2024-01-15"
+        );
+        assert!(ann.note.is_none(), "note should be absent");
+    }
+
+    #[test]
+    fn test_lot_annotation_note_only() {
+        let input =
+            "2024-03-01 Buy\n    assets:brokerage   10 AAPL ((BUY-2024-01))\n    assets:cash\n";
+        let journal = parse_hledger(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!("expected transaction")
+        };
+        let details = tx.postings[0].amount.as_ref().expect("amount present");
+        let AmountDetails::Amount { lot_annotation, .. } = details else {
+            panic!("expected Amount details")
+        };
+        let ann = lot_annotation.as_ref().expect("lot annotation present");
+        assert!(ann.cost.is_none(), "cost should be absent");
+        assert!(ann.date.is_none(), "date should be absent");
+        assert_eq!(ann.note.as_deref(), Some("BUY-2024-01"));
+    }
+
+    #[test]
+    fn test_lot_annotation_combined() {
+        let input = "2024-03-01 Buy\n    assets:brokerage   10 AAPL {$150} [2024-03-01] ((BUY-2024-01))\n    assets:cash\n";
+        let journal = parse_hledger(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!("expected transaction")
+        };
+        let details = tx.postings[0].amount.as_ref().expect("amount present");
+        let AmountDetails::Amount { lot_annotation, .. } = details else {
+            panic!("expected Amount details")
+        };
+        let ann = lot_annotation.as_ref().expect("lot annotation present");
+        assert!(ann.cost.is_some(), "cost should be set");
+        assert_eq!(
+            ann.date,
+            chrono::NaiveDate::from_ymd_opt(2024, 3, 1),
+            "date should be 2024-03-01"
+        );
+        assert_eq!(ann.note.as_deref(), Some("BUY-2024-01"));
+    }
+
+    #[test]
+    fn test_lot_annotation_double_brace_rejected() {
+        let input = "2024-03-01 Buy\n    assets:brokerage   10 AAPL {{$1500}}\n    assets:cash\n";
+        let result = parse_hledger(input);
+        assert!(
+            result.is_err(),
+            "double-brace `{{total}}` should be rejected at parse time"
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("double-brace"),
+            "error message should mention double-brace, got: {msg}"
+        );
     }
 }

--- a/crates/doppio/src/grammars/hledger/mod.rs
+++ b/crates/doppio/src/grammars/hledger/mod.rs
@@ -244,6 +244,8 @@ fn parse_amount_logic(pair: Pair<Rule>) -> AmountDetails {
         Rule::value_logic => {
             let inner = p.into_inner();
             let mut value = None;
+            let mut lot_annotation: LotAnnotation = LotAnnotation::default();
+            let mut has_lot_annotation = false;
             let mut lot_pricing = None;
             let mut balance_assertion = None;
 
@@ -252,13 +254,23 @@ fn parse_amount_logic(pair: Pair<Rule>) -> AmountDetails {
                     Rule::value_expr => {
                         value = Some(parse_expr(p));
                     }
-                    Rule::lot_price => {
-                        let s = p.as_str();
-                        let inner_val = parse_expr(p.into_inner().next().unwrap());
-                        if s.starts_with("@@") {
-                            lot_pricing = Some(LotPricing::Total(inner_val));
-                        } else {
-                            lot_pricing = Some(LotPricing::Unit(inner_val));
+                    Rule::lot_annotation_or_price => {
+                        let child = p.into_inner().next().unwrap();
+                        match child.as_rule() {
+                            Rule::lot_price => {
+                                let s = child.as_str();
+                                let inner_val = parse_expr(child.into_inner().next().unwrap());
+                                if s.starts_with("@@") {
+                                    lot_pricing = Some(LotPricing::Total(inner_val));
+                                } else {
+                                    lot_pricing = Some(LotPricing::Unit(inner_val));
+                                }
+                            }
+                            Rule::lot_annotation => {
+                                has_lot_annotation = true;
+                                parse_lot_annotation_into(child, &mut lot_annotation);
+                            }
+                            _ => unreachable!(),
                         }
                     }
                     Rule::assertion => {
@@ -276,6 +288,7 @@ fn parse_amount_logic(pair: Pair<Rule>) -> AmountDetails {
             }
             AmountDetails::Amount {
                 value: value.unwrap(),
+                lot_annotation: has_lot_annotation.then_some(lot_annotation),
                 lot_pricing,
                 balance_assertion,
             }
@@ -290,6 +303,31 @@ fn parse_amount_logic(pair: Pair<Rule>) -> AmountDetails {
             AmountDetails::BalanceAssignment(parse_expr(inner_expr_pair))
         }
         _ => unreachable!("unexpected rule in amount_logic: {:?}", p.as_rule()),
+    }
+}
+
+/// Merge a single `lot_annotation` grammar node into an accumulating
+/// [`LotAnnotation`] struct.  Duplicate annotations of the same kind take the
+/// last value (matching ledger-cli behaviour).
+fn parse_lot_annotation_into(pair: Pair<Rule>, acc: &mut LotAnnotation) {
+    let child = pair.into_inner().next().unwrap();
+    match child.as_rule() {
+        Rule::lot_cost => {
+            let expr_pair = child.into_inner().next().unwrap();
+            acc.cost = Some(parse_expr(expr_pair));
+        }
+        Rule::lot_date => {
+            let date_pair = child.into_inner().next().unwrap();
+            let d = parse_date(date_pair);
+            if let (Some(year), month, day) = (d.year, d.month, d.date) {
+                acc.date = chrono::NaiveDate::from_ymd_opt(year, month, day);
+            }
+        }
+        Rule::lot_note => {
+            let note_str = child.into_inner().next().unwrap().as_str().to_string();
+            acc.note = Some(note_str);
+        }
+        _ => unreachable!(),
     }
 }
 

--- a/crates/doppio/src/grammars/ledger/ledger.pest
+++ b/crates/doppio/src/grammars/ledger/ledger.pest
@@ -115,9 +115,25 @@ amount_logic = ${
     )
 }
 
-// A value expression, optionally followed by lot pricing and/or a balance
-// assertion check.
-value_logic = ${ value_expr ~ (ws* ~ lot_price)? ~ (ws* ~ assertion)? }
+// A value expression, optionally followed by lot annotations and/or lot pricing
+// and/or a balance assertion check.
+//
+// Lot annotations may appear in any order between the value and the optional
+// `@`/`@@` price. Multiple annotations of different kinds are allowed;
+// duplicate kinds take the last value (matching ledger-cli behaviour).
+value_logic = ${ value_expr ~ (ws* ~ lot_annotation_or_price)* ~ (ws* ~ assertion)? }
+lot_annotation_or_price = ${ lot_annotation | lot_price }
+lot_annotation = ${ lot_cost | lot_date | lot_note }
+// Double-brace `{{expr}}` means total cost; single-brace `{expr}` means per-unit
+// cost. Try `{{` before `{` so the longer token wins.
+lot_cost = ${ ("{{" ~ ws* ~ value_expr ~ ws* ~ "}}") | ("{" ~ ws* ~ value_expr ~ ws* ~ "}") }
+// `[date]` — lot acquisition date. Only valid after a posting amount, so there
+// is no ambiguity with `[Account]` virtual balanced postings (those appear in
+// account position, not after an amount).
+lot_date = ${ "[" ~ date ~ "]" }
+// `((note))` — free-form lot note. Try `((` before `(` to avoid partial matches.
+lot_note = ${ "((" ~ lot_note_inner ~ "))" }
+lot_note_inner = @{ (!"))" ~ ANY)* }
 
 // A balance check or balance assignment: `= target` or `== target`.
 // Used in two ways within `amount_logic`:

--- a/crates/doppio/src/grammars/ledger/mod.rs
+++ b/crates/doppio/src/grammars/ledger/mod.rs
@@ -79,7 +79,7 @@ impl<F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>> Parser<F> {
         for pair in pairs.into_iter().next().unwrap().into_inner() {
             match pair.as_rule() {
                 Rule::transaction => {
-                    entries.push(Entry::Transaction(parse_transaction(pair)));
+                    entries.push(Entry::Transaction(parse_transaction(pair)?));
                 }
                 Rule::comment_line => {
                     entries.push(Entry::Comment(pair.as_str().to_string()));
@@ -604,7 +604,7 @@ fn parse_date(pairs: &mut Pairs<Rule>) -> Date {
     Date { year, month, date }
 }
 
-fn parse_transaction(pair: Pair<Rule>) -> Transaction {
+fn parse_transaction(pair: Pair<Rule>) -> Result<Transaction, Box<dyn std::error::Error>> {
     let mut inner = pair.into_inner();
     let header_pair = inner.next().unwrap();
     let mut postings = Vec::new();
@@ -620,7 +620,7 @@ fn parse_transaction(pair: Pair<Rule>) -> Transaction {
                 }
             }
             Rule::posting => {
-                postings.push(parse_posting(p));
+                postings.push(parse_posting(p)?);
             }
             _ => {}
         }
@@ -648,7 +648,7 @@ fn parse_transaction(pair: Pair<Rule>) -> Transaction {
         }
     }
 
-    Transaction {
+    Ok(Transaction {
         date,
         secondary_date,
         state,
@@ -656,10 +656,10 @@ fn parse_transaction(pair: Pair<Rule>) -> Transaction {
         description,
         notes,
         postings,
-    }
+    })
 }
 
-fn parse_posting(pair: Pair<Rule>) -> Posting {
+fn parse_posting(pair: Pair<Rule>) -> Result<Posting, Box<dyn std::error::Error>> {
     let inner = pair.into_inner();
     let mut state = TransactionState::Uncleared;
     let mut account = String::new();
@@ -704,7 +704,7 @@ fn parse_posting(pair: Pair<Rule>) -> Posting {
                     _ => {}
                 }
             }
-            Rule::amount_logic => amount = Some(parse_amount_logic(p)),
+            Rule::amount_logic => amount = Some(parse_amount_logic(p)?),
             Rule::note => notes.push(p.as_str().trim().to_string()),
             Rule::posting_note => {
                 if let Some(note_pair) = p.into_inner().next() {
@@ -715,16 +715,16 @@ fn parse_posting(pair: Pair<Rule>) -> Posting {
         }
     }
 
-    Posting {
+    Ok(Posting {
         account,
         amount,
         state,
         notes,
         kind,
-    }
+    })
 }
 
-fn parse_amount_logic(pair: Pair<Rule>) -> AmountDetails {
+fn parse_amount_logic(pair: Pair<Rule>) -> Result<AmountDetails, Box<dyn std::error::Error>> {
     let p = pair.into_inner().next().unwrap();
     match p.as_rule() {
         Rule::value_logic => {
@@ -755,7 +755,7 @@ fn parse_amount_logic(pair: Pair<Rule>) -> AmountDetails {
                             }
                             Rule::lot_annotation => {
                                 has_lot_annotation = true;
-                                parse_lot_annotation_into(child, &mut lot_annotation);
+                                parse_lot_annotation_into(child, &mut lot_annotation)?;
                             }
                             _ => unreachable!(),
                         }
@@ -767,16 +767,18 @@ fn parse_amount_logic(pair: Pair<Rule>) -> AmountDetails {
                     _ => unreachable!(),
                 }
             }
-            AmountDetails::Amount {
+            Ok(AmountDetails::Amount {
                 value: value.unwrap(),
                 lot_annotation: has_lot_annotation.then_some(lot_annotation),
                 lot_pricing,
                 balance_assertion,
-            }
+            })
         }
         Rule::assertion => {
             let inner_expr_pair = p.into_inner().next().unwrap();
-            AmountDetails::BalanceAssignment(parse_expr(inner_expr_pair))
+            Ok(AmountDetails::BalanceAssignment(parse_expr(
+                inner_expr_pair,
+            )))
         }
         _ => unreachable!(),
     }
@@ -785,13 +787,32 @@ fn parse_amount_logic(pair: Pair<Rule>) -> AmountDetails {
 /// Merge a single `lot_annotation` grammar node into an accumulating
 /// [`LotAnnotation`] struct.  Duplicate annotations of the same kind take the
 /// last value (matching ledger-cli behaviour).
-fn parse_lot_annotation_into(pair: Pair<Rule>, acc: &mut LotAnnotation) {
+///
+/// # Errors
+///
+/// Returns an error if a `{{total}}` double-brace lot cost is encountered.
+/// The double-brace form is syntactically accepted by the grammar but its
+/// per-lot total-cost semantics are not yet implemented.  Treating it silently
+/// as a per-unit cost would produce wrong balances (e.g. `10 AAPL {{$1500}}`
+/// would yield a cash contribution of $15 000 instead of $1 500).  Use
+/// `{cost}` for per-unit cost or `@@ total` for transient total cost instead.
+fn parse_lot_annotation_into(
+    pair: Pair<Rule>,
+    acc: &mut LotAnnotation,
+) -> Result<(), Box<dyn std::error::Error>> {
     let child = pair.into_inner().next().unwrap();
     match child.as_rule() {
         Rule::lot_cost => {
-            // lot_cost inner: value_expr (single-brace per-unit cost).
-            // Both `{expr}` and `{{expr}}` map to per-unit cost at the AST
-            // level; total-cost (`{{}}`) support can be layered later.
+            // Reject the `{{expr}}` double-brace form. The grammar matches it
+            // before `{expr}` so the raw token text starts with "{{".
+            if child.as_str().starts_with("{{") {
+                return Err(
+                    "double-brace `{{total}}` lot syntax is not yet implemented; \
+                     use `{cost}` for per-unit cost or `@@ total` for transient total cost"
+                        .into(),
+                );
+            }
+            // lot_cost inner: value_expr — per-unit cost.
             let expr_pair = child.into_inner().next().unwrap();
             acc.cost = Some(parse_expr(expr_pair));
         }
@@ -810,6 +831,7 @@ fn parse_lot_annotation_into(pair: Pair<Rule>, acc: &mut LotAnnotation) {
         }
         _ => unreachable!(),
     }
+    Ok(())
 }
 
 /// Parse a `date` grammar pair from the ledger grammar into an [`ast::Date`].
@@ -1178,6 +1200,110 @@ mod tests {
         let pairs = LedgerParser::parse(Rule::number, input).unwrap();
         assert_eq!(clean_parse_decimal(pairs.as_str()), dec!(1234.56));
     }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Lot annotation grammar tests
+    // ──────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_lot_annotation_cost_only() {
+        let input = "2024-03-01 Buy\n    Assets:Brokerage   10 AAPL {$150}\n    Assets:Cash\n";
+        let journal = parse_ledger(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!("expected transaction")
+        };
+        let details = tx.postings[0].amount.as_ref().expect("amount present");
+        let AmountDetails::Amount { lot_annotation, .. } = details else {
+            panic!("expected Amount details")
+        };
+        let ann = lot_annotation.as_ref().expect("lot annotation present");
+        assert!(ann.cost.is_some(), "cost should be set");
+        assert!(ann.date.is_none(), "date should be absent");
+        assert!(ann.note.is_none(), "note should be absent");
+        assert!(matches!(
+            ann.cost.as_ref().unwrap(),
+            ValueExpr::Amount {
+                commodity: Some(c),
+                ..
+            } if c == "$"
+        ));
+    }
+
+    #[test]
+    fn test_lot_annotation_date_only() {
+        let input =
+            "2024-03-01 Buy\n    Assets:Brokerage   10 AAPL [2024-01-15]\n    Assets:Cash\n";
+        let journal = parse_ledger(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!("expected transaction")
+        };
+        let details = tx.postings[0].amount.as_ref().expect("amount present");
+        let AmountDetails::Amount { lot_annotation, .. } = details else {
+            panic!("expected Amount details")
+        };
+        let ann = lot_annotation.as_ref().expect("lot annotation present");
+        assert!(ann.cost.is_none(), "cost should be absent");
+        assert_eq!(
+            ann.date,
+            chrono::NaiveDate::from_ymd_opt(2024, 1, 15),
+            "date should be 2024-01-15"
+        );
+        assert!(ann.note.is_none(), "note should be absent");
+    }
+
+    #[test]
+    fn test_lot_annotation_note_only() {
+        let input =
+            "2024-03-01 Buy\n    Assets:Brokerage   10 AAPL ((BUY-2024-01))\n    Assets:Cash\n";
+        let journal = parse_ledger(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!("expected transaction")
+        };
+        let details = tx.postings[0].amount.as_ref().expect("amount present");
+        let AmountDetails::Amount { lot_annotation, .. } = details else {
+            panic!("expected Amount details")
+        };
+        let ann = lot_annotation.as_ref().expect("lot annotation present");
+        assert!(ann.cost.is_none(), "cost should be absent");
+        assert!(ann.date.is_none(), "date should be absent");
+        assert_eq!(ann.note.as_deref(), Some("BUY-2024-01"));
+    }
+
+    #[test]
+    fn test_lot_annotation_combined() {
+        let input = "2024-03-01 Buy\n    Assets:Brokerage   10 AAPL {$150} [2024-03-01] ((BUY-2024-01))\n    Assets:Cash\n";
+        let journal = parse_ledger(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!("expected transaction")
+        };
+        let details = tx.postings[0].amount.as_ref().expect("amount present");
+        let AmountDetails::Amount { lot_annotation, .. } = details else {
+            panic!("expected Amount details")
+        };
+        let ann = lot_annotation.as_ref().expect("lot annotation present");
+        assert!(ann.cost.is_some(), "cost should be set");
+        assert_eq!(
+            ann.date,
+            chrono::NaiveDate::from_ymd_opt(2024, 3, 1),
+            "date should be 2024-03-01"
+        );
+        assert_eq!(ann.note.as_deref(), Some("BUY-2024-01"));
+    }
+
+    #[test]
+    fn test_lot_annotation_double_brace_rejected() {
+        let input = "2024-03-01 Buy\n    Assets:Brokerage   10 AAPL {{$1500}}\n    Assets:Cash\n";
+        let result = parse_ledger(input);
+        assert!(
+            result.is_err(),
+            "double-brace `{{total}}` should be rejected at parse time"
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("double-brace"),
+            "error message should mention double-brace, got: {msg}"
+        );
+    }
 }
 
 #[cfg(test)]
@@ -1220,7 +1346,7 @@ mod directed_tests {
         // Parse specifically as a transaction
         let mut pairs = LedgerParser::parse(Rule::transaction, input).unwrap();
         let tx_pair = pairs.next().unwrap();
-        let tx = parse_transaction(tx_pair);
+        let tx = parse_transaction(tx_pair).unwrap();
 
         assert_eq!(tx.postings.len(), 3);
     }

--- a/crates/doppio/src/grammars/ledger/mod.rs
+++ b/crates/doppio/src/grammars/ledger/mod.rs
@@ -731,6 +731,8 @@ fn parse_amount_logic(pair: Pair<Rule>) -> AmountDetails {
             let inner = p.into_inner();
 
             let mut value = None;
+            let mut lot_annotation: LotAnnotation = LotAnnotation::default();
+            let mut has_lot_annotation = false;
             let mut lot_pricing = None;
             let mut balance_assertion = None;
 
@@ -739,19 +741,26 @@ fn parse_amount_logic(pair: Pair<Rule>) -> AmountDetails {
                     Rule::value_expr => {
                         value = Some(parse_expr(p));
                     }
-                    Rule::lot_price => {
-                        // Inspect the raw text to distinguish "@" from "@@"
-                        // before descending into the inner value_expr.
-                        let s = p.as_str();
-                        let inner_val = parse_expr(p.into_inner().next().unwrap());
-                        if s.starts_with("@@") {
-                            lot_pricing = Some(LotPricing::Total(inner_val));
-                        } else {
-                            lot_pricing = Some(LotPricing::Unit(inner_val));
+                    Rule::lot_annotation_or_price => {
+                        let child = p.into_inner().next().unwrap();
+                        match child.as_rule() {
+                            Rule::lot_price => {
+                                let s = child.as_str();
+                                let inner_val = parse_expr(child.into_inner().next().unwrap());
+                                if s.starts_with("@@") {
+                                    lot_pricing = Some(LotPricing::Total(inner_val));
+                                } else {
+                                    lot_pricing = Some(LotPricing::Unit(inner_val));
+                                }
+                            }
+                            Rule::lot_annotation => {
+                                has_lot_annotation = true;
+                                parse_lot_annotation_into(child, &mut lot_annotation);
+                            }
+                            _ => unreachable!(),
                         }
                     }
                     Rule::assertion => {
-                        // Now parsing as a ValueExpr
                         let inner_expr_pair = p.into_inner().next().unwrap();
                         balance_assertion = Some(parse_expr(inner_expr_pair));
                     }
@@ -760,6 +769,7 @@ fn parse_amount_logic(pair: Pair<Rule>) -> AmountDetails {
             }
             AmountDetails::Amount {
                 value: value.unwrap(),
+                lot_annotation: has_lot_annotation.then_some(lot_annotation),
                 lot_pricing,
                 balance_assertion,
             }
@@ -769,6 +779,50 @@ fn parse_amount_logic(pair: Pair<Rule>) -> AmountDetails {
             AmountDetails::BalanceAssignment(parse_expr(inner_expr_pair))
         }
         _ => unreachable!(),
+    }
+}
+
+/// Merge a single `lot_annotation` grammar node into an accumulating
+/// [`LotAnnotation`] struct.  Duplicate annotations of the same kind take the
+/// last value (matching ledger-cli behaviour).
+fn parse_lot_annotation_into(pair: Pair<Rule>, acc: &mut LotAnnotation) {
+    let child = pair.into_inner().next().unwrap();
+    match child.as_rule() {
+        Rule::lot_cost => {
+            // lot_cost inner: value_expr (single-brace per-unit cost).
+            // Both `{expr}` and `{{expr}}` map to per-unit cost at the AST
+            // level; total-cost (`{{}}`) support can be layered later.
+            let expr_pair = child.into_inner().next().unwrap();
+            acc.cost = Some(parse_expr(expr_pair));
+        }
+        Rule::lot_date => {
+            // lot_date inner: date
+            let date_pair = child.into_inner().next().unwrap();
+            let date = parse_date_pair(date_pair);
+            if let (Some(year), month, day) = (date.year, date.month, date.date) {
+                acc.date = chrono::NaiveDate::from_ymd_opt(year, month, day);
+            }
+        }
+        Rule::lot_note => {
+            // lot_note inner: lot_note_inner (atomic string)
+            let note_str = child.into_inner().next().unwrap().as_str().to_string();
+            acc.note = Some(note_str);
+        }
+        _ => unreachable!(),
+    }
+}
+
+/// Parse a `date` grammar pair from the ledger grammar into an [`ast::Date`].
+/// Used for lot_date parsing (separate from the transaction-header date parsing).
+fn parse_date_pair(pair: Pair<Rule>) -> Date {
+    let mut inner = pair.into_inner();
+    let year: i32 = inner.next().unwrap().as_str().parse().unwrap();
+    let month: u32 = inner.next().unwrap().as_str().parse().unwrap();
+    let day: u32 = inner.next().unwrap().as_str().parse().unwrap();
+    Date {
+        year: Some(year),
+        month,
+        date: day,
     }
 }
 
@@ -952,6 +1006,7 @@ mod tests {
                         value: dec!(50.00),
                         commodity: Some("$".into()),
                     },
+                    lot_annotation: None,
                     lot_pricing: None,
                     balance_assertion: None,
                 })
@@ -979,6 +1034,7 @@ mod tests {
                         value: dec!(10),
                         commodity: Some("AAPL".into()),
                     },
+                    lot_annotation: None,
                     lot_pricing: Some(LotPricing::Unit(ValueExpr::Amount {
                         commodity: Some("$".into()),
                         value: dec!(150.00)

--- a/crates/doppio/tests/parity.rs
+++ b/crates/doppio/tests/parity.rs
@@ -571,6 +571,42 @@ fn lot_persistence_cost_vs_price() {
 }
 
 #[test]
+fn lot_persistence_date_only() {
+    // Fixture: 10 AAPL [2024-01-15] — date annotation only, no cost.
+    // Exercises the cost-fallback path: no {cost} or @ price means the
+    // null posting balances in the posted commodity (AAPL contributes
+    // itself as -10 AAPL). The lot's date field is still preserved.
+    let j = compile("lot_persistence_date_only.ledger");
+    let t = &j.transactions[0];
+    assert_eq!(t.postings[0].amount_in("AAPL"), Some(dec!(10)));
+    // Cost-fallback: AAPL contributes itself, null posting = -10 AAPL.
+    assert_eq!(t.postings[1].amount_in("AAPL"), Some(dec!(-10)));
+    assert!(t.postings[0].has_lot(), "lot annotation should be present");
+    assert_eq!(
+        t.postings[0].lot_date_naive(),
+        Some(NaiveDate::from_ymd_opt(2024, 1, 15).unwrap()),
+    );
+    assert_eq!(t.postings[0].lot_cost_in("$"), None, "no cost annotation");
+    assert_eq!(t.postings[0].lot_note(), None, "no note annotation");
+}
+
+#[test]
+fn lot_persistence_note_only() {
+    // Fixture: 10 AAPL ((BUY-2024-01)) — note annotation only, no cost.
+    // Exercises the cost-fallback path: no {cost} or @ price means the
+    // null posting balances in AAPL. The lot's note field is preserved.
+    let j = compile("lot_persistence_note_only.ledger");
+    let t = &j.transactions[0];
+    assert_eq!(t.postings[0].amount_in("AAPL"), Some(dec!(10)));
+    // Cost-fallback: null posting = -10 AAPL.
+    assert_eq!(t.postings[1].amount_in("AAPL"), Some(dec!(-10)));
+    assert!(t.postings[0].has_lot(), "lot annotation should be present");
+    assert_eq!(t.postings[0].lot_note(), Some("BUY-2024-01"));
+    assert_eq!(t.postings[0].lot_date_naive(), None, "no date annotation");
+    assert_eq!(t.postings[0].lot_cost_in("$"), None, "no cost annotation");
+}
+
+#[test]
 fn virtual_posting_unbalanced() {
     // Fixture has 3 postings: Assets:Checking $100, Equity:Opening -$100,
     // (Equity:Reservations) -$25. The parens mark the third as a virtual

--- a/crates/doppio/tests/parity.rs
+++ b/crates/doppio/tests/parity.rs
@@ -18,6 +18,7 @@
 //! See `docs/SUPPORTED_FEATURES.md` for the human-readable matrix and
 //! the Phase D milestone for the in-flight gap-fills.
 
+use chrono::NaiveDate;
 use doppio::elaboration::Journal;
 use rust_decimal::dec;
 use std::path::PathBuf;
@@ -474,59 +475,99 @@ fn running_balance() {
 // developer landing the schema un-comments it as part of their PR.
 // ──────────────────────────────────────────────────────────────────────────
 
+// ──────────────────────────────────────────────────────────────────────────
+// Lot persistence — #139
+// ──────────────────────────────────────────────────────────────────────────
+
 #[test]
-#[ignore = "tracks #139 — lot persistence {cost} not yet supported"]
 fn lot_persistence_cost() {
     // Fixture: 10 AAPL {$150} @ $155.
     //
     // Cost basis ($150/share) is the historical lot annotation; price
     // ($155) is the actual transaction value. The cash side balances
-    // against the price, not the cost — this is the Ledger semantics
-    // that lot persistence makes representable but doesn't change.
+    // against the price, not the cost — the `@` price wins over `{cost}`
+    // when both are present.
     let j = compile("lot_persistence_cost.ledger");
     let t = &j.transactions[0];
     assert_eq!(t.postings.len(), 2);
     assert_eq!(t.postings[0].account, "Assets:Brokerage");
     assert_eq!(t.postings[0].amount_in("AAPL"), Some(dec!(10)));
-    // Cash side null posting: -(10 * $155) = -$1550.
+    // Cash side null posting: -(10 * $155) = -$1550. Price drives balance.
     assert_eq!(t.postings[1].account, "Assets:Cash");
     assert_eq!(t.postings[1].amount_in("$"), Some(dec!(-1550)));
-    // TODO(#139): once the proto::Posting.lot field ships, also assert:
-    //   let lot = t.postings[0].lot.as_ref().expect("lot annotation present");
-    //   assert_eq!(lot.cost.as_ref().and_then(|a| a.get("$")), Some(dec!(150)));
+    // Lot annotation preserved on the proto posting.
+    let lot = t.postings[0].lot.as_ref().expect("lot annotation present");
+    assert_eq!(lot.cost.as_ref().and_then(|a| a.get("$")), Some(dec!(150)));
 }
 
 #[test]
-#[ignore = "tracks #139 — lot persistence [date] not yet supported"]
 fn lot_persistence_date() {
     // Fixture: 10 AAPL {$150} [2024-03-01]. Cost + lot acquisition date.
     let j = compile("lot_persistence_date.ledger");
     let t = &j.transactions[0];
     assert_eq!(t.postings[0].amount_in("AAPL"), Some(dec!(10)));
-    // No `@ price` — cash side null posting balances against the cost
-    // basis ($150/share * 10 = $1500).
+    // No `@ price` — cash side null posting balances against cost ($150 * 10 = $1500).
     assert_eq!(t.postings[1].amount_in("$"), Some(dec!(-1500)));
-    // TODO(#139): assert lot.cost == $150 AND lot.date == 2024-03-01
-    //   let lot = t.postings[0].lot.as_ref().expect("lot annotation present");
-    //   assert_eq!(lot.cost.as_ref().and_then(|a| a.get("$")), Some(dec!(150)));
-    //   assert_eq!(
-    //       lot.date.map(epoch_days_to_date),
-    //       Some(NaiveDate::from_ymd_opt(2024, 3, 1).unwrap()),
-    //   );
+    let lot = t.postings[0].lot.as_ref().expect("lot annotation present");
+    assert_eq!(lot.cost.as_ref().and_then(|a| a.get("$")), Some(dec!(150)));
+    assert_eq!(
+        t.postings[0].lot_date_naive(),
+        Some(NaiveDate::from_ymd_opt(2024, 3, 1).unwrap()),
+    );
 }
 
 #[test]
-#[ignore = "tracks #139 — lot persistence ((note)) not yet supported"]
 fn lot_persistence_note() {
     // Fixture: 10 AAPL {$150} ((BUY-2024-01)). Cost + free-form note.
     let j = compile("lot_persistence_note.ledger");
     let t = &j.transactions[0];
     assert_eq!(t.postings[0].amount_in("AAPL"), Some(dec!(10)));
     assert_eq!(t.postings[1].amount_in("$"), Some(dec!(-1500)));
-    // TODO(#139): assert lot.cost == $150 AND lot.note == "BUY-2024-01"
-    //   let lot = t.postings[0].lot.as_ref().expect("lot annotation present");
-    //   assert_eq!(lot.cost.as_ref().and_then(|a| a.get("$")), Some(dec!(150)));
-    //   assert_eq!(lot.note.as_deref(), Some("BUY-2024-01"));
+    let lot = t.postings[0].lot.as_ref().expect("lot annotation present");
+    assert_eq!(lot.cost.as_ref().and_then(|a| a.get("$")), Some(dec!(150)));
+    assert_eq!(t.postings[0].lot_note(), Some("BUY-2024-01"));
+}
+
+#[test]
+fn lot_persistence_combined() {
+    // Fixture: 10 AAPL {$150} [2024-03-01] ((BUY-2024-01)).
+    // All three annotations combined; cost drives cash balance (no @ price).
+    let j = compile("lot_persistence_combined.ledger");
+    let t = &j.transactions[0];
+    assert_eq!(t.postings[0].amount_in("AAPL"), Some(dec!(10)));
+    assert_eq!(t.postings[1].amount_in("$"), Some(dec!(-1500)));
+    assert!(t.postings[0].has_lot());
+    assert_eq!(
+        t.postings[0].lot_cost_in("$"),
+        Some(dec!(150)),
+        "lot cost should be $150/share"
+    );
+    assert_eq!(
+        t.postings[0].lot_date_naive(),
+        Some(NaiveDate::from_ymd_opt(2024, 3, 1).unwrap()),
+    );
+    assert_eq!(t.postings[0].lot_note(), Some("BUY-2024-01"));
+}
+
+#[test]
+fn lot_persistence_cost_vs_price() {
+    // Fixture: 10 AAPL {$150} @ $155.
+    // Price ($155) drives the cash balance; cost ($150) is the lot basis.
+    // This is the canonical cost-vs-price scenario: they differ because of
+    // e.g. a non-cash acquisition or a price at time of split.
+    let j = compile("lot_persistence_cost_vs_price.ledger");
+    let t = &j.transactions[0];
+    assert_eq!(t.postings[0].account, "Assets:Brokerage");
+    assert_eq!(t.postings[0].amount_in("AAPL"), Some(dec!(10)));
+    // Price ($155/share) drives cash: -(10 * $155) = -$1550.
+    assert_eq!(t.postings[1].account, "Assets:Cash");
+    assert_eq!(t.postings[1].amount_in("$"), Some(dec!(-1550)));
+    // Lot cost annotation preserved as $150 (NOT $155).
+    assert_eq!(
+        t.postings[0].lot_cost_in("$"),
+        Some(dec!(150)),
+        "lot cost should be $150, not the price $155"
+    );
 }
 
 #[test]

--- a/crates/doppio/tests/parity/fixtures/lot_persistence_combined.ledger
+++ b/crates/doppio/tests/parity/fixtures/lot_persistence_combined.ledger
@@ -1,0 +1,4 @@
+; Lot persistence: combined {cost} [date] ((note)) annotations. Tracks #139.
+2024-03-01 Buy AAPL
+    Assets:Brokerage   10 AAPL {$150} [2024-03-01] ((BUY-2024-01))
+    Assets:Cash

--- a/crates/doppio/tests/parity/fixtures/lot_persistence_cost_vs_price.ledger
+++ b/crates/doppio/tests/parity/fixtures/lot_persistence_cost_vs_price.ledger
@@ -1,0 +1,5 @@
+; Lot persistence: {cost} vs @ price interaction. Tracks #139.
+; Price ($155) drives cash balance; cost ($150) is the lot cost basis.
+2024-03-01 Buy AAPL
+    Assets:Brokerage   10 AAPL {$150} @ $155
+    Assets:Cash

--- a/crates/doppio/tests/parity/fixtures/lot_persistence_date_only.ledger
+++ b/crates/doppio/tests/parity/fixtures/lot_persistence_date_only.ledger
@@ -1,0 +1,6 @@
+; Lot persistence: `[date]` alone — no `{cost}`. Exercises the cost-fallback
+; path where [date] is recorded on the lot but the cash side balances in the
+; posted commodity (AAPL contributes itself). Tracks #139.
+2024-03-01 Buy AAPL
+    Assets:Brokerage   10 AAPL [2024-01-15]
+    Assets:OtherBrokerage

--- a/crates/doppio/tests/parity/fixtures/lot_persistence_note_only.ledger
+++ b/crates/doppio/tests/parity/fixtures/lot_persistence_note_only.ledger
@@ -1,0 +1,6 @@
+; Lot persistence: `((note))` alone — no `{cost}`. Exercises the cost-fallback
+; path where ((note)) is recorded on the lot but the cash side balances in the
+; posted commodity (AAPL contributes itself). Tracks #139.
+2024-03-01 Buy AAPL
+    Assets:Brokerage   10 AAPL ((BUY-2024-01))
+    Assets:OtherBrokerage

--- a/docs/SUPPORTED_FEATURES.md
+++ b/docs/SUPPORTED_FEATURES.md
@@ -37,6 +37,10 @@ Status legend:
 | Lot pricing `@@ total` | ✅ | |
 | Virtual posting `(Account)` | ✅ | Unbalanced — excluded from balance check; stored with `PostingKind::VirtualUnbalanced` |
 | Virtual posting `[Account]` | ✅ | Balanced — included in balance check; stored with `PostingKind::VirtualBalanced` |
+| Lot cost annotation `{cost}` | ✅ | v0.4.0 (PR #139). Per-unit cost basis pinned on the lot; drives cash balance when no `@`/`@@` price present |
+| Lot date annotation `[date]` | ✅ | v0.4.0 (PR #139). Acquisition date stored on `proto::Lot.date` as epoch days |
+| Lot note annotation `((note))` | ✅ | v0.4.0 (PR #139). Free-form note stored on `proto::Lot.note` |
+| Cost-vs-price priority | ✅ | v0.4.0 (PR #139). When `{cost}` and `@ price` both present, `@` price drives the cash balance and `{cost}` is the lot basis only |
 | Null posting (auto-inferred amount) | ✅ | Exactly one per transaction; multiple null postings is an error |
 | Posting balance assertion `= amount` | ✅ | Enforced during elaboration |
 | Strict balance assertion `== amount` | ✅ | Enforced during elaboration |

--- a/proto/doppio.proto
+++ b/proto/doppio.proto
@@ -137,6 +137,26 @@ message Amount {
   map<string, Decimal> by_commodity = 1;
 }
 
+// Per-lot cost basis and acquisition metadata, pinned at purchase time for
+// capital-gains tracking and FIFO/LIFO lot selection on a later sale.
+//
+// Corresponds to the `{cost}`, `[date]`, and `((note))` annotation forms
+// in ledger-cli syntax (e.g. `10 AAPL {$150} [2024-03-01] ((BUY-2024-01))`).
+//
+// All three fields are optional; an absent `lot` field on a `Posting` means
+// no lot annotation was present on the posting.
+message Lot {
+  // Per-lot cost basis as a multi-commodity amount. Typically single-commodity
+  // (the lot's quote currency) but the schema mirrors `Amount` for symmetry.
+  // Corresponds to the `{cost}` annotation form (per-unit cost).
+  Amount cost = 1;
+  // Optional lot acquisition date in epoch days (matches Transaction.date).
+  // Corresponds to the `[date]` annotation form.
+  optional sint32 date = 2;
+  // Optional free-form lot note. Corresponds to the `((note))` annotation form.
+  optional string note = 3;
+}
+
 // A posting with a fully evaluated, concrete amount.
 message Posting {
   // The canonical account name (after alias resolution). For virtual postings
@@ -157,6 +177,9 @@ message Posting {
   // Virtual-posting kind. Defaults to REAL (via UNSPECIFIED = 0) so that
   // older `.dop` files without this field continue to behave as all-real.
   PostingKind kind = 7;
+  // Lot annotation (cost basis, acquisition date, free-form note).
+  // Absent (proto3 default) means no lot annotation was present.
+  optional Lot lot = 8;
 }
 
 // A fully evaluated and balanced transaction.


### PR DESCRIPTION
## Summary

- **Proto schema**: adds `Lot` message (cost/date/note fields 1-3) and `lot = 8` on `Posting`. Field 7 is reserved for PR #156 (virtual postings `kind`), so these two PRs can merge without renumbering.
- **Grammar** (both ledger + hledger frontends): extends `value_logic` to parse a chain of `lot_annotation_or_price` nodes, supporting `{cost}`, `[date]`, and `((note))` in any order between the amount and the optional `@`/`@@` price.
- **AST**: adds `LotAnnotation { cost, date, note }` struct and `lot_annotation: Option<LotAnnotation>` field on `AmountDetails::Amount`.
- **Elaborator**: evaluates cost annotation through the existing value-expr pipeline, emits `proto::Lot`, and applies the three-priority cash-contribution rule:
  1. `@`/`@@` price present → price drives cash balance (unchanged behaviour)
  2. `{cost}` present, no price → cost × quantity drives cash balance
  3. Neither → value contributes in its own commodity (unchanged fallback)
- **Helper accessors**: `has_lot`, `lot_cost_in`, `lot_date_naive`, `lot_note` on `elaboration::Posting` in `elaboration_ext.rs`.
- **Tests**: three parity tests lifted from `#[ignore]`, two new fixtures added (`lot_persistence_combined.ledger`, `lot_persistence_cost_vs_price.ledger`).
- **Docs**: `SUPPORTED_FEATURES.md` rows for lot cost/date/note flipped to ✅.

## Proto field number

`lot = 8` on `Posting`. Field 7 is **not used** by this PR (reserved for PR #156). When both PRs are merged the field-number space is clean.

## Cost-vs-price priority

| Scenario | Cash balance driver | `proto::Lot.cost` |
|---|---|---|
| `10 AAPL @ $155` | `@ $155` (price) | absent |
| `10 AAPL {$150}` | `{$150}` (cost) | `$150` |
| `10 AAPL {$150} @ $155` | `@ $155` (price wins) | `$150` |

## Test plan

- [ ] `cargo fmt --all --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo test --workspace` — 41 parity tests pass (4 still ignored: #140×2, #141, #142); lot_persistence_cost/date/note/combined/cost_vs_price all green
- [ ] `cargo bench --no-run --workspace` — compiles
- [ ] `cargo build --target wasm32-unknown-unknown -p doppio --lib` — compiles

Closes #139