### PR TITLE
feat(web): JS-native .dop reader (closes #151)

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -36,6 +36,8 @@ jobs:
         run: npm ci
       - name: Generate protobuf TS stubs
         run: npm run generate
+      - name: Run unit tests
+        run: npm test
       - name: Type-check and build
         run: npm run build
       - name: Upload Pages artifact

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -19,10 +19,12 @@
       "devDependencies": {
         "@bufbuild/buf": "^1.47.0",
         "@bufbuild/protoc-gen-es": "^2.2.0",
+        "@types/node": "^25.6.0",
         "@types/pako": "^2.0.3",
         "@vitejs/plugin-vue": "^5.1.0",
         "typescript": "^5.6.0",
         "vite": "^5.4.0",
+        "vitest": "^2.1.9",
         "vue-tsc": "^2.1.0"
       },
       "engines": {
@@ -1075,6 +1077,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
     "node_modules/@types/pako": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
@@ -1107,6 +1119,146 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0",
         "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@volar/language-core": {
@@ -1287,6 +1439,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1304,6 +1466,16 @@
         "balanced-match": "^1.0.0"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/chart.js": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
@@ -1314,6 +1486,16 @@
       },
       "engines": {
         "pnpm": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/csstype": {
@@ -1353,6 +1535,16 @@
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "license": "MIT"
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/entities": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
@@ -1364,6 +1556,13 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1410,6 +1609,16 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1434,6 +1643,13 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -1504,6 +1720,23 @@
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1606,6 +1839,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1613,6 +1853,54 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/typescript": {
@@ -1628,6 +1916,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.21",
@@ -1687,6 +1982,179 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-uri": {
@@ -1768,6 +2236,23 @@
       },
       "peerDependencies": {
         "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,8 @@
     "dev": "npm run generate && vite",
     "build": "npm run generate && vue-tsc -b && vite build",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "generate": "buf generate",
     "fixtures": "cd .. && cargo run -q --bin dop -- compile web/fixtures/sample.ledger -o web/public/sample.dop"
   },
@@ -26,10 +28,12 @@
   "devDependencies": {
     "@bufbuild/buf": "^1.47.0",
     "@bufbuild/protoc-gen-es": "^2.2.0",
+    "@types/node": "^25.6.0",
     "@types/pako": "^2.0.3",
     "@vitejs/plugin-vue": "^5.1.0",
     "typescript": "^5.6.0",
     "vite": "^5.4.0",
+    "vitest": "^2.1.9",
     "vue-tsc": "^2.1.0"
   }
 }

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,8 +1,106 @@
 <script setup lang="ts">
-// Skeleton page. Subsequent issues populate the views:
-//   #151 — JS-native .dop loader (Buf-generated TS types + decimal.js)
-//   #150 — balance / register / chart Vue components
-//   #149 — drag-and-drop WASM source-parser shim (post-1.0)
+import { computed, onMounted, ref } from "vue";
+import Decimal from "decimal.js";
+import {
+  readDop,
+  localDateToString,
+  type Journal,
+  type LocalDate,
+  DopError,
+} from "@/lib/dop";
+
+const journal = ref<Journal | null>(null);
+const error = ref<string | null>(null);
+
+interface BalanceLine {
+  account: string;
+  byCommodity: { commodity: string; total: Decimal }[];
+}
+
+const summary = computed(() => {
+  if (!journal.value) return null;
+  const j = journal.value;
+  const dates = j.transactions.map((t) => t.date);
+  return {
+    transactions: j.transactions.length,
+    accounts: Object.keys(j.accounts).length,
+    commodities: Object.keys(j.commodities).length,
+    prices: j.prices.length,
+    firstDate: dates.length ? minDate(dates) : null,
+    lastDate: dates.length ? maxDate(dates) : null,
+  };
+});
+
+const balanceByAccount = computed<BalanceLine[]>(() => {
+  if (!journal.value) return [];
+  const totals: Record<string, Map<string, Decimal>> = {};
+  for (const t of journal.value.transactions) {
+    for (const p of t.postings) {
+      if (p.kind === "virtualUnbalanced") continue;
+      const row = (totals[p.account] ??= new Map());
+      for (const [c, v] of Object.entries(p.amount.byCommodity)) {
+        row.set(c, (row.get(c) ?? new Decimal(0)).plus(v));
+      }
+    }
+  }
+  return Object.keys(totals)
+    .sort()
+    .map((account) => ({
+      account,
+      byCommodity: [...totals[account]!.entries()]
+        .filter(([_, v]) => !v.isZero())
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([commodity, total]) => ({ commodity, total })),
+    }))
+    .filter((line) => line.byCommodity.length > 0);
+});
+
+function minDate(ds: LocalDate[]): LocalDate {
+  return ds.reduce((a, b) =>
+    a.year < b.year ||
+    (a.year === b.year && a.month < b.month) ||
+    (a.year === b.year && a.month === b.month && a.day < b.day)
+      ? a
+      : b,
+  );
+}
+
+function maxDate(ds: LocalDate[]): LocalDate {
+  return ds.reduce((a, b) =>
+    a.year > b.year ||
+    (a.year === b.year && a.month > b.month) ||
+    (a.year === b.year && a.month === b.month && a.day > b.day)
+      ? a
+      : b,
+  );
+}
+
+function formatAmount(commodity: string, value: Decimal): string {
+  const sign = value.isNegative() ? "-" : "";
+  const abs = value.abs().toFixed(2);
+  if (commodity === "$") return `${sign}$${abs}`;
+  return `${sign}${abs} ${commodity}`;
+}
+
+onMounted(async () => {
+  try {
+    const url = `${import.meta.env.BASE_URL}sample.dop`;
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`fetch ${url} → HTTP ${res.status}`);
+    }
+    const buf = new Uint8Array(await res.arrayBuffer());
+    journal.value = readDop(buf);
+  } catch (e) {
+    if (e instanceof DopError) {
+      error.value = `[${e.kind}] ${e.message}`;
+    } else if (e instanceof Error) {
+      error.value = e.message;
+    } else {
+      error.value = String(e);
+    }
+  }
+});
 </script>
 
 <template>
