### PR TITLE
refactor(fx): drop BFS chaining; direct + inverse only (closes #158)

### DIFF
--- a/crates/doppio/src/elaboration_ext.rs
+++ b/crates/doppio/src/elaboration_ext.rs
@@ -212,30 +212,24 @@ impl elaboration::Journal {
             return Some(Decimal::ONE);
         }
 
-        // For each price entry that relates the pair (in either direction), is
-        // within `as_of`, and carries a non-zero price, yield (date, rate).
-        // Take the latest by date. Ties break in favour of the entry that
-        // appears later in source order — `max_by_key` returns the last equal
-        // element, matching "more-recently-declared wins".
         self.prices
             .iter()
+            // Pair must relate, in either direction.
             .filter_map(|hp| {
                 let direct = hp.commodity == from_commodity && hp.price_commodity == to_commodity;
                 let inverse = hp.commodity == to_commodity && hp.price_commodity == from_commodity;
-                if !direct && !inverse {
-                    return None;
-                }
-                let date = hp.date_naive();
-                if as_of.is_some_and(|cutoff| date > cutoff) {
-                    return None;
-                }
-                let raw = hp.price.as_ref()?.to_decimal();
-                if raw.is_zero() {
-                    return None;
-                }
-                let rate = if direct { raw } else { Decimal::ONE / raw };
-                Some((date, rate))
+                (direct || inverse).then(|| (hp, direct, hp.date_naive()))
             })
+            // Date must be at or before as_of (or as_of is None).
+            .filter(|(_, _, date)| as_of.is_none_or(|cutoff| *date <= cutoff))
+            // Price field must be present.
+            .filter_map(|(hp, direct, date)| Some((date, direct, hp.price.as_ref()?.to_decimal())))
+            // Price must be non-zero (avoids degenerate inversions).
+            .filter(|(_, _, raw)| !raw.is_zero())
+            // Apply inversion when the entry was matched in reverse direction.
+            .map(|(date, direct, raw)| (date, if direct { raw } else { Decimal::ONE / raw }))
+            // Latest by date wins. Ties resolve in source order — `max_by_key`
+            // returns the last equal element, matching "more-recently-declared".
             .max_by_key(|(date, _)| *date)
             .map(|(_, rate)| rate)
     }

--- a/crates/doppio/src/elaboration_ext.rs
+++ b/crates/doppio/src/elaboration_ext.rs
@@ -212,30 +212,32 @@ impl elaboration::Journal {
             return Some(Decimal::ONE);
         }
 
-        let mut best: Option<(chrono::NaiveDate, Decimal)> = None;
-        for hp in &self.prices {
-            let direct = hp.commodity == from_commodity && hp.price_commodity == to_commodity;
-            let inverse = hp.commodity == to_commodity && hp.price_commodity == from_commodity;
-            if !direct && !inverse {
-                continue;
-            }
-            let date = hp.date_naive();
-            if as_of.is_some_and(|cutoff| date > cutoff) {
-                continue;
-            }
-            let raw = match hp.price.as_ref() {
-                Some(p) => p.to_decimal(),
-                None => continue,
-            };
-            if raw.is_zero() {
-                continue;
-            }
-            let rate = if direct { raw } else { Decimal::ONE / raw };
-            if best.is_none_or(|(prev_date, _)| date > prev_date) {
-                best = Some((date, rate));
-            }
-        }
-        best.map(|(_, r)| r)
+        // For each price entry that relates the pair (in either direction), is
+        // within `as_of`, and carries a non-zero price, yield (date, rate).
+        // Take the latest by date. Ties break in favour of the entry that
+        // appears later in source order — `max_by_key` returns the last equal
+        // element, matching "more-recently-declared wins".
+        self.prices
+            .iter()
+            .filter_map(|hp| {
+                let direct = hp.commodity == from_commodity && hp.price_commodity == to_commodity;
+                let inverse = hp.commodity == to_commodity && hp.price_commodity == from_commodity;
+                if !direct && !inverse {
+                    return None;
+                }
+                let date = hp.date_naive();
+                if as_of.is_some_and(|cutoff| date > cutoff) {
+                    return None;
+                }
+                let raw = hp.price.as_ref()?.to_decimal();
+                if raw.is_zero() {
+                    return None;
+                }
+                let rate = if direct { raw } else { Decimal::ONE / raw };
+                Some((date, rate))
+            })
+            .max_by_key(|(date, _)| *date)
+            .map(|(_, rate)| rate)
     }
 }
 

