### PR TITLE
chore: audit and prune unused dependency features (closes #125)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -416,7 +415,6 @@ dependencies = [
  "protoc-bin-vendored",
  "regex",
  "rust_decimal",
- "serde",
 ]
 
 [[package]]
@@ -440,7 +438,6 @@ dependencies = [
  "doppio",
  "regex",
  "rust_decimal",
- "serde",
  "serde_json",
  "tempfile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["finance", "parser-implementations"]
 [workspace.dependencies]
 # Shared deps with their versions pinned at workspace level. Each member
 # crate re-declares the deps it actually uses with `workspace = true`.
-chrono = { version = "0.4.42", default-features = false, features = ["serde"] }
+chrono = { version = "0.4.42", default-features = false }
 clap = { version = "4.5.59", features = ["derive"] }
 glob = "0.3.3"
 miniz_oxide = "0.8"
@@ -25,7 +25,6 @@ pest_derive = "2.8.6"
 prost = "0.13"
 regex = "1"
 rust_decimal = "1.40.0"
-serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1"
 # Dev-deps shared across members:
 criterion = { version = "0.8.2", features = ["html_reports"] }

--- a/crates/doppio-cli/Cargo.toml
+++ b/crates/doppio-cli/Cargo.toml
@@ -22,7 +22,6 @@ chrono = { workspace = true }
 clap = { workspace = true }
 regex = { workspace = true }
 rust_decimal = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]

--- a/crates/doppio/Cargo.toml
+++ b/crates/doppio/Cargo.toml
@@ -18,7 +18,6 @@ pest_derive = { workspace = true }
 prost = { workspace = true }
 regex = { workspace = true }
 rust_decimal = { workspace = true }
-serde = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 glob = { workspace = true }

--- a/docs/SUPPORTED_FEATURES.md
+++ b/docs/SUPPORTED_FEATURES.md
@@ -210,3 +210,30 @@ If you find a ledger-cli or hledger construct that doppio rejects (or accepts
 but elaborates wrong) and it isn't documented here, please open an issue at
 <https://github.com/alevy/doppio/issues> — small minimal-failing-case
 snippets are especially welcome.
+
+## Dependency feature flags (non-default)
+
+This section documents every non-default Cargo feature that the doppio workspace
+enables, so future contributors do not need to re-derive the rationale.
+
+### `crates/doppio` (library)
+
+| Crate | Feature | Why enabled |
+|---|---|---|
+| `chrono` | _(none beyond no-default)_ | `default-features = false` keeps `std` without pulling in `js-sys` or serde. No serde integration with chrono types is used; dates travel over the wire as epoch-day integers (prost `i32`). |
+| `rust_decimal` | _(none in prod)_ | Default features are sufficient for arithmetic. The `macros` feature (`dec!` literal syntax) is enabled only in `[dev-dependencies]` for unit tests. |
+| `prost` | _(default)_ | No extra features needed; `prost-build` + `protoc-bin-vendored` are build-deps only. |
+
+### `crates/doppio-cli` (binary)
+
+| Crate | Feature | Why enabled |
+|---|---|---|
+| `chrono` | _(same as library)_ | Parses and formats `NaiveDate` values for `--begin`/`--end`/`--as-of` CLI flags; no serde involvement. |
+| `clap` | `derive` | Enables `#[derive(Parser)]` and `#[derive(Subcommand)]` proc-macros used in `main.rs`. |
+| `serde_json` | _(default)_ | Used directly (`serde_json::json!`, `to_string_pretty`) for `--format json` output. `serde` itself is pulled in transitively by `serde_json` and is not declared as a direct dependency. |
+
+### `crates/doppio-categorize`
+
+| Crate | Feature | Why enabled |
+|---|---|---|
+| `chrono` | _(same as library)_ | `NaiveDate` used in `Sample` and `Query` types for recency-weighted scoring. |


### PR DESCRIPTION
## Summary

- **Dropped `serde` from the doppio library entirely** — the migration from postcard+xz to prost+deflate (PR #109) made the library's `serde` dependency vestigial. Zero uses of `Serialize`, `Deserialize`, or `#[serde(…)]` remain in `crates/doppio/src/`.
- **Dropped `serde` as a direct dep from `doppio-cli`** — the CLI uses `serde_json` for `--format json` output but only via `serde_json::json!` and `to_string_pretty`; no derive macros. `serde` arrives transitively from `serde_json`.
- **Dropped `chrono`'s `serde` feature** from the workspace pin — no chrono type is ever serde-derived anywhere in the workspace; dates are encoded as epoch-day `i32` fields in the protobuf schema.
- **Dropped the top-level `serde` workspace dep** — with no crate directly depending on it, the workspace entry is now dead weight.
- **Added dependency feature flag rationale** to `docs/SUPPORTED_FEATURES.md` — per the original ask in #125.

## Per-Cargo.toml change table

| File | Removed | Kept (non-default) | Rationale for kept |
|---|---|---|---|
| `Cargo.toml` (workspace) | `serde` dep + `derive` feature; `chrono` `serde` feature | `chrono` `default-features = false`; `clap` `derive` | Avoids `js-sys` on wasm; clap derive macros required |
| `crates/doppio/Cargo.toml` | `serde = { workspace = true }` | — | Library is now serde-free |
| `crates/doppio-cli/Cargo.toml` | `serde = { workspace = true }` | `serde_json` (default) | JSON output only via `serde_json::json!`; no derive macros |

## Was dropping serde from the doppio library achievable?

Yes, fully achieved. `grep -rn "serde\|Serialize\|Deserialize" crates/doppio/src/` returns zero results. The library compiles and all tests pass without it.

## Inconclusive / follow-up

None. All four hypotheses from the issue were verified conclusively:
1. `chrono` `serde` feature — unused, dropped.
2. `serde` `derive` feature — unused anywhere, dropped.
3. `serde` in doppio library — unused, dropped.
4. `rust_decimal` serde features — were never enabled in the first place; no action needed.

## Pre-push gates

All five gates passed on this branch:

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo test --workspace` — all pass
- `cargo bench --no-run --workspace` — compiles
- `cargo build --target wasm32-unknown-unknown -p doppio --lib` — compiles