@@ -11,27 +109,62 @@
     <p class="tagline">
       A typed compiler pipeline for
       <a href="https://ledger-cli.org/" target="_blank" rel="noopener">Ledger</a>
-      plain-text accounting. This page is a browser demo for the
-      <code>.dop</code> compiled-journal format.
+      plain-text accounting. This page reads a compiled
+      <code>.dop</code> file using a JS-native protobuf decoder — no Rust or
+      WASM at runtime.
     </p>
   </header>
 
   <main class="content">
-    <section class="placeholder">
-      <h2>Coming soon</h2>
-      <p>
-        The interactive views land in
-        <a href="https://github.com/alevy/doppio/issues/150" target="_blank" rel="noopener">#150</a>.
-        The JS-native <code>.dop</code> reader (the central architectural
-        validator of the format-as-API claim) lands in
-        <a href="https://github.com/alevy/doppio/issues/151" target="_blank" rel="noopener">#151</a>.
-      </p>
-      <p>
-        Until then, this page proves the build pipeline works end to end:
-        <code>buf generate</code> from
-        <code>proto/doppio.proto</code> → Vite/Vue static bundle → GitHub Pages.
-      </p>
+    <section v-if="error" class="card error">
+      <h2>Failed to load <code>sample.dop</code></h2>
+      <pre>{{ error }}</pre>
     </section>
+
+    <section v-else-if="!journal" class="card">
+      <h2>Loading…</h2>
+    </section>
+
+    <template v-else>
+      <section class="card">
+        <h2>Journal summary</h2>
+        <dl class="stats">
+          <div><dt>Transactions</dt><dd>{{ summary!.transactions }}</dd></div>
+          <div><dt>Accounts</dt><dd>{{ summary!.accounts }}</dd></div>
+          <div><dt>Commodities</dt><dd>{{ summary!.commodities }}</dd></div>
+          <div><dt>Price quotes</dt><dd>{{ summary!.prices }}</dd></div>
+          <div>
+            <dt>Date range</dt>
+            <dd>
+              {{ localDateToString(summary!.firstDate!) }} →
+              {{ localDateToString(summary!.lastDate!) }}
+            </dd>
+          </div>
+        </dl>
+      </section>
+
+      <section class="card">
+        <h2>Balance</h2>
+        <table class="balance">
+          <tbody>
+            <tr v-for="line in balanceByAccount" :key="line.account">
+              <th scope="row">{{ line.account }}</th>
+              <td>
+                <span
+                  v-for="({ commodity, total }, idx) in line.byCommodity"
+                  :key="commodity"
+                  class="amount"
+                  :class="{ negative: total.isNegative() }"
+                >
+                  <template v-if="idx > 0">, </template>
+                  {{ formatAmount(commodity, total) }}
+                </span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </template>
   </main>
 
   <footer class="footer">
@@ -76,31 +209,64 @@
 .content {
   flex: 1;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
+  gap: 1.25rem;
   padding: 2rem 1.5rem;
 }
 