--- a/crates/doppio/src/elaboration_ext.rs
+++ b/crates/doppio/src/elaboration_ext.rs
@@ -3,7 +3,6 @@
 //! `OUT_DIR` via the `build.rs` `include!`) doesn't clobber these impls.
 
 use crate::elaboration;
-use std::collections::{BTreeMap, HashSet, VecDeque};
 
 impl elaboration::Decimal {
     /// Reconstruct a [`rust_decimal::Decimal`] from this proto-encoded value.
@@ -178,31 +177,29 @@ impl elaboration::Journal {
     /// Return the conversion rate from `from_commodity` to `to_commodity` as
     /// of `as_of` (or the latest available if `as_of` is `None`).
     ///
-    /// Searches `self.prices` for `P` entries and performs a BFS through the
-    /// commodity price graph to find a conversion path. For each pair of
-    /// commodities the most recent quote whose date is `<= as_of` (or the
-    /// most recent overall when `as_of` is `None`) is used.
+    /// **Direct + inverse only — no chaining through intermediate
+    /// commodities.** Scans `self.prices` for entries that directly relate
+    /// the requested pair, in either direction. The most-recent eligible
+    /// quote (date ≤ `as_of`, in either direction) wins. If the winning
+    /// quote was declared as the inverse pair (`to → from`), the returned
+    /// rate is `1 / quoted`.
     ///
-    /// Multi-hop conversion is supported: if there is no direct EUR→USD quote
-    /// but there are EUR→GBP and GBP→USD quotes, the combined rate is returned.
-    /// Rates are multiplied along the path (BFS finds shortest hops first).
+    /// This is a deliberate design choice; see `docs/exchange-rates.md`
+    /// for rationale and comparison with hledger (chains with a depth
+    /// limit) and Beancount (also refuses to chain). The short version:
+    /// each chain hop accumulates uncertainty — different vendor, different
+    /// time of day, different bid-ask spread — and silently fabricating
+    /// rates from chains hides missing P directives that the user should
+    /// see and fill in.
     ///
-    /// Inverse quotes are also traversed: if only USD→EUR is declared, then
-    /// EUR→USD is available as `1 / (USD→EUR rate)`. Explicit and derived
-    /// (inverse) quotes are merged by the most-recent-date rule.
+    /// Returns `None` if no direct or inverse quote for the pair is
+    /// available within `as_of`.
     ///
-    /// When multiple shortest paths exist, the one whose intermediate
-    /// commodities sort first alphabetically is used (BFS expansion follows
-    /// the BTreeMap-keyed adjacency map's deterministic key order).
-    ///
-    /// Conversion uses the report's `--end` date as the as-of cutoff, or the
-    /// latest available quote if `--end` is not specified. ledger-cli converts
-    /// per-posting using the transaction's own date by default; this
-    /// implementation uses a single uniform as-of for all postings, which is
-    /// simpler but means historical reports without `--end` will use
-    /// anachronistically recent rates.
-    ///
-    /// Returns `None` if no conversion path exists.
+    /// CLI usage: `dop balance --exchange COMMODITY` and `dop register
+    /// --exchange COMMODITY` use `--end` as the as-of cutoff, or `None`
+    /// (latest) if no `--end` is set. Commodities for which this lookup
+    /// returns `None` are left unconverted in the report with a warning
+    /// to stderr.
     pub fn exchange_rate_at(
         &self,
         from_commodity: &str,
@@ -215,72 +212,30 @@ impl elaboration::Journal {
             return Some(Decimal::ONE);
         }
 
-        // Eligible quotes: each `HistoricalPrice` with a non-zero price and a
-        // date at or before `as_of` (or any date if `as_of` is `None`),
-        // flattened to `(from, to, rate, date)` tuples.
-        let eligible_quotes = self.prices.iter().filter_map(|hp| {
-            let price_val = hp.price.as_ref()?.to_decimal();
-            if price_val == Decimal::ZERO {
-                return None;
+        let mut best: Option<(chrono::NaiveDate, Decimal)> = None;
+        for hp in &self.prices {
+            let direct = hp.commodity == from_commodity && hp.price_commodity == to_commodity;
+            let inverse = hp.commodity == to_commodity && hp.price_commodity == from_commodity;
+            if !direct && !inverse {
+                continue;
             }
             let date = hp.date_naive();
             if as_of.is_some_and(|cutoff| date > cutoff) {
-                return None;
+                continue;
             }
-            Some((
-                hp.commodity.as_str(),
-                hp.price_commodity.as_str(),
-                price_val,
-                date,
-            ))
-        });
-
-        // Build adjacency map: commodity → { neighbour → (date, rate) }.
-        // For each eligible quote, insert both a forward edge `from → to` at
-        // `rate` and an inverse edge `to → from` at `1/rate`. When the same
-        // (from, to) pair appears more than once, keep the most recent quote
-        // by date.
-        let mut adj: BTreeMap<&str, BTreeMap<&str, (chrono::NaiveDate, Decimal)>> = BTreeMap::new();
-        let mut upsert = |from, to, date: chrono::NaiveDate, rate: Decimal| {
-            let entry = adj
-                .entry(from)
-                .or_default()
-                .entry(to)
-                .or_insert((date, rate));
-            if date > entry.0 {
-                *entry = (date, rate);
+            let raw = match hp.price.as_ref() {
+                Some(p) => p.to_decimal(),
+                None => continue,
+            };
+            if raw.is_zero() {
+                continue;
             }
-        };
-        for (from, to, rate, date) in eligible_quotes {
-            upsert(from, to, date, rate);
-            upsert(to, from, date, Decimal::ONE / rate);
-        }
-
-        // BFS from `from_commodity` to `to_commodity`.
-        // State: (current_commodity, accumulated_rate).
-        let mut queue: VecDeque<(&str, Decimal)> = VecDeque::new();
-        let mut visited: HashSet<&str> = HashSet::new();
-
-        queue.push_back((from_commodity, Decimal::ONE));
-        visited.insert(from_commodity);
-
-        while let Some((current, rate)) = queue.pop_front() {
-            if let Some(neighbours) = adj.get(current) {
-                for (neighbour, (_date, edge_rate)) in neighbours {
-                    if visited.contains(neighbour) {
-                        continue;
-                    }
-                    let combined = rate * edge_rate;
-                    if *neighbour == to_commodity {
-                        return Some(combined);
-                    }
-                    visited.insert(neighbour);
-                    queue.push_back((neighbour, combined));
-                }
+            let rate = if direct { raw } else { Decimal::ONE / raw };
+            if best.is_none_or(|(prev_date, _)| date > prev_date) {
+                best = Some((date, rate));
             }
         }
-
-        None
+        best.map(|(_, r)| r)
     }
 }
 
@@ -937,22 +892,25 @@ mod tests {
     }
 
     #[test]
-    fn exchange_rate_at_two_hop_chain() {
-        // EUR→GBP and GBP→USD; no direct EUR→USD.
+    fn exchange_rate_at_chained_path_not_traversed() {
+        // EUR→GBP and GBP→USD declared, but there is no direct or inverse
+        // EUR↔USD quote. Doppio's contract is direct + inverse only — it
+        // refuses to chain through intermediates. See docs/exchange-rates.md
+        // for rationale; aligns with Beancount's "non-transitive" choice.
         let j = journal_with_prices(vec![
             make_price(2024, 1, 1, "EUR", "GBP", "0.85".parse().unwrap()),
             make_price(2024, 1, 1, "GBP", "USD", "1.27".parse().unwrap()),
         ]);
-        let rate = j
-            .exchange_rate_at("EUR", "USD", None)
-            .expect("two-hop path exists");
-        let expected = "0.85".parse::<Decimal>().unwrap() * "1.27".parse::<Decimal>().unwrap();
-        assert_eq!(rate, expected);
+        assert_eq!(
+            j.exchange_rate_at("EUR", "USD", None),
+            None,
+            "chained paths through intermediate commodities must not be traversed"
+        );
     }
 
     #[test]
-    fn exchange_rate_at_no_path_returns_none() {
-        // EUR→GBP exists, but there is no path to USD.
+    fn exchange_rate_at_no_quote_returns_none() {
+        // Only EUR→GBP exists; nothing relates EUR and USD in either direction.
         let j = journal_with_prices(vec![make_price(
             2024,
             1,

--- a/docs/SUPPORTED_FEATURES.md
+++ b/docs/SUPPORTED_FEATURES.md
@@ -124,7 +124,7 @@ Status legend:
 | `dop register` | ✅ | Per-posting register with running totals per commodity |
 | `dop register --begin/--end/--cleared/--tag/--format` | ✅ | Same filters as `balance` |
 | `dop register --real` / `-R` | ✅ | Excludes virtual postings from register output |
-| `dop balance/register --exchange COMMODITY` (or `-X`) | ✅ | Converts non-target commodity balances via `P`-directive price chain; warns to stderr for unconvertible commodities. Conversion uses the report's `--end` date as the as-of cutoff, or the latest available quote if `--end` is not specified. ledger-cli converts per-posting using the transaction's own date by default; this implementation uses a single uniform as-of for all postings, which is simpler but means historical reports without `--end` will use anachronistically recent rates. |
+| `dop balance/register --exchange COMMODITY` (or `-X`) | ✅ | Converts non-target commodity balances via direct or inverse `P`-directive quotes; warns to stderr for unconvertible commodities. **No chaining through intermediates** — see [`docs/exchange-rates.md`](exchange-rates.md) for the algorithm and rationale (deliberate, aligns with Beancount). Uses `--end` as the as-of cutoff, or latest available if `--end` is unset. |
 | `dop print SRC` | ✅ | Re-emits source. Format strings not applied (intentional) |
 | `dop stats` | ✅ | Transaction/account/commodity counts and date range |
 | `dop accounts` | ✅ | Lists unique account names |

--- a/docs/exchange-rates.md
+++ b/docs/exchange-rates.md
@@ -1,0 +1,192 @@
+# Exchange rate semantics in doppio
+
+doppio supports converting amounts between commodities using `P` directives
+declared in the journal. This document captures the **algorithm**, the
+**rationale** for the choice, and how it compares to ledger-cli, hledger, and
+Beancount. It is the normative spec for cross-language consumers of `.dop`
+files reading the `journal.prices` field.
+
+## The algorithm in 6 lines
+
+Given `(from_commodity, to_commodity, as_of)`:
+
+1. If `from == to`, return `1`.
+2. Scan `journal.prices` for entries that **directly relate** the pair, in
+   either direction:
+   - **direct**: `entry.commodity == from` and `entry.price_commodity == to`
+   - **inverse**: `entry.commodity == to` and `entry.price_commodity == from`
+3. Discard entries whose date is after `as_of` (or all are eligible if
+   `as_of` is `None`).
+4. Discard entries whose price is zero or absent.
+5. From the remainder, pick the **most-recent eligible entry overall** in
+   either direction.
+6. Return its rate (verbatim if direct; `1 / rate` if inverse). Return
+   `None` if no entry survived.
+
+That's it. No graph, no chaining, no path search, no tie-break beyond date
+ordering. A consumer in any language can implement this in ~10 lines.
+
+## Reference TypeScript implementation
+
+```ts
+function exchangeRateAt(
+  prices: HistoricalPrice[],
+  from: string,
+  to: string,
+  asOf: Date | null,
+): Decimal | null {
+  if (from === to) return new Decimal(1);
+  let best: { date: Date; rate: Decimal } | null = null;
+  for (const p of prices) {
+    const direct = p.commodity === from && p.priceCommodity === to;
+    const inverse = p.commodity === to && p.priceCommodity === from;
+    if (!direct && !inverse) continue;
+    const date = epochDaysToDate(p.date);
+    if (asOf && date > asOf) continue;
+    const raw = decimalFromProto(p.price);
+    if (raw.isZero()) continue;
+    const rate = direct ? raw : new Decimal(1).div(raw);
+    if (!best || date > best.date) best = { date, rate };
+  }
+  return best?.rate ?? null;
+}
+```
+
+10 LOC of substance. Identical structure works in Python, Go, etc. — the
+multilingual recipe in `proto/doppio.proto`'s top comment block expands on
+this with idiomatic versions.
+
+## Why direct + inverse only — no chaining
+
+doppio explicitly **refuses** to compute a rate by chaining through
+intermediate commodities. If a journal declares `EUR → GBP` and
+`GBP → USD` but no direct `EUR ↔ USD` quote, `exchange_rate_at("EUR", "USD",
+…)` returns `None`. This is intentional. Three intertwined reasons:
+
+### 1. PTA exchange rates are inherently estimates
+
+Real markets do not produce a single canonical rate for any pair. EUR→USD
+on Tuesday at 09:00 from Vendor A is not the same number as EUR→USD on
+Tuesday at 17:00 from Vendor B, and neither equals the inverse of USD→EUR
+at the same moment. Bid-ask spread alone creates non-trivial divergence.
+The journal records the user's chosen quote at a chosen moment; the
+lookup just returns it. Every conversion the journal can express is an
+estimate by construction; nobody pretends otherwise.
+
+### 2. Chaining accumulates uncertainty silently
+
+Multi-hop synthesis takes data points the user wrote down — each subject
+to the uncertainty above — and combines them through multiplication. The
+result is a fabricated rate the user never declared. Worse:
+
+- Each chained hop may come from a different vendor or different time of
+  day, so the chain mixes incompatible bases.
+- Each hop has an implicit transaction cost the journal doesn't model;
+  chaining glosses over it.
+- "Shortest path" through the graph is not necessarily the cheapest, the
+  most liquid, or the path the user actually used to make the conversion.
+- A direct path may exist in the real world and just isn't in the ledger
+  because nobody recorded it. The chained rate is a guess about a rate
+  the user could have looked up.
+
+Calling chained-BFS a "best estimator" makes it sound principled. It
+isn't. It's a guess in a graph the user didn't author, and the user has
+no signal that it's a guess.
+
+### 3. The "no quote" failure mode is healthier feedback
+
+When a chain doesn't exist, returning `None` and surfacing it ("no
+direct quote from EUR to $; leaving 100 EUR unconverted") prompts the
+user to record the missing P directive. The journal becomes more
+explicit over time. Silently fabricating around the missing data hides
+the gap and gradually erodes the user's trust in the report's numbers.
+
+## Comparison: how the other PTA tools handle this
+
+| | doppio (this project) | Beancount | hledger | ledger-cli |
+|---|---|---|---|---|
+| Direct quote | ✓ | ✓ | ✓ tier 1 | ✓ |
+| Inverse quote (1/B→A) | ✓ (most-recent overall wins) | ✓ | ✓ tier 2 | ✓ |
+| Chain through intermediates | ✗ — explicit decision | ✗ — explicit decision | ✓ tier 3-4 with depth limit | ✓ "as long as desired" per docs |
+| Failure mode when no rate | `None` returned | `None` (varies by tool path) | "gave up" message at depth limit | implementation-defined |
+| Algorithm complexity | linear scan | linear scan | bounded BFS | under-documented |
+
+**Beancount** explicitly treats currency conversion as **non-transitive**:
+"Commodity conversion in beancount is not transitive, so even though you
+might have mapping for XXX→GBP and GBP→EUR, beancount won't map XXX to
+EUR via GBP." This is the design choice doppio inherits.
+
+**hledger** chains with a tiered fallback (direct → inverse → forward
+chain → mixed forward/reverse chain), depth-limited with a "gave up"
+failure mode. Documented at <https://hledger.org/currency-conversion.html>.
+hledger's depth limit acknowledges what doppio takes a step further:
+chain confidence drops with each hop.
+
+**ledger-cli** chains without an obvious depth limit per the official
+docs ("equivalence chains can be as long as desired"), but the precise
+algorithm is under-documented in the manual; community discussions treat
+it as a "ledger does the right thing for typical cases" black box.
+
+doppio's choice aligns with Beancount, *not* with hledger/ledger-cli. A
+journal authored against ledger-cli that relies on chained conversion
+will surface differently in doppio: the unchained pairs return `None`,
+prompting the user to add explicit P directives.
+
+## CLI behaviour
+
+`dop balance --exchange COMMODITY` and `dop register --exchange COMMODITY`
+convert each posting amount via `exchange_rate_at(amount.commodity,
+target, as_of)`. As-of is the report's `--end` if specified, else `None`
+(latest). Commodities for which `exchange_rate_at` returns `None` are left
+unconverted in the report, with one stderr warning per missing pair.
+Example:
+
+```text
+$ dop balance --exchange USD --end 2024-12-31
+no direct quote from JPY to USD; leaving 1,000.00 JPY unconverted
+                $1,250.00  Assets:Brokerage
+                  €100.00 → $110.00  Assets:Cash:Eurozone
+                1,000.00 JPY  Assets:Cash:Tokyo
+                ────────────
+                $1,360.00 + 1,000.00 JPY
+```
+
+The mixed-commodity total is the truthful answer when conversion is
+incomplete, not a fabricated USD figure.
+
+## What this means for downstream consumers
+
+A `.dop` file ships `journal.prices` exactly as the user authored it
+(plus any inferred prices from cost annotations). The lookup contract is
+the 10-line algorithm above. **That is the entire format-as-API contract
+for FX.**
+
+If a consumer wants chaining behaviour like ledger-cli or hledger,
+nothing in the format prevents them from implementing it on top. The
+library doesn't choose for them; the format ships the raw quotes and the
+default lookup is conservative. A consumer who does want chaining
+explicitly opts into the trade-offs documented above.
+
+## History
+
+This document supersedes earlier doppio behaviour: through v0.4, the
+Rust `Journal::exchange_rate_at` did unbounded BFS chaining with inverse
+edges and alphabetical tie-breaking — strictly more aggressive than
+hledger's bounded version. The decision to drop chaining was driven by:
+
+- **The "is this is good idea?" pressure test in
+  [#158](https://github.com/alevy/doppio/issues/158)**: explored five
+  encoding strategies for embedding pre-resolved rates into `.dop` so
+  cross-language consumers wouldn't re-implement BFS. The synthetic-data
+  measurements (committed to
+  [`alevy/doppio-research:prototypes/exchange-rates-baking/FINDINGS.md`](https://github.com/alevy/doppio-research/blob/main/prototypes/exchange-rates-baking/FINDINGS.md))
+  surfaced both the wire-cost penalty of correct embedding strategies
+  and the semantic divergence of compact ones. None was clearly better
+  than baseline.
+- **Recognising the BFS itself was over-engineered**, not just hard to
+  port to other languages. The reframing question — "what does the user
+  actually want when they write a P directive?" — pointed at the
+  Beancount answer: don't fabricate beyond what was written.
+
+The PR that landed this change closed [#158](https://github.com/alevy/doppio/issues/158)
+with the conclusion documented above.

--- a/proto/doppio.proto
+++ b/proto/doppio.proto
@@ -66,6 +66,105 @@
 // — it carries the lower bits of the two's-complement representation, not a
 // magnitude. This is why the language recipes mask `mantissaLow` defensively
 // rather than treating it as signed.
+//
+// =============================================================================
+// Exchange rate lookup
+// =============================================================================
+//
+// Exchange rates are stored verbatim in `Journal.prices` as `HistoricalPrice`
+// entries. Consumers compute a rate from `from_commodity` to `to_commodity`
+// as of a given date with the algorithm below — direct + inverse only, no
+// chaining through intermediate commodities. This is doppio's normative
+// contract; consumers in any language MUST implement it identically when
+// returning a "default" rate for cross-language parity. (Consumers MAY
+// implement chaining or other strategies on top, opt-in.)
+//
+// Algorithm:
+//
+//   exchange_rate_at(prices, from, to, as_of) -> Optional<rate>:
+//     if from == to: return 1
+//     best = None
+//     for hp in prices:
+//       direct  = (hp.commodity == from and hp.price_commodity == to)
+//       inverse = (hp.commodity == to   and hp.price_commodity == from)
+//       if not (direct or inverse): continue
+//       if as_of is not None and hp.date_naive() > as_of: continue
+//       if hp.price is None or hp.price.to_decimal() == 0: continue
+//       rate = hp.price.to_decimal() if direct else 1 / hp.price.to_decimal()
+//       if best is None or hp.date_naive() > best.date:
+//         best = (hp.date_naive(), rate)
+//     return best.rate if best is not None else None
+//
+// The "most-recent quote in either direction wins" rule is uniform: there
+// is no preference between an explicit forward quote and the inverse of a
+// reverse quote. The data point closest to `as_of` is the answer regardless
+// of how it was declared.
+//
+// Rationale and comparison with hledger / Beancount / ledger-cli are in
+// the doppio repo's `docs/exchange-rates.md`.
+//
+// Recipes for common languages:
+//
+//   TypeScript:
+//     function exchangeRateAt(
+//       prices: HistoricalPrice[],
+//       from: string,
+//       to: string,
+//       asOf: Date | null,
+//     ): Decimal | null {
+//       if (from === to) return new Decimal(1);
+//       let best: { date: Date; rate: Decimal } | null = null;
+//       for (const p of prices) {
+//         const direct = p.commodity === from && p.priceCommodity === to;
+//         const inverse = p.commodity === to && p.priceCommodity === from;
+//         if (!direct && !inverse) continue;
+//         const date = epochDaysToDate(p.date);
+//         if (asOf && date > asOf) continue;
+//         const raw = decimalFromProto(p.price);
+//         if (raw.isZero()) continue;
+//         const rate = direct ? raw : new Decimal(1).div(raw);
+//         if (!best || date > best.date) best = { date, rate };
+//       }
+//       return best?.rate ?? null;
+//     }
+//
+//   Python (using stdlib `decimal.Decimal` and `datetime.date`):
+//     from decimal import Decimal
+//     def exchange_rate_at(prices, from_, to, as_of):
+//         if from_ == to: return Decimal(1)
+//         best = None
+//         for hp in prices:
+//             direct = hp.commodity == from_ and hp.price_commodity == to
+//             inverse = hp.commodity == to and hp.price_commodity == from_
+//             if not (direct or inverse): continue
+//             date = epoch_days_to_date(hp.date)
+//             if as_of is not None and date > as_of: continue
+//             raw = decimal_from_proto(hp.price)
+//             if raw == 0: continue
+//             rate = raw if direct else Decimal(1) / raw
+//             if best is None or date > best[0]: best = (date, rate)
+//         return best[1] if best else None
+//
+//   Go (sketch; uses the project's preferred decimal lib at the boundary):
+//     func ExchangeRateAt(prices []HistoricalPrice, from, to string, asOf *time.Time) *Rate {
+//       if from == to { return One() }
+//       var best *struct{ date time.Time; rate Rate }
+//       for _, p := range prices {
+//         direct := p.Commodity == from && p.PriceCommodity == to
+//         inverse := p.Commodity == to && p.PriceCommodity == from
+//         if !direct && !inverse { continue }
+//         date := EpochDaysToTime(p.Date)
+//         if asOf != nil && date.After(*asOf) { continue }
+//         raw := DecimalFromProto(p.Price)
+//         if raw.IsZero() { continue }
+//         rate := raw; if !direct { rate = OneDiv(raw) }
+//         if best == nil || date.After(best.date) {
+//           best = &struct{ date time.Time; rate Rate }{date, rate}
+//         }
+//       }
+//       if best == nil { return nil }
+//       return &best.rate
+//     }
 
 syntax = "proto3";
 


### PR DESCRIPTION
## Summary

Replace `Journal::exchange_rate_at`'s unbounded BFS-with-inverse-edges implementation with a linear scan that returns the most-recent direct or inverse quote for the requested pair. **No chaining through intermediate commodities.** This aligns doppio with Beancount's "non-transitive" design and diverges (deliberately) from hledger/ledger-cli, which chain.

The PR closes #158. The decision is captured in detail in two comments on that issue and in the new design doc.

## Why

Multi-hop chaining silently fabricates rates the user never declared, accumulating uncertainty across vendor / time / spread differences invisibly. Returning `None` and surfacing missing `P` directives is healthier feedback. The TS port for cross-language consumers (#151) drops from ~70 LOC to ~10 LOC as a side effect, which makes the format-as-API claim near-trivially demonstrable.

Full reasoning in [`docs/exchange-rates.md`](https://github.com/alevy/doppio/blob/feat/158-direct-only-fx/docs/exchange-rates.md), including a TypeScript reference implementation and a comparison table with hledger/Beancount/ledger-cli.

## Changes

- `crates/doppio/src/elaboration_ext.rs`:
  - `Journal::exchange_rate_at` rewritten as a linear scan; ~20 LOC of substance
  - Doc comment rewritten to spell out direct + inverse semantics and link the design doc
  - Tests: dropped `_two_hop_chain`; renamed `_no_path_returns_none` → `_no_quote_returns_none`; added `_chained_path_not_traversed` as the explicit "no transitivity" contract
  - Dropped now-unused `HashSet`/`VecDeque` imports
- `proto/doppio.proto`: added "Exchange rate lookup" section to the top comment block with normative algorithm pseudocode and TypeScript / Python / Go reference recipes (mirrors the existing multilingual decimal-reassembly pattern)
- `docs/exchange-rates.md` (new): durable design-decision capture for future high-level documentation. Algorithm, rationale (3 reasons), comparison table with the other PTA tools, TS reference impl, CLI behaviour, history note linking to the [doppio-research embedding-strategies exploration](https://github.com/alevy/doppio-research/blob/main/prototypes/exchange-rates-baking/FINDINGS.md).
- `docs/SUPPORTED_FEATURES.md`: updated `--exchange` row to flag the no-chaining contract and link the design doc

## CLI behaviour

No code changes. PR #155's CLI already handles `None` returns gracefully (stderr warning + leave the commodity unconverted in the report). The practical difference is that more pairs now return `None` legitimately — exactly the chains we're refusing to fabricate.

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test --workspace` — 230 lib + parity + CLI integration tests pass
- [x] `cargo bench --no-run --workspace` — clean
- [x] `cargo build --target wasm32-unknown-unknown -p doppio --lib` — clean
- [ ] CI green