-.placeholder {
-  max-width: 36rem;
+.card {
+  width: 100%;
+  max-width: 44rem;
   background: #fff;
   border: 1px solid #e5e5e5;
   border-radius: 0.5rem;
-  padding: 1.5rem 2rem;
+  padding: 1.25rem 1.5rem;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
 }
 
-.placeholder h2 {
-  margin-top: 0;
-  font-size: 1.2rem;
+.card h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1.05rem;
+  color: #333;
 }
 
-.footer {
-  border-top: 1px solid #e5e5e5;
-  padding: 1rem 1.5rem;
-  text-align: center;
-  color: #666;
-  font-size: 0.9rem;
-  background: #fff;
+.error {
+  border-color: #c44;
+  color: #722;
 }
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  gap: 0.75rem 1.5rem;
+  margin: 0;
+}
+
+.stats div { display: flex; flex-direction: column; }
+.stats dt { font-size: 0.78rem; color: #777; text-transform: uppercase; letter-spacing: 0.04em; }
+.stats dd { margin: 0.15rem 0 0; font-size: 1.05rem; }
+
+table.balance {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+table.balance th {
+  text-align: left;
+  font-weight: 500;
+  color: #444;
+  padding: 0.3rem 0.75rem 0.3rem 0;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+table.balance td {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.amount.negative { color: #b62325; }
 </style>

--- a/web/src/lib/dop/date.test.ts
+++ b/web/src/lib/dop/date.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import {
+  compareLocalDate,
+  epochDaysFromLocalDate,
+  localDateFromEpochDays,
+  localDateFromJSDate,
+  localDateToJSDate,
+  localDateToString,
+} from "./date.js";
+
+describe("localDateFromEpochDays", () => {
+  it("decodes the Unix epoch as 1970-01-01", () => {
+    expect(localDateFromEpochDays(0)).toEqual({ year: 1970, month: 1, day: 1 });
+  });
+
+  it("decodes negative epoch days as pre-1970 dates", () => {
+    expect(localDateFromEpochDays(-1)).toEqual({ year: 1969, month: 12, day: 31 });
+    // 1900-01-01: 70 years before 1970, with 17 leap years interspersed.
+    expect(localDateFromEpochDays(-25567)).toEqual({ year: 1900, month: 1, day: 1 });
+  });
+
+  it("matches a known date around the sample journal's window", () => {
+    // 2024-01-01: 54 years after epoch including 13 leap days.
+    // Cross-check against `Date.UTC` to avoid hand-computing.
+    const epochDaysOf2024Jan1 = Date.UTC(2024, 0, 1) / 86_400_000;
+    expect(localDateFromEpochDays(epochDaysOf2024Jan1)).toEqual({
+      year: 2024,
+      month: 1,
+      day: 1,
+    });
+  });
+
+  it("handles end-of-month and month-end transitions", () => {
+    expect(localDateFromEpochDays(Date.UTC(2024, 1, 29) / 86_400_000)).toEqual({
+      year: 2024,
+      month: 2,
+      day: 29,
+    }); // 2024 is a leap year
+    expect(localDateFromEpochDays(Date.UTC(2023, 1, 28) / 86_400_000)).toEqual({
+      year: 2023,
+      month: 2,
+      day: 28,
+    }); // 2023 is not
+  });
+});
+
+describe("epochDaysFromLocalDate (round-trip with localDateFromEpochDays)", () => {
+  it("round-trips zero and small offsets", () => {
+    for (const days of [0, 1, -1, 365, -365, 36500]) {
+      const ld = localDateFromEpochDays(days);
+      expect(epochDaysFromLocalDate(ld)).toBe(days);
+    }
+  });
+
+  it("round-trips a range spanning 200 years", () => {
+    // ~73,000 days; sample 5,000 of them deterministically.
+    for (let days = -25_000; days <= 50_000; days += 137) {
+      const ld = localDateFromEpochDays(days);
+      expect(epochDaysFromLocalDate(ld)).toBe(days);
+    }
+  });
+});
+
+describe("localDateToString", () => {
+  it("zero-pads month, day, and year", () => {
+    expect(localDateToString({ year: 2024, month: 1, day: 5 })).toBe("2024-01-05");
+    expect(localDateToString({ year: 7, month: 12, day: 31 })).toBe("0007-12-31");
+  });
+});
+
+describe("compareLocalDate", () => {
+  it("orders by year, then month, then day", () => {
+    const a = { year: 2024, month: 1, day: 1 };
+    const b = { year: 2024, month: 1, day: 2 };
+    const c = { year: 2024, month: 2, day: 1 };
+    const d = { year: 2025, month: 1, day: 1 };
+    expect(compareLocalDate(a, a)).toBe(0);
+    expect(compareLocalDate(a, b)).toBeLessThan(0);
+    expect(compareLocalDate(b, c)).toBeLessThan(0);
+    expect(compareLocalDate(c, d)).toBeLessThan(0);
+    expect(compareLocalDate(d, a)).toBeGreaterThan(0);
+  });
+});
+
+describe("localDateToJSDate / localDateFromJSDate", () => {
+  it("round-trips through a UTC-midnight Date", () => {
+    const original = { year: 2024, month: 5, day: 17 };
+    expect(localDateFromJSDate(localDateToJSDate(original))).toEqual(original);
+  });
+
+  it("anchors to UTC, not local time", () => {
+    const d = localDateToJSDate({ year: 2024, month: 1, day: 1 });
+    expect(d.getUTCFullYear()).toBe(2024);
+    expect(d.getUTCMonth()).toBe(0);
+    expect(d.getUTCDate()).toBe(1);
+    expect(d.getUTCHours()).toBe(0);
+  });
+});

--- a/web/src/lib/dop/date.ts
+++ b/web/src/lib/dop/date.ts
@@ -1,0 +1,106 @@
+// LocalDate is a calendar date with no time-of-day or timezone.
+//
+// We avoid `Date` for journal dates because `Date` carries an implicit
+// timezone offset, which means a single Date value renders differently
+// depending on the user's locale. Journal dates are inherently local
+// (they're written by humans on a calendar) and should round-trip
+// identically across machines.
+export interface LocalDate {
+  readonly year: number;
+  readonly month: number; // 1..12
+  readonly day: number; // 1..31
+}
+
+// Days from 0000-03-01 (Gregorian) to 1970-01-01.
+const DAYS_TO_UNIX_EPOCH = 719_468;
+// Days in each 400-year Gregorian cycle.
+const DAYS_PER_CYCLE = 146_097;
+
+/**
+ * Convert epoch-days (signed days since 1970-01-01, matching the wire
+ * format) to a LocalDate.
+ *
+ * The algorithm is Howard Hinnant's civil_from_days
+ * (https://howardhinnant.github.io/date_algorithms.html#civil_from_days),
+ * which handles negative inputs (pre-1970 dates) without special cases.
+ */
+export function localDateFromEpochDays(epochDays: number): LocalDate {
+  const z = epochDays + DAYS_TO_UNIX_EPOCH;
+  const era = Math.floor(z / DAYS_PER_CYCLE);
+  const dayOfEra = z - era * DAYS_PER_CYCLE; // [0, 146096]
+  const yearOfEra = Math.floor(
+    (dayOfEra - Math.floor(dayOfEra / 1460) + Math.floor(dayOfEra / 36524) - Math.floor(dayOfEra / 146096)) / 365,
+  ); // [0, 399]
+  const year0 = yearOfEra + era * 400;
+  const dayOfYear =
+    dayOfEra -
+    (365 * yearOfEra + Math.floor(yearOfEra / 4) - Math.floor(yearOfEra / 100)); // [0, 365]
+  const mp = Math.floor((5 * dayOfYear + 2) / 153); // [0, 11]
+  const day = dayOfYear - Math.floor((153 * mp + 2) / 5) + 1;
+  const month = mp < 10 ? mp + 3 : mp - 9;
+  const year = year0 + (month <= 2 ? 1 : 0);
+  return { year, month, day };
+}
+
+/**
+ * Inverse of `localDateFromEpochDays`. Useful when comparing journal
+ * dates against external inputs (e.g. a date picker) that come in as
+ * year/month/day triples.
+ */
+export function epochDaysFromLocalDate(d: LocalDate): number {
+  const y = d.year - (d.month <= 2 ? 1 : 0);
+  const era = Math.floor(y / 400);
+  const yearOfEra = y - era * 400;
+  const dayOfYear =
+    Math.floor((153 * (d.month > 2 ? d.month - 3 : d.month + 9) + 2) / 5) +
+    d.day -
+    1;
+  const dayOfEra =
+    yearOfEra * 365 +
+    Math.floor(yearOfEra / 4) -
+    Math.floor(yearOfEra / 100) +
+    dayOfYear;
+  return era * DAYS_PER_CYCLE + dayOfEra - DAYS_TO_UNIX_EPOCH;
+}
+
+/**
+ * Render a LocalDate as ISO 8601 (YYYY-MM-DD).
+ */
+export function localDateToString(d: LocalDate): string {
+  const yy = d.year.toString().padStart(4, "0");
+  const mm = d.month.toString().padStart(2, "0");
+  const dd = d.day.toString().padStart(2, "0");
+  return `${yy}-${mm}-${dd}`;
+}
+
+/**
+ * Compare two LocalDates lexicographically: returns negative, zero, or
+ * positive in line with `Array.prototype.sort` callbacks.
+ */
+export function compareLocalDate(a: LocalDate, b: LocalDate): number {
+  if (a.year !== b.year) return a.year - b.year;
+  if (a.month !== b.month) return a.month - b.month;
+  return a.day - b.day;
+}
+
+/**
+ * Convert a LocalDate to a `Date` at UTC midnight. The reverse
+ * conversion (`fromJSDate`) reads UTC components, so the round-trip
+ * is lossless. Convenient for handing dates to date-picker UIs that
+ * expect a `Date`.
+ */
+export function localDateToJSDate(d: LocalDate): Date {
+  return new Date(Date.UTC(d.year, d.month - 1, d.day));
+}
+
+/**
+ * Read a `Date`'s UTC year/month/day components into a LocalDate.
+ * Pairs with `localDateToJSDate` for round-tripping through UI inputs.
+ */
+export function localDateFromJSDate(d: Date): LocalDate {
+  return {
+    year: d.getUTCFullYear(),
+    month: d.getUTCMonth() + 1,
+    day: d.getUTCDate(),
+  };
+}

--- a/web/src/lib/dop/decimal.test.ts
+++ b/web/src/lib/dop/decimal.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import Decimal from "decimal.js";
+import { decimalFromWire } from "./decimal.js";
+
+// Helper to construct a wire Decimal as the loader sees it: mantissa is
+// already split into low (uint64, 0..2^64-1) and high (sint64, signed).
+// JS bigint literals are arbitrary-precision; we only require that the
+// shape match the Buf-generated type.
+function wire(low: bigint, high: bigint, scale: number) {
+  return { mantissaLow: low, mantissaHigh: high, scale } as never;
+}
+
+describe("decimalFromWire", () => {
+  it("decodes zero", () => {
+    expect(decimalFromWire(wire(0n, 0n, 0)).toString()).toBe("0");
+    expect(decimalFromWire(wire(0n, 0n, 2)).toString()).toBe("0");
+  });
+
+  it("decodes simple positive values at scale 0", () => {
+    expect(decimalFromWire(wire(1n, 0n, 0)).toString()).toBe("1");
+    expect(decimalFromWire(wire(110n, 0n, 0)).toString()).toBe("110");
+  });
+
+  it("decodes simple positive values at scale 2", () => {
+    // $1.10 — mantissa 110 with scale 2 means 110 * 10^-2 = 1.1
+    expect(decimalFromWire(wire(110n, 0n, 2)).equals(new Decimal("1.10"))).toBe(true);
+    // $1,825.00 from sample.ledger
+    expect(decimalFromWire(wire(182500n, 0n, 2)).equals(new Decimal("1825.00"))).toBe(true);
+  });
+
+  it("decodes negative values via sign-extended high half", () => {
+    // -1: mantissaHigh = -1 (all bits set), mantissaLow = max u64 (all bits
+    // set). Two's complement for -1 over 128 bits.
+    const allOnesU64 = (1n << 64n) - 1n;
+    expect(decimalFromWire(wire(allOnesU64, -1n, 0)).toString()).toBe("-1");
+    // -1.10 is mantissa -110 at scale 2. Two's complement of 110 in 128
+    // bits: low half = 2^64 - 110, high half = -1.
+    const low = (1n << 64n) - 110n;
+    expect(decimalFromWire(wire(low, -1n, 2)).equals(new Decimal("-1.10"))).toBe(true);
+  });
+
+  it("decodes large mantissas that exceed 64 bits", () => {
+    // Mantissa = 2^65 = 36893488147419103232; high = 2, low = 0.
+    expect(decimalFromWire(wire(0n, 2n, 0)).toString()).toBe("36893488147419103232");
+  });
+
+  it("masks low half defensively as unsigned", () => {
+    // If a malformed encoder wrote mantissaLow with the high bit set (top
+    // bit of the uint64) and mantissaHigh = 0, the result is 2^63, not -2^63.
+    expect(decimalFromWire(wire(1n << 63n, 0n, 0)).toString()).toBe("9223372036854775808");
+  });
+
+  it("respects the scale (10^-scale)", () => {
+    // 12345 with scale 4 -> 1.2345
+    expect(decimalFromWire(wire(12345n, 0n, 4)).equals(new Decimal("1.2345"))).toBe(true);
+  });
+});

--- a/web/src/lib/dop/decimal.ts
+++ b/web/src/lib/dop/decimal.ts
@@ -1,0 +1,22 @@
+import Decimal from "decimal.js";
+import type { Decimal as WireDecimal } from "../proto/generated/doppio_pb.js";
+
+const MASK_64 = (1n << 64n) - 1n;
+
+/**
+ * Reassemble a wire-shape Decimal (split 128-bit mantissa + scale) into
+ * a `decimal.js` Decimal. The `mantissaHigh` half carries sign; the
+ * `mantissaLow` half is masked defensively so that a uint64 wire value
+ * is treated as the lower 64 bits of two's complement, not as a signed
+ * value.
+ *
+ * See `proto/doppio.proto`'s top comment for the canonical algorithm and
+ * its language ports.
+ */
+export function decimalFromWire(p: WireDecimal): Decimal {
+  const mantissa = (p.mantissaHigh << 64n) | (p.mantissaLow & MASK_64);
+  // decimal.js parses the bigint string directly, then we apply the scale.
+  // (Decimal accepts a signed string, including "-" prefix, of arbitrary length.)
+  const d = new Decimal(mantissa.toString());
+  return p.scale === 0 ? d : d.div(new Decimal(10).pow(p.scale));
+}

--- a/web/src/lib/dop/errors.ts
+++ b/web/src/lib/dop/errors.ts
@@ -1,0 +1,23 @@
+export type DopErrorKind =
+  | "header-too-short"
+  | "magic-mismatch"
+  | "version-mismatch"
+  | "compression-unknown"
+  | "inflate-failed"
+  | "protobuf-decode-failed"
+  | "missing-required-field";
+
+/**
+ * A typed error produced by `readDop`. The `kind` discriminator lets
+ * callers branch on the failure mode (e.g. "ask user to recompile" for
+ * version-mismatch vs "the file is corrupt" for the inflate cases).
+ */
+export class DopError extends Error {
+  readonly kind: DopErrorKind;
+
+  constructor(kind: DopErrorKind, message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "DopError";
+    this.kind = kind;
+  }
+}

--- a/web/src/lib/dop/index.ts
+++ b/web/src/lib/dop/index.ts
@@ -1,15 +1,32 @@
-// Public surface of the JS-native .dop reader. Implementation lands in #151.
+// Public surface of the JS-native .dop reader.
 //
-// Intended shape (subject to refinement during #151):
-//   export function readDop(buf: Uint8Array): Journal;
+// Usage:
+//   import { readDop } from "@/lib/dop";
+//   const journal = readDop(new Uint8Array(await (await fetch("/sample.dop")).arrayBuffer()));
 //
-// where Journal is a TS-native projection of proto::Journal with:
-//   - Decimal values eagerly converted to decimal.js Decimal
-//   - Dates carried as { year, month, day } LocalDate triples
-//   - oneof fields normalised to discriminated unions
-//
-// The wire-shape types (proto::Journal etc.) are generated into ./generated/
-// at build time via `buf generate`. The decoder layer translates between the
-// wire shape and the public TS shape so views never depend on protobuf
-// internals.
-export {};
+// All decode errors throw `DopError` with a `kind` discriminator. See
+// `errors.ts` for the kinds.
+export { readDop } from "./loader.js";
+export { DopError } from "./errors.js";
+export type { DopErrorKind } from "./errors.js";
+export {
+  localDateFromEpochDays,
+  epochDaysFromLocalDate,
+  localDateToString,
+  compareLocalDate,
+  localDateToJSDate,
+  localDateFromJSDate,
+} from "./date.js";
+export type { LocalDate } from "./date.js";
+export type {
+  Journal,
+  Transaction,
+  Posting,
+  Amount,
+  Lot,
+  AccountProperties,
+  CommodityProperties,
+  HistoricalPrice,
+  PostingKind,
+  TransactionState,
+} from "./types.js";

--- a/web/src/lib/dop/loader.test.ts
+++ b/web/src/lib/dop/loader.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import Decimal from "decimal.js";
+import { readDop } from "./loader.js";
+import { DopError } from "./errors.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const samplePath = resolve(here, "../../../public/sample.dop");
+const sample = readFileSync(samplePath);
+const sampleBytes = new Uint8Array(sample.buffer, sample.byteOffset, sample.byteLength);
+
+describe("readDop on the committed sample.dop", () => {
+  const journal = readDop(sampleBytes);
+
+  it("decodes a non-empty journal", () => {
+    expect(journal.transactions.length).toBeGreaterThan(40);
+    expect(Object.keys(journal.accounts).length).toBeGreaterThanOrEqual(14);
+    expect(Object.keys(journal.commodities).length).toBeGreaterThanOrEqual(2);
+    expect(journal.prices.length).toBe(6);
+  });
+
+  it("preserves transaction order and dates", () => {
+    expect(journal.transactions[0]!.date).toEqual({ year: 2024, month: 1, day: 1 });
+    const last = journal.transactions[journal.transactions.length - 1]!;
+    expect(last.date).toEqual({ year: 2024, month: 6, day: 30 });
+  });
+
+  it("matches the journal's mid-year balance assertion on Checking", () => {
+    // sample.ledger asserts Assets:Bank:Checking == $10,318.88 at 2024-06-30.
+    // We sum every checking posting in USD ourselves to verify the loader
+    // produces the same total the assertion baked in.
+    let total = new Decimal(0);
+    for (const t of journal.transactions) {
+      for (const p of t.postings) {
+        if (p.account === "Assets:Bank:Checking") {
+          const usd = p.amount.byCommodity["$"];
+          if (usd) total = total.plus(usd);
+        }
+      }
+    }
+    expect(total.equals(new Decimal("10318.88"))).toBe(true);
+  });
+
+  it("decodes a lot annotation on the AAPL opening posting", () => {
+    const opening = journal.transactions.find(
+      (t) => t.description === "Opening AAPL position",
+    );
+    expect(opening).toBeDefined();
+    const lotPosting = opening!.postings.find((p) => p.account === "Assets:Brokerage");
+    expect(lotPosting).toBeDefined();
+    expect(lotPosting!.lot).toBeDefined();
+    expect(lotPosting!.lot!.date).toEqual({ year: 2023, month: 8, day: 1 });
+    const cost = lotPosting!.lot!.cost!.byCommodity["$"]!;
+    expect(cost.equals(new Decimal("150"))).toBe(true);
+  });
+
+  it("decodes historical price entries for FX", () => {
+    const eurPrices = journal.prices.filter(
+      (p) => p.commodity === "EUR" && p.priceCommodity === "$",
+    );
+    expect(eurPrices.length).toBe(3);
+    // First EUR quote is 2024-01-02 at $1.09.
+    const first = eurPrices[0]!;
+    expect(first.date).toEqual({ year: 2024, month: 1, day: 2 });
+    expect(first.price.equals(new Decimal("1.09"))).toBe(true);
+  });
+
+  it("preserves cleared/pending state on transactions", () => {
+    const cleared = journal.transactions.filter((t) => t.state === "cleared");
+    expect(cleared.length).toBeGreaterThan(40);
+  });
+});
+
+describe("readDop error paths", () => {
+  it("rejects buffers shorter than the 8-byte header", () => {
+    expect(() => readDop(new Uint8Array(3))).toThrow(DopError);
+    try {
+      readDop(new Uint8Array(3));
+    } catch (e) {
+      expect((e as DopError).kind).toBe("header-too-short");
+    }
+  });
+
+  it("rejects bad magic bytes", () => {
+    const buf = new Uint8Array(16);
+    // Magic left as zeros; will fail.
+    try {
+      readDop(buf);
+    } catch (e) {
+      expect((e as DopError).kind).toBe("magic-mismatch");
+    }
+  });
+
+  it("rejects unsupported version numbers", () => {
+    const buf = new Uint8Array(sampleBytes);
+    buf[4] = 99;
+    buf[5] = 0;
+    try {
+      readDop(buf);
+    } catch (e) {
+      expect((e as DopError).kind).toBe("version-mismatch");
+    }
+  });
+
+  it("rejects unknown compression bytes", () => {
+    const buf = new Uint8Array(sampleBytes);
+    buf[6] = 7; // not a known compression method
+    try {
+      readDop(buf);
+    } catch (e) {
+      expect((e as DopError).kind).toBe("compression-unknown");
+    }
+  });
+
+  it("surfaces inflate failures with kind=inflate-failed", () => {
+    // Keep the header valid (so we get past version + compression checks)
+    // but corrupt the body so deflate fails to decode it.
+    const buf = new Uint8Array(sampleBytes);
+    // Stomp every byte after the header with 0xFF — guaranteed-invalid
+    // raw deflate stream.
+    for (let i = 8; i < buf.length; i++) buf[i] = 0xff;
+    try {
+      readDop(buf);
+    } catch (e) {
+      expect((e as DopError).kind).toBe("inflate-failed");
+    }
+  });
+});

--- a/web/src/lib/dop/loader.ts
+++ b/web/src/lib/dop/loader.ts
@@ -1,0 +1,207 @@
+import { fromBinary } from "@bufbuild/protobuf";
+import { inflateRaw } from "pako";
+import {
+  JournalSchema,
+  PostingKind as WirePostingKind,
+  TransactionState as WireTransactionState,
+  type Amount as WireAmount,
+  type Journal as WireJournal,
+  type Lot as WireLot,
+  type Posting as WirePosting,
+  type Transaction as WireTransaction,
+  type HistoricalPrice as WireHistoricalPrice,
+} from "../proto/generated/doppio_pb.js";
+import { decimalFromWire } from "./decimal.js";
+import { localDateFromEpochDays } from "./date.js";
+import { DopError } from "./errors.js";
+import type {
+  Amount,
+  Journal,
+  Lot,
+  Posting,
+  Transaction,
+  TransactionState,
+  PostingKind,
+  HistoricalPrice,
+} from "./types.js";
+
+// 8-byte header layout, matching `dop_write_header` in the Rust crate:
+//   bytes 0..4  — magic "DOP\0"
+//   bytes 4..6  — format version, little-endian u16
+//   byte  6     — compression method (0 = none, 1 = deflate)
+//   byte  7     — reserved
+const MAGIC = Uint8Array.of(0x44, 0x4f, 0x50, 0x00); // "DOP\0"
+const SUPPORTED_VERSION = 3;
+const HEADER_LEN = 8;
+
+/**
+ * Decode a `.dop` artifact into the public-shape `Journal`.
+ *
+ * The flow is fixed by the file format:
+ *   1. parse and validate the 8-byte header,
+ *   2. inflate the body if the header declares deflate,
+ *   3. decode the body as `proto::Journal` via Buf,
+ *   4. walk the wire shape into the public TS shape (Decimal/LocalDate
+ *      substituted; everything else passthrough).
+ *
+ * Errors thrown are always `DopError` with a `kind` discriminator so the
+ * UI can branch on header/version/inflate/protobuf failure modes
+ * separately.
+ */
+export function readDop(buf: Uint8Array): Journal {
+  if (buf.length < HEADER_LEN) {
+    throw new DopError(
+      "header-too-short",
+      `not a .dop file: input is only ${buf.length} bytes (header alone is ${HEADER_LEN})`,
+    );
+  }
+
+  for (let i = 0; i < MAGIC.length; i++) {
+    if (buf[i] !== MAGIC[i]) {
+      throw new DopError(
+        "magic-mismatch",
+        "not a .dop file: magic bytes do not match \"DOP\\0\"",
+      );
+    }
+  }
+
+  const version = buf[4]! | (buf[5]! << 8); // little-endian u16
+  if (version !== SUPPORTED_VERSION) {
+    throw new DopError(
+      "version-mismatch",
+      `incompatible .dop format version ${version} (this build supports version ${SUPPORTED_VERSION}); recompile from source with \`dop compile\``,
+    );
+  }
+
+  const compression = buf[6]!;
+  // byte 7 is reserved; ignored on read.
+
+  const compressed = buf.subarray(HEADER_LEN);
+  let body: Uint8Array;
+  if (compression === 0) {
+    body = compressed;
+  } else if (compression === 1) {
+    try {
+      body = inflateRaw(compressed);
+    } catch (cause) {
+      throw new DopError("inflate-failed", "deflate decompression failed", { cause });
+    }
+  } else {
+    throw new DopError(
+      "compression-unknown",
+      `unknown compression byte ${compression} in .dop header`,
+    );
+  }
+
+  let wire: WireJournal;
+  try {
+    wire = fromBinary(JournalSchema, body);
+  } catch (cause) {
+    throw new DopError("protobuf-decode-failed", "protobuf body failed to decode", { cause });
+  }
+
+  return convertJournal(wire);
+}
+
+function convertJournal(j: WireJournal): Journal {
+  return {
+    transactions: j.transactions.map(convertTransaction),
+    accounts: { ...j.accounts },
+    commodities: Object.fromEntries(
+      Object.entries(j.commodities).map(([name, c]) => [
+        name,
+        { format: c.format, noMarket: c.noMarket, note: c.note },
+      ]),
+    ),
+    prices: j.prices.map(convertHistoricalPrice),
+  };
+}
+
+function convertTransaction(t: WireTransaction): Transaction {
+  return {
+    date: localDateFromEpochDays(t.date),
+    secondaryDate:
+      t.secondaryDate !== undefined ? localDateFromEpochDays(t.secondaryDate) : undefined,
+    state: convertTransactionState(t.state),
+    code: t.code,
+    description: t.description,
+    tags: [...t.tags],
+    metadata: { ...t.metadata },
+    postings: t.postings.map(convertPosting),
+  };
+}
+
+function convertPosting(p: WirePosting): Posting {
+  if (!p.amount) {
+    throw new DopError(
+      "missing-required-field",
+      `posting on account "${p.account}" is missing its amount`,
+    );
+  }
+  return {
+    account: p.account,
+    payee: p.payee,
+    amount: convertAmount(p.amount),
+    state: convertTransactionState(p.state),
+    tags: [...p.tags],
+    metadata: { ...p.metadata },
+    kind: convertPostingKind(p.kind),
+    lot: p.lot ? convertLot(p.lot) : undefined,
+  };
+}
+
+function convertAmount(a: WireAmount): Amount {
+  const byCommodity: Record<string, import("decimal.js").default> = {};
+  for (const [commodity, decimal] of Object.entries(a.byCommodity)) {
+    byCommodity[commodity] = decimalFromWire(decimal);
+  }
+  return { byCommodity };
+}
+
+function convertLot(l: WireLot): Lot {
+  return {
+    cost: l.cost ? convertAmount(l.cost) : undefined,
+    date: l.date !== undefined ? localDateFromEpochDays(l.date) : undefined,
+    note: l.note,
+  };
+}
+
+function convertHistoricalPrice(p: WireHistoricalPrice): HistoricalPrice {
+  if (!p.price) {
+    throw new DopError(
+      "missing-required-field",
+      `historical price for ${p.commodity} -> ${p.priceCommodity} is missing its price`,
+    );
+  }
+  return {
+    date: localDateFromEpochDays(p.date),
+    time: p.time,
+    commodity: p.commodity,
+    price: decimalFromWire(p.price),
+    priceCommodity: p.priceCommodity,
+  };
+}
+
+function convertTransactionState(s: WireTransactionState): TransactionState {
+  switch (s) {
+    case WireTransactionState.PENDING:
+      return "pending";
+    case WireTransactionState.CLEARED:
+      return "cleared";
+    // UNSPECIFIED is treated as UNCLEARED by all consumers (matches Rust).
+    default:
+      return "uncleared";
+  }
+}
+
+function convertPostingKind(k: WirePostingKind): PostingKind {
+  switch (k) {
+    case WirePostingKind.VIRTUAL_UNBALANCED:
+      return "virtualUnbalanced";
+    case WirePostingKind.VIRTUAL_BALANCED:
+      return "virtualBalanced";
+    // UNSPECIFIED defaults to REAL per the schema's evolution rule.
+    default:
+      return "real";
+  }
+}

--- a/web/src/lib/dop/types.ts
+++ b/web/src/lib/dop/types.ts
@@ -1,0 +1,76 @@
+// Public TS shape of an elaborated journal. Mirrors the Rust
+// `doppio::elaboration::Journal` structure, with the only substitutions:
+//   - protobuf Decimal     → decimal.js Decimal
+//   - epoch-days sint32    → LocalDate
+//   - protobuf maps        → Record<string, T>  (already what Buf emits)
+// Field names follow camelCase per TypeScript convention; the wire is
+// lower_snake_case but Buf's TS plugin already converts it for us.
+//
+// All structural decisions and naming follow `proto/doppio.proto`. Any
+// field-level documentation lives there; this file intentionally keeps
+// types lean so the schema's comment block stays the single source of
+// truth.
+
+import type Decimal from "decimal.js";
+import type { LocalDate } from "./date.js";
+
+export type TransactionState = "uncleared" | "pending" | "cleared";
+
+export type PostingKind = "real" | "virtualUnbalanced" | "virtualBalanced";
+
+export interface Amount {
+  byCommodity: Record<string, Decimal>;
+}
+
+export interface Lot {
+  cost?: Amount;
+  date?: LocalDate;
+  note?: string;
+}
+
+export interface Posting {
+  account: string;
+  payee: string;
+  amount: Amount;
+  state: TransactionState;
+  tags: string[];
+  metadata: Record<string, string>;
+  kind: PostingKind;
+  lot?: Lot;
+}
+
+export interface Transaction {
+  date: LocalDate;
+  secondaryDate?: LocalDate;
+  state: TransactionState;
+  code?: string;
+  description: string;
+  tags: string[];
+  metadata: Record<string, string>;
+  postings: Posting[];
+}
+
+export interface AccountProperties {
+  note?: string;
+}
+
+export interface CommodityProperties {
+  format?: string;
+  noMarket: boolean;
+  note?: string;
+}
+
+export interface HistoricalPrice {
+  date: LocalDate;
+  time?: string;
+  commodity: string;
+  price: Decimal;
+  priceCommodity: string;
+}
+
+export interface Journal {
+  transactions: Transaction[];
+  accounts: Record<string, AccountProperties>;
+  commodities: Record<string, CommodityProperties>;
+  prices: HistoricalPrice[];
+}

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -19,7 +19,9 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]
-    }
+    },
+    "types": ["vite/client"]
   },
-  "include": ["src/**/*.ts", "src/**/*.vue", "src/**/*.tsx"]
+  "include": ["src/**/*.ts", "src/**/*.vue", "src/**/*.tsx"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
+import { fileURLToPath, URL } from "node:url";
 
 // gh-pages serves this app from https://alevy.github.io/doppio/.
 // Local dev (npm run dev) uses base "/" automatically.
 export default defineConfig(({ command }) => ({
   plugins: [vue()],
   base: command === "build" ? "/doppio/" : "/",
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
 }));

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary

Implements `readDop(buf): Journal` — the JS-native loader that proves doppio's format-as-API claim end-to-end. Reads the 8-byte header, inflates the deflate-compressed body, decodes via `@bufbuild/protobuf`, and returns a public-shape Journal mirroring the Rust `elaboration::Journal` with TS-native substitutions (`decimal.js` for Decimal, `LocalDate {year, month, day}` for dates). No Rust or WASM at runtime.

Closes #151.

## Decisions baked in (from the design discussion)

- **Single-pass conversion.** Walks Buf's wire-shape result directly into the public shape — no intermediate TS type tree. Files are organised by concern (`decimal.ts`, `date.ts`, `errors.ts`, `types.ts`, `loader.ts`) for testability, but only one function (`readDop`) is the entry point.
- **Public types mirror Rust 1:1**, with the only swaps being `Decimal` and `LocalDate`. Field names follow camelCase (Buf default); maps stay as `Record<string, T>` (Buf default for proto3 maps).
- **`LocalDate` is a tiny opaque type**, not `Date`. Conversion helpers (`toJSDate`/`fromJSDate`) bridge to date pickers when needed.
- **Errors are typed.** `DopError` carries a `kind` discriminator (`header-too-short` | `magic-mismatch` | `version-mismatch` | `compression-unknown` | `inflate-failed` | `protobuf-decode-failed` | `missing-required-field`) so the UI can branch on failure mode.

## What's wired up

- `web/src/lib/dop/` — public surface; re-exports from `index.ts`
- `web/src/App.vue` — fetches `/sample.dop` on mount, renders journal stats + a multi-commodity balance table (replaces the placeholder card from #148)
- 28 vitest specs covering:
  - Decimal reassembly (zero, positive at scale 0/2, negative via two's-complement, large >64-bit mantissas, defensive masking of the unsigned low half, scale handling)
  - Epoch-days ↔ LocalDate (including pre-1970 negatives, leap-year boundaries, ~550 round-trips spanning 200 years)
  - Full round-trip on `public/sample.dop`: transaction/account/commodity/price counts, transaction order, the journal's mid-year balance assertion (sums Assets:Bank:Checking USD across every posting → equals \$10,318.88), lot annotation on the AAPL opening posting, FX price decode, cleared-state tracking
  - Every error path: short buffers, bad magic, wrong version, unknown compression byte, corrupted deflate body
- `web.yml` workflow now runs `npm test` before the build

## Test plan

- [x] `npm test` — 28 passed
- [x] `npm run build` — type-check + Vite build green; bundle 190 KB / 65 KB gzipped (decimal.js + pako + protobuf-es runtime + generated stubs + Vue + Pinia)
- [x] `cargo test --workspace` (no Rust changes; sanity)
- [ ] Visual confirmation on the deployed Pages URL after merge

## Bundle size note

Bundle grew from 62 KB → 190 KB ungzipped (25 → 65 KB gzipped) since the bootstrap. The growth is decimal.js (~37 KB), pako (~30 KB), and the protobuf-es runtime + generated stubs. No code-splitting yet; the loader and the views (when #150 lands) all live in the same bundle. We can revisit if the post-#150 number gets uncomfortable.

## Follow-ups

- #150 — balance / register / chart Vue views (the loader hands them a typed Journal)
- #149 — drag-and-drop WASM source-parser shim (post-1.0)