### PR TITLE
feat(web): balance, register, and chart views (closes #150)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.0",
         "chart.js": "^4.4.0",
+        "chartjs-adapter-date-fns": "^3.0.0",
+        "date-fns": "^4.1.0",
         "decimal.js": "^10.4.3",
         "pako": "^2.1.0",
         "pinia": "^2.2.0",
@@ -1488,6 +1490,16 @@
         "pnpm": ">=8"
       }
     },
+    "node_modules/chartjs-adapter-date-fns": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chartjs-adapter-date-fns/-/chartjs-adapter-date-fns-3.0.0.tgz",
+      "integrity": "sha512-Rs3iEB3Q5pJ973J93OBTpnP7qoGwvq3nUnoMdtxO+9aoJof7UFcRbWcIDteXuYd1fgAvct/32T9qaLyLuZVwCg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": ">=2.8.0",
+        "date-fns": ">=2.0.0"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -1503,6 +1515,16 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/de-indent": {
       "version": "1.0.2",

--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,8 @@
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.0",
     "chart.js": "^4.4.0",
+    "chartjs-adapter-date-fns": "^3.0.0",
+    "date-fns": "^4.1.0",
     "decimal.js": "^10.4.3",
     "pako": "^2.1.0",
     "pinia": "^2.2.0",

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,105 +1,37 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from "vue";
-import Decimal from "decimal.js";
-import {
-  readDop,
-  localDateToString,
-  type Journal,
-  type LocalDate,
-  DopError,
-} from "@/lib/dop";
+import { storeToRefs } from "pinia";
+import { useJournalStore } from "@/store/journal";
+import FilterBar from "@/components/FilterBar.vue";
+import BalanceView from "@/components/BalanceView.vue";
+import RegisterView from "@/components/RegisterView.vue";
+import ChartView from "@/components/ChartView.vue";
+import { localDateToString } from "@/lib/dop";
 
-const journal = ref<Journal | null>(null);
-const error = ref<string | null>(null);
+const journals = useJournalStore();
+const { journal, error, loading } = storeToRefs(journals);
 
-interface BalanceLine {
-  account: string;
-  byCommodity: { commodity: string; total: Decimal }[];
-}
+type Tab = "balance" | "register" | "chart";
+const activeTab = ref<Tab>("balance");
 
 const summary = computed(() => {
-  if (!journal.value) return null;
   const j = journal.value;
+  if (!j) return null;
   const dates = j.transactions.map((t) => t.date);
+  const first = dates[0];
+  const last = dates[dates.length - 1];
   return {
     transactions: j.transactions.length,
     accounts: Object.keys(j.accounts).length,
     commodities: Object.keys(j.commodities).length,
     prices: j.prices.length,
-    firstDate: dates.length ? minDate(dates) : null,
-    lastDate: dates.length ? maxDate(dates) : null,
+    range: first && last ? `${localDateToString(first)} → ${localDateToString(last)}` : null,
   };
 });
 
-const balanceByAccount = computed<BalanceLine[]>(() => {
-  if (!journal.value) return [];
-  const totals: Record<string, Map<string, Decimal>> = {};
-  for (const t of journal.value.transactions) {
-    for (const p of t.postings) {
-      if (p.kind === "virtualUnbalanced") continue;
-      const row = (totals[p.account] ??= new Map());
-      for (const [c, v] of Object.entries(p.amount.byCommodity)) {
-        row.set(c, (row.get(c) ?? new Decimal(0)).plus(v));
-      }
-    }
-  }
-  return Object.keys(totals)
-    .sort()
-    .map((account) => ({
-      account,
-      byCommodity: [...totals[account]!.entries()]
-        .filter(([_, v]) => !v.isZero())
-        .sort(([a], [b]) => a.localeCompare(b))
-        .map(([commodity, total]) => ({ commodity, total })),
-    }))
-    .filter((line) => line.byCommodity.length > 0);
-});
-
-function minDate(ds: LocalDate[]): LocalDate {
-  return ds.reduce((a, b) =>
-    a.year < b.year ||
-    (a.year === b.year && a.month < b.month) ||
-    (a.year === b.year && a.month === b.month && a.day < b.day)
-      ? a
-      : b,
-  );
-}
-
-function maxDate(ds: LocalDate[]): LocalDate {
-  return ds.reduce((a, b) =>
-    a.year > b.year ||
-    (a.year === b.year && a.month > b.month) ||
-    (a.year === b.year && a.month === b.month && a.day > b.day)
-      ? a
-      : b,
-  );
-}
-
-function formatAmount(commodity: string, value: Decimal): string {
-  const sign = value.isNegative() ? "-" : "";
-  const abs = value.abs().toFixed(2);
-  if (commodity === "$") return `${sign}$${abs}`;
-  return `${sign}${abs} ${commodity}`;
-}
-
-onMounted(async () => {
-  try {
-    const url = `${import.meta.env.BASE_URL}sample.dop`;
-    const res = await fetch(url);
-    if (!res.ok) {
-      throw new Error(`fetch ${url} → HTTP ${res.status}`);
-    }
-    const buf = new Uint8Array(await res.arrayBuffer());
-    journal.value = readDop(buf);
-  } catch (e) {
-    if (e instanceof DopError) {
-      error.value = `[${e.kind}] ${e.message}`;
-    } else if (e instanceof Error) {
-      error.value = e.message;
-    } else {
-      error.value = String(e);
-    }
-  }
+onMounted(() => {
+  const url = `${import.meta.env.BASE_URL}sample.dop`;
+  journals.loadFromUrl(url);
 });
 </script>
 
@@ -121,48 +53,55 @@ onMounted(async () => {
       <pre>{{ error }}</pre>
     </section>
 
-    <section v-else-if="!journal" class="card">
+    <section v-else-if="loading || !journal" class="card">
       <h2>Loading…</h2>
     </section>
 
     <template v-else>
-      <section class="card">
-        <h2>Journal summary</h2>
-        <dl class="stats">
-          <div><dt>Transactions</dt><dd>{{ summary!.transactions }}</dd></div>
-          <div><dt>Accounts</dt><dd>{{ summary!.accounts }}</dd></div>
-          <div><dt>Commodities</dt><dd>{{ summary!.commodities }}</dd></div>
-          <div><dt>Price quotes</dt><dd>{{ summary!.prices }}</dd></div>
-          <div>
-            <dt>Date range</dt>
-            <dd>
-              {{ localDateToString(summary!.firstDate!) }} →
-              {{ localDateToString(summary!.lastDate!) }}
-            </dd>
-          </div>
-        </dl>
+      <section class="card summary-bar">
+        <span><strong>{{ summary!.transactions }}</strong> transactions</span>
+        <span><strong>{{ summary!.accounts }}</strong> accounts</span>
+        <span><strong>{{ summary!.commodities }}</strong> commodities</span>
+        <span><strong>{{ summary!.prices }}</strong> prices</span>
+        <span class="range" v-if="summary!.range">{{ summary!.range }}</span>
       </section>
 
-      <section class="card">
-        <h2>Balance</h2>
-        <table class="balance">
-          <tbody>
-            <tr v-for="line in balanceByAccount" :key="line.account">
-              <th scope="row">{{ line.account }}</th>
-              <td>
-                <span
-                  v-for="({ commodity, total }, idx) in line.byCommodity"
-                  :key="commodity"
-                  class="amount"
-                  :class="{ negative: total.isNegative() }"
-                >
-                  <template v-if="idx > 0">, </template>
-                  {{ formatAmount(commodity, total) }}
-                </span>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+      <FilterBar :show-depth="activeTab === 'balance'" />
+
+      <nav class="tabs" role="tablist">
+        <button
+          type="button"
+          role="tab"
+          :aria-selected="activeTab === 'balance'"
+          :class="{ active: activeTab === 'balance' }"
+          @click="activeTab = 'balance'"
+        >
+          Balance
+        </button>
+        <button
+          type="button"
+          role="tab"
+          :aria-selected="activeTab === 'register'"
+          :class="{ active: activeTab === 'register' }"
+          @click="activeTab = 'register'"
+        >
+          Register
+        </button>
+        <button
+          type="button"
+          role="tab"
+          :aria-selected="activeTab === 'chart'"
+          :class="{ active: activeTab === 'chart' }"
+          @click="activeTab = 'chart'"
+        >
+          Chart
+        </button>
+      </nav>
+
+      <section class="card pane">
+        <BalanceView v-if="activeTab === 'balance'" />
+        <RegisterView v-else-if="activeTab === 'register'" />
+        <ChartView v-else-if="activeTab === 'chart'" />
       </section>
     </template>
   </main>
@@ -188,15 +127,15 @@ onMounted(async () => {
 
 <style scoped>
 .hero {
-  padding: 2.5rem 1.5rem 1.5rem;
+  padding: 2rem 1.5rem 1rem;
   text-align: center;
   border-bottom: 1px solid #e5e5e5;
   background: #fff;
 }
 
 .hero h1 {
-  margin: 0 0 0.5rem;
-  font-size: 2.4rem;
+  margin: 0 0 0.4rem;
+  font-size: 2.2rem;
   letter-spacing: -0.02em;
 }
 
@@ -210,63 +149,85 @@ onMounted(async () => {
   flex: 1;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 1.25rem;
-  padding: 2rem 1.5rem;
+  align-items: stretch;
+  max-width: 64rem;
+  width: 100%;
+  margin: 0 auto;
+  padding: 1.25rem 1.5rem;
 }
 
 .card {
-  width: 100%;
-  max-width: 44rem;
   background: #fff;
   border: 1px solid #e5e5e5;
   border-radius: 0.5rem;
-  padding: 1.25rem 1.5rem;
+  padding: 1rem 1.25rem;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  margin-bottom: 0;
 }
 
-.card h2 {
-  margin: 0 0 0.75rem;
-  font-size: 1.05rem;
-  color: #333;
-}
-
-.error {
+.card.error {
   border-color: #c44;
   color: #722;
+  margin-bottom: 1rem;
 }
 
-.stats {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
-  gap: 0.75rem 1.5rem;
-  margin: 0;
+.summary-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.5rem;
+  align-items: baseline;
+  font-size: 0.9rem;
+  color: #555;
+  margin-bottom: 1rem;
 }
 
-.stats div { display: flex; flex-direction: column; }
-.stats dt { font-size: 0.78rem; color: #777; text-transform: uppercase; letter-spacing: 0.04em; }
-.stats dd { margin: 0.15rem 0 0; font-size: 1.05rem; }
-
-table.balance {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.95rem;
-}
-
-table.balance th {
-  text-align: left;
-  font-weight: 500;
-  color: #444;
-  padding: 0.3rem 0.75rem 0.3rem 0;
-  border-bottom: 1px solid #f0f0f0;
-}
-
-table.balance td {
-  text-align: right;
+.summary-bar .range {
+  color: #888;
+  margin-left: auto;
   font-variant-numeric: tabular-nums;
-  padding: 0.3rem 0;
-  border-bottom: 1px solid #f0f0f0;
 }
 
-.amount.negative { color: #b62325; }
+.tabs {
+  display: flex;
+  gap: 0.25rem;
+  margin: 0 0 -1px;
+}
+
+.tabs button {
+  padding: 0.5rem 1rem;
+  border: 1px solid #e5e5e5;
+  border-bottom: 1px solid transparent;
+  border-top-left-radius: 0.4rem;
+  border-top-right-radius: 0.4rem;
+  background: #f4f4f4;
+  cursor: pointer;
+  font: inherit;
+  color: #555;
+}
+
+.tabs button.active {
+  background: #fff;
+  color: #1769aa;
+  font-weight: 500;
+  border-bottom-color: #fff;
+}
+
+.tabs button:hover:not(.active) {
+  background: #ececec;
+}
+
+.pane {
+  border-top-left-radius: 0;
+  padding: 1.25rem;
+  min-height: 16rem;
+}
+
+.footer {
+  border-top: 1px solid #e5e5e5;
+  padding: 1rem 1.5rem;
+  text-align: center;
+  color: #666;
+  font-size: 0.9rem;
+  background: #fff;
+}
 </style>

--- a/web/src/components/BalanceView.vue
+++ b/web/src/components/BalanceView.vue
@@ -8,7 +8,7 @@ import { formatAmount } from "@/lib/format";
 
 const journals = useJournalStore();
 const filters = useFiltersStore();
-const { pattern, clearedOnly, begin, end, depth } = storeToRefs(filters);
+const { pattern, clearedOnly, begin, end, depth, naturalSigns } = storeToRefs(filters);
 
 const tree = computed<BalanceNode[]>(() => {
   const j = journals.journal;
@@ -22,6 +22,7 @@ const tree = computed<BalanceNode[]>(() => {
       end: end.value,
     },
     depth.value,
+    naturalSigns.value,
   );
 });
 

--- a/web/src/components/BalanceView.vue
+++ b/web/src/components/BalanceView.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { storeToRefs } from "pinia";
+import { useJournalStore } from "@/store/journal";
+import { useFiltersStore } from "@/store/filters";
+import { buildBalanceTree, type BalanceNode } from "@/lib/views/balance";
+import { formatAmount } from "@/lib/format";
+
+const journals = useJournalStore();
+const filters = useFiltersStore();
+const { pattern, clearedOnly, begin, end, depth } = storeToRefs(filters);
+
+const tree = computed<BalanceNode[]>(() => {
+  const j = journals.journal;
+  if (!j) return [];
+  return buildBalanceTree(
+    j,
+    {
+      pattern: pattern.value,
+      clearedOnly: clearedOnly.value,
+      begin: begin.value,
+      end: end.value,
+    },
+    depth.value,
+  );
+});
+
+function flatten(nodes: BalanceNode[]): BalanceNode[] {
+  const out: BalanceNode[] = [];
+  function walk(ns: BalanceNode[]) {
+    for (const n of ns) {
+      out.push(n);
+      walk(n.children);
+    }
+  }
+  walk(nodes);
+  return out;
+}
+
+const rows = computed(() => flatten(tree.value));
+</script>
+
+<template>
+  <div v-if="rows.length === 0" class="empty">
+    No matching accounts.
+  </div>
+  <table v-else class="balance">
+    <tbody>
+      <tr v-for="node in rows" :key="node.fullName">
+        <th
+          scope="row"
+          :style="{ paddingLeft: `${(node.depth - 1) * 1.25}rem` }"
+          :class="{ 'has-children': node.children.length > 0 }"
+        >
+          {{ node.segment }}
+        </th>
+        <td>
+          <span
+            v-for="([commodity, total], idx) in Object.entries(node.rollupTotals.byCommodity).sort(([a], [b]) => a.localeCompare(b))"
+            :key="commodity"
+            class="amount"
+            :class="{ negative: total.isNegative() }"
+          >
+            <template v-if="idx > 0">, </template>{{ formatAmount(commodity, total) }}
+          </span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<style scoped>
+table.balance {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+th {
+  text-align: left;
+  font-weight: 500;
+  color: #444;
+  padding: 0.3rem 0.75rem 0.3rem 0;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+th.has-children {
+  font-weight: 600;
+  color: #222;
+}
+
+td {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.amount.negative {
+  color: #b62325;
+}
+
+.empty {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: #888;
+}
+</style>

--- a/web/src/components/ChartView.vue
+++ b/web/src/components/ChartView.vue
@@ -36,7 +36,7 @@ ChartJS.register(
 
 const journals = useJournalStore();
 const filters = useFiltersStore();
-const { begin, end } = storeToRefs(filters);
+const { begin, end, naturalSigns } = storeToRefs(filters);
 
 const pairs = computed(() => {
   const j = journals.journal;
@@ -68,6 +68,7 @@ const series = computed(() => {
     selected.value.commodity,
     begin.value,
     end.value,
+    naturalSigns.value,
   );
 });
 

--- a/web/src/components/ChartView.vue
+++ b/web/src/components/ChartView.vue
@@ -1,0 +1,225 @@
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import { storeToRefs } from "pinia";
+import { Line } from "vue-chartjs";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+  Filler,
+  TimeScale,
+} from "chart.js";
+import "chartjs-adapter-date-fns";
+import Decimal from "decimal.js";
+import { useJournalStore } from "@/store/journal";
+import { useFiltersStore } from "@/store/filters";
+import { accountCommodityPairs, buildAccountSeries } from "@/lib/views/chart";
+import { localDateToJSDate, localDateToString } from "@/lib/dop";
+import { formatAmount } from "@/lib/format";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+  Filler,
+  TimeScale,
+);
+
+const journals = useJournalStore();
+const filters = useFiltersStore();
+const { begin, end } = storeToRefs(filters);
+
+const pairs = computed(() => {
+  const j = journals.journal;
+  return j ? accountCommodityPairs(j) : [];
+});
+
+// Index into pairs.value. Avoids encoding (account, commodity) into a
+// single string key — accounts contain `:` and commodities are arbitrary.
+const selectedIdx = ref<number>(0);
+
+watch(
+  pairs,
+  (ps) => {
+    const preferredAt = ps.findIndex(
+      (p) => p.account === "Assets:Bank:Checking" && p.commodity === "$",
+    );
+    selectedIdx.value = preferredAt >= 0 ? preferredAt : 0;
+  },
+  { immediate: true },
+);
+
+const selected = computed(() => pairs.value[selectedIdx.value] ?? null);
+
+const series = computed(() => {
+  if (!journals.journal || !selected.value) return [];
+  return buildAccountSeries(
+    journals.journal,
+    selected.value.account,
+    selected.value.commodity,
+    begin.value,
+    end.value,
+  );
+});
+
+const chartData = computed(() => ({
+  labels: series.value.map((p) => localDateToJSDate(p.date)),
+  datasets: [
+    {
+      label: selected.value
+        ? `${selected.value.account} (${selected.value.commodity})`
+        : "",
+      data: series.value.map((p) => p.value.toNumber()),
+      fill: true,
+      borderColor: "#1769aa",
+      backgroundColor: "rgba(23, 105, 170, 0.12)",
+      tension: 0.15,
+      pointRadius: 2,
+      pointHoverRadius: 5,
+    },
+  ],
+}));
+
+const chartOptions = computed(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  interaction: { mode: "index" as const, intersect: false },
+  scales: {
+    x: {
+      type: "time" as const,
+      time: { unit: "month" as const },
+      grid: { color: "#f0f0f0" },
+    },
+    y: {
+      grid: { color: "#f0f0f0" },
+      ticks: {
+        callback: (v: string | number) =>
+          selected.value
+            ? formatAmount(selected.value.commodity, new Decimal(Number(v)))
+            : v,
+      },
+    },
+  },
+  plugins: {
+    legend: { display: false },
+    tooltip: {
+      callbacks: {
+        title: (items: { parsed: { x: number | null } }[]): string => {
+          const x = items[0]?.parsed.x;
+          return x == null ? "" : new Date(x).toISOString().slice(0, 10);
+        },
+        label: (ctx: { parsed: { y: number | null } }): string => {
+          const y = ctx.parsed.y;
+          if (y == null) return "";
+          return selected.value
+            ? formatAmount(selected.value.commodity, new Decimal(y))
+            : String(y);
+        },
+      },
+    },
+  },
+}));
+
+const summary = computed(() => {
+  if (series.value.length === 0) return null;
+  const first = series.value[0]!;
+  const last = series.value[series.value.length - 1]!;
+  return {
+    first: { date: localDateToString(first.date), value: first.value },
+    last: { date: localDateToString(last.date), value: last.value },
+  };
+});
+</script>
+
+<template>
+  <div class="chart-pane">
+    <div class="controls">
+      <label>
+        <span class="label">Account / commodity</span>
+        <select v-model.number="selectedIdx">
+          <option v-for="(p, i) in pairs" :key="`${p.account}|${p.commodity}`" :value="i">
+            {{ p.account }} ({{ p.commodity }})
+          </option>
+        </select>
+      </label>
+      <div v-if="summary && selected" class="summary">
+        <span>
+          <strong>{{ summary.first.date }}</strong>
+          {{ formatAmount(selected.commodity, summary.first.value) }}
+          →
+          <strong>{{ summary.last.date }}</strong>
+          {{ formatAmount(selected.commodity, summary.last.value) }}
+        </span>
+      </div>
+    </div>
+    <div v-if="series.length === 0" class="empty">
+      No activity for this account in the selected date range.
+    </div>
+    <div v-else class="canvas">
+      <Line :data="chartData" :options="chartOptions" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.chart-pane {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 1rem;
+}
+
+.controls label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  font-size: 0.85rem;
+  color: #555;
+}
+
+.label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #777;
+}
+
+select {
+  padding: 0.3rem 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 0.25rem;
+  font: inherit;
+  background: #fafafa;
+  min-width: 18rem;
+}
+
+.summary {
+  font-size: 0.85rem;
+  color: #555;
+}
+
+.canvas {
+  height: 320px;
+}
+
+.empty {
+  padding: 3rem 1rem;
+  text-align: center;
+  color: #888;
+}
+</style>

--- a/web/src/components/FilterBar.vue
+++ b/web/src/components/FilterBar.vue
@@ -11,7 +11,7 @@ import {
 defineProps<{ showDepth?: boolean }>();
 
 const filters = useFiltersStore();
-const { pattern, clearedOnly, begin, end, depth } = storeToRefs(filters);
+const { pattern, clearedOnly, begin, end, depth, naturalSigns } = storeToRefs(filters);
 
 // Bind LocalDate state to <input type="date"> via ISO YYYY-MM-DD strings.
 const beginISO = computed({
@@ -80,6 +80,10 @@ function fromISO(s: string): LocalDate {
     <label class="toggle">
       <input v-model="clearedOnly" type="checkbox" />
       <span>Cleared only</span>
+    </label>
+    <label class="toggle" title="Display Income / Liabilities / Equity with their natural sign instead of the raw double-entry sign.">
+      <input v-model="naturalSigns" type="checkbox" />
+      <span>Natural signs</span>
     </label>
   </div>
 </template>

--- a/web/src/components/FilterBar.vue
+++ b/web/src/components/FilterBar.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { storeToRefs } from "pinia";
+import { useFiltersStore } from "@/store/filters";
+import {
+  epochDaysFromLocalDate,
+  localDateFromEpochDays,
+  type LocalDate,
+} from "@/lib/dop";
+
+defineProps<{ showDepth?: boolean }>();
+
+const filters = useFiltersStore();
+const { pattern, clearedOnly, begin, end, depth } = storeToRefs(filters);
+
+// Bind LocalDate state to <input type="date"> via ISO YYYY-MM-DD strings.
+const beginISO = computed({
+  get: () => (begin.value ? toISO(begin.value) : ""),
+  set: (v) => {
+    begin.value = v ? fromISO(v) : null;
+  },
+});
+const endISO = computed({
+  get: () => (end.value ? toISO(end.value) : ""),
+  set: (v) => {
+    end.value = v ? fromISO(v) : null;
+  },
+});
+const depthString = computed({
+  get: () => (depth.value === null ? "" : String(depth.value)),
+  set: (v) => {
+    const n = parseInt(v, 10);
+    depth.value = Number.isFinite(n) && n > 0 ? n : null;
+  },
+});
+
+function toISO(d: LocalDate): string {
+  return new Date(epochDaysFromLocalDate(d) * 86_400_000).toISOString().slice(0, 10);
+}
+
+function fromISO(s: string): LocalDate {
+  // <input type="date"> emits YYYY-MM-DD in the user's locale. Treat it
+  // as a calendar date — no timezone conversion.
+  const [y, m, d] = s.split("-").map(Number);
+  return localDateFromEpochDays(
+    Math.round(Date.UTC(y!, (m ?? 1) - 1, d ?? 1) / 86_400_000),
+  );
+}
+</script>
+
+<template>
+  <div class="filter-bar">
+    <label>
+      <span class="label">Account</span>
+      <input
+        v-model="pattern"
+        type="text"
+        placeholder="filter (substring)"
+        spellcheck="false"
+      />
+    </label>
+    <label>
+      <span class="label">Begin</span>
+      <input v-model="beginISO" type="date" />
+    </label>
+    <label>
+      <span class="label">End</span>
+      <input v-model="endISO" type="date" />
+    </label>
+    <label v-if="showDepth">
+      <span class="label">Depth</span>
+      <input
+        v-model="depthString"
+        type="number"
+        min="1"
+        placeholder="∞"
+        class="narrow"
+      />
+    </label>
+    <label class="toggle">
+      <input v-model="clearedOnly" type="checkbox" />
+      <span>Cleared only</span>
+    </label>
+  </div>
+</template>
+
+<style scoped>
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  align-items: flex-end;
+  padding: 0.5rem 0.75rem;
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  font-size: 0.85rem;
+  color: #555;
+}
+
+label.toggle {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.4rem;
+  padding-bottom: 0.3rem;
+}
+
+.label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #777;
+}
+
+input[type="text"],
+input[type="number"],
+input[type="date"] {
+  padding: 0.3rem 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 0.25rem;
+  font: inherit;
+  min-width: 9rem;
+  background: #fafafa;
+}
+
+input.narrow {
+  min-width: 4rem;
+  width: 5rem;
+}
+</style>

--- a/web/src/components/RegisterView.vue
+++ b/web/src/components/RegisterView.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { storeToRefs } from "pinia";
+import { useJournalStore } from "@/store/journal";
+import { useFiltersStore } from "@/store/filters";
+import { buildRegister } from "@/lib/views/register";
+import { formatAmount } from "@/lib/format";
+import { localDateToString } from "@/lib/dop";
+
+const journals = useJournalStore();
+const filters = useFiltersStore();
+const { pattern, clearedOnly, begin, end } = storeToRefs(filters);
+
+const rows = computed(() => {
+  const j = journals.journal;
+  if (!j) return [];
+  return buildRegister(j, {
+    pattern: pattern.value,
+    clearedOnly: clearedOnly.value,
+    begin: begin.value,
+    end: end.value,
+  });
+});
+
+function postingAmounts(commodities: Record<string, import("decimal.js").default>) {
+  return Object.entries(commodities).sort(([a], [b]) => a.localeCompare(b));
+}
+</script>
+
+<template>
+  <div v-if="rows.length === 0" class="empty">No matching postings.</div>
+  <table v-else class="register">
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Description</th>
+        <th>Account</th>
+        <th class="num">Amount</th>
+        <th class="num">Running</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        v-for="(row, idx) in rows"
+        :key="`${idx}-${row.account}`"
+        :class="{ pending: row.state === 'pending', uncleared: row.state === 'uncleared' }"
+      >
+        <td class="date">{{ localDateToString(row.date) }}</td>
+        <td class="desc">{{ row.description }}</td>
+        <td class="account">{{ row.account }}</td>
+        <td class="num">
+          <span
+            v-for="([commodity, value], i) in postingAmounts(row.posting.amount.byCommodity)"
+            :key="commodity"
+            class="amount"
+            :class="{ negative: value.isNegative() }"
+          >
+            <template v-if="i > 0">, </template>{{ formatAmount(commodity, value) }}
+          </span>
+        </td>
+        <td class="num running">
+          <span
+            v-for="([commodity, value], i) in postingAmounts(row.running)"
+            :key="commodity"
+            class="amount"
+            :class="{ negative: value.isNegative() }"
+          >
+            <template v-if="i > 0">, </template>{{ formatAmount(commodity, value) }}
+          </span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<style scoped>
+table.register {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+th {
+  text-align: left;
+  font-weight: 500;
+  color: #555;
+  padding: 0.4rem 0.75rem 0.4rem 0;
+  border-bottom: 2px solid #ddd;
+  position: sticky;
+  top: 0;
+  background: #fff;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+th.num,
+td.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+td {
+  padding: 0.3rem 0.75rem 0.3rem 0;
+  border-bottom: 1px solid #f3f3f3;
+}
+
+td.date {
+  white-space: nowrap;
+  color: #666;
+  font-size: 0.85rem;
+  font-variant-numeric: tabular-nums;
+}
+
+td.account {
+  color: #444;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.85rem;
+}
+
+td.running {
+  color: #666;
+}
+
+.amount.negative {
+  color: #b62325;
+}
+
+tr.pending td {
+  font-style: italic;
+}
+
+tr.uncleared td.desc::before {
+  content: "·";
+  color: #aaa;
+  margin-right: 0.4rem;
+}
+</style>

--- a/web/src/components/RegisterView.vue
+++ b/web/src/components/RegisterView.vue
@@ -9,17 +9,21 @@ import { localDateToString } from "@/lib/dop";
 
 const journals = useJournalStore();
 const filters = useFiltersStore();
-const { pattern, clearedOnly, begin, end } = storeToRefs(filters);
+const { pattern, clearedOnly, begin, end, naturalSigns } = storeToRefs(filters);
 
 const rows = computed(() => {
   const j = journals.journal;
   if (!j) return [];
-  return buildRegister(j, {
-    pattern: pattern.value,
-    clearedOnly: clearedOnly.value,
-    begin: begin.value,
-    end: end.value,
-  });
+  return buildRegister(
+    j,
+    {
+      pattern: pattern.value,
+      clearedOnly: clearedOnly.value,
+      begin: begin.value,
+      end: end.value,
+    },
+    naturalSigns.value,
+  );
 });
 
 function postingAmounts(commodities: Record<string, import("decimal.js").default>) {
@@ -50,7 +54,7 @@ function postingAmounts(commodities: Record<string, import("decimal.js").default
         <td class="account">{{ row.account }}</td>
         <td class="num">
           <span
-            v-for="([commodity, value], i) in postingAmounts(row.posting.amount.byCommodity)"
+            v-for="([commodity, value], i) in postingAmounts(row.amount)"
             :key="commodity"
             class="amount"
             :class="{ negative: value.isNegative() }"

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -1,0 +1,13 @@
+import type Decimal from "decimal.js";
+
+/**
+ * Render a (commodity, value) pair for display. Recognises the bare `$`
+ * symbol and renders it as a prefix with no space; other commodities are
+ * suffixed with a space, mirroring ledger-cli's typical output.
+ */
+export function formatAmount(commodity: string, value: Decimal): string {
+  const sign = value.isNegative() ? "-" : "";
+  const abs = value.abs().toFixed(2);
+  if (commodity === "$") return `${sign}$${abs}`;
+  return `${sign}${abs} ${commodity}`;
+}

--- a/web/src/lib/views/accountType.test.ts
+++ b/web/src/lib/views/accountType.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { displaySign, inferAccountType } from "./accountType.js";
+
+describe("inferAccountType", () => {
+  it("recognises the four canonical top-level segments", () => {
+    expect(inferAccountType("Income:Consulting")).toBe("income");
+    expect(inferAccountType("Assets:Bank:Checking")).toBe("assets");
+    expect(inferAccountType("Liabilities:CreditCard")).toBe("liabilities");
+    expect(inferAccountType("Equity:OpeningBalances")).toBe("equity");
+  });
+
+  it("matches on the top-level segment only, not sub-segments", () => {
+    expect(inferAccountType("Investments:Income")).toBeNull();
+    expect(inferAccountType("Holdings:Assets")).toBeNull();
+  });
+
+  it("returns null for top-level segments outside the heuristic table", () => {
+    expect(inferAccountType("Expenses:Rent")).toBeNull();
+    expect(inferAccountType("MyMadeUpTop:Foo")).toBeNull();
+  });
+
+  it("is case-sensitive — the canonical names use TitleCase", () => {
+    expect(inferAccountType("income:Salary")).toBeNull();
+    expect(inferAccountType("ASSETS:Bank")).toBeNull();
+  });
+
+  it("handles accounts with no colon (top-level only)", () => {
+    expect(inferAccountType("Income")).toBe("income");
+    expect(inferAccountType("Equity")).toBe("equity");
+  });
+});
+
+describe("displaySign", () => {
+  it("returns 1 for every account when naturalSigns is off", () => {
+    expect(displaySign("Income:Consulting", false)).toBe(1);
+    expect(displaySign("Liabilities:CreditCard", false)).toBe(1);
+    expect(displaySign("Assets:Bank:Checking", false)).toBe(1);
+    expect(displaySign("Expenses:Rent", false)).toBe(1);
+  });
+
+  it("flips signs for credit-normal types when naturalSigns is on", () => {
+    expect(displaySign("Income:Consulting", true)).toBe(-1);
+    expect(displaySign("Liabilities:CreditCard", true)).toBe(-1);
+    expect(displaySign("Equity:OpeningBalances", true)).toBe(-1);
+  });
+
+  it("does not flip Assets or Expenses (debit-normal / unknown)", () => {
+    expect(displaySign("Assets:Bank:Checking", true)).toBe(1);
+    expect(displaySign("Expenses:Rent", true)).toBe(1);
+    expect(displaySign("Whatever:Foo", true)).toBe(1);
+  });
+});

--- a/web/src/lib/views/accountType.ts
+++ b/web/src/lib/views/accountType.ts
@@ -1,0 +1,56 @@
+// Heuristic mapping of an account's top-level segment to one of the four
+// canonical PTA account types. Anything outside this table (Expenses,
+// Investments, freeform tops) is treated as an unknown type for which
+// no sign correction is applied.
+//
+// The four names are deliberate. Expenses is intentionally absent: it is
+// debit-normal like Assets, so leaving it out has the same display effect
+// (no sign flip) as classifying it explicitly. The shorter table is
+// easier to maintain and to reason about.
+//
+// Future work: an explicit `; type: X` tag on `account` directives
+// (mirroring hledger's convention) should override this heuristic. That
+// requires plumbing structured metadata through doppio's elaborator,
+// which the current proto schema doesn't yet support — tracked as a
+// follow-up issue.
+
+export type AccountType = "income" | "assets" | "liabilities" | "equity";
+
+const TOP_LEVEL_TYPE: Record<string, AccountType> = {
+  Income: "income",
+  Assets: "assets",
+  Liabilities: "liabilities",
+  Equity: "equity",
+};
+
+/**
+ * Infer the canonical account type from the first colon-separated segment
+ * of the account name. Returns null if the segment is not in the
+ * heuristic table — callers should treat that as "unknown / debit-normal".
+ */
+export function inferAccountType(account: string): AccountType | null {
+  const top = account.split(":", 1)[0];
+  if (top === undefined) return null;
+  return TOP_LEVEL_TYPE[top] ?? null;
+}
+
+/**
+ * Sign multiplier to apply to an account's posted amounts when the user
+ * has asked for "natural signs" display (the default in the demo UI).
+ *
+ * Returns -1 for credit-normal account types so that the displayed
+ * value matches what a non-accountant intuits ("Income: \$3,400" reads
+ * as money earned, not money lost). Returns 1 otherwise — including for
+ * unknown account types so we err on the side of not flipping signs we
+ * aren't confident about.
+ *
+ * When `naturalSigns` is false, always returns 1 — the raw double-entry
+ * convention. This is the "accountant view" useful for verifying that
+ * a balance equation holds.
+ */
+export function displaySign(account: string, naturalSigns: boolean): 1 | -1 {
+  if (!naturalSigns) return 1;
+  const t = inferAccountType(account);
+  if (t === "income" || t === "liabilities" || t === "equity") return -1;
+  return 1;
+}

--- a/web/src/lib/views/balance.ts
+++ b/web/src/lib/views/balance.ts
@@ -98,8 +98,12 @@ export function buildBalanceTree(
         acc.set(c, (acc.get(c) ?? new Decimal(0)).plus(v));
       }
     }
+    // Keep zero rollups so accounts that net to zero (e.g. a credit card
+    // whose charges and payments cancel within the period) still surface
+    // with an explicit "$0.00" instead of disappearing. Commodities the
+    // subtree never touched are simply absent from `acc`.
     for (const [c, v] of acc) {
-      if (!v.isZero()) node.rollupTotals.byCommodity[c] = v;
+      node.rollupTotals.byCommodity[c] = v;
     }
   }
 
@@ -129,13 +133,5 @@ export function buildBalanceTree(
     for (const t of tops) prune(t);
   }
 
-  // Drop subtrees whose rollup is entirely zero (everything cancelled).
-  function isAllZero(t: BalanceTotals): boolean {
-    return Object.keys(t.byCommodity).length === 0;
-  }
-  function pruneEmpty(node: BalanceNode): boolean {
-    node.children = node.children.filter(pruneEmpty);
-    return !isAllZero(node.rollupTotals);
-  }
-  return tops.filter(pruneEmpty);
+  return tops;
 }

--- a/web/src/lib/views/balance.ts
+++ b/web/src/lib/views/balance.ts
@@ -1,5 +1,6 @@
 import Decimal from "decimal.js";
 import type { Journal } from "@/lib/dop";
+import { displaySign } from "./accountType.js";
 import { filteredPostings, type ViewFilters } from "./filter.js";
 
 export interface BalanceTotals {
@@ -38,6 +39,7 @@ export function buildBalanceTree(
   journal: Journal,
   filters: ViewFilters,
   maxDepth: number | null,
+  naturalSigns = false,
 ): BalanceNode[] {
   // Step 1: accumulate own-totals per full account name.
   const own = new Map<string, Map<string, Decimal>>();
@@ -47,8 +49,10 @@ export function buildBalanceTree(
       totals = new Map();
       own.set(p.account, totals);
     }
+    const sign = displaySign(p.account, naturalSigns);
     for (const [c, v] of Object.entries(p.amount.byCommodity)) {
-      totals.set(c, (totals.get(c) ?? new Decimal(0)).plus(v));
+      const flipped = sign === -1 ? v.neg() : v;
+      totals.set(c, (totals.get(c) ?? new Decimal(0)).plus(flipped));
     }
   }
 

--- a/web/src/lib/views/balance.ts
+++ b/web/src/lib/views/balance.ts
@@ -1,0 +1,137 @@
+import Decimal from "decimal.js";
+import type { Journal } from "@/lib/dop";
+import { filteredPostings, type ViewFilters } from "./filter.js";
+
+export interface BalanceTotals {
+  // commodity → total. Zero entries are pruned at build time.
+  byCommodity: Record<string, Decimal>;
+}
+
+export interface BalanceNode {
+  // Last segment of the account name (e.g. "Checking" for "Assets:Bank:Checking").
+  segment: string;
+  // Full colon-joined account name.
+  fullName: string;
+  // Depth from the root (top-level account = 1).
+  depth: number;
+  // Postings landing on THIS account exactly.
+  ownTotals: BalanceTotals;
+  // Own + all descendants, rolled up.
+  rollupTotals: BalanceTotals;
+  children: BalanceNode[];
+}
+
+/**
+ * Build a hierarchical balance tree from a Journal under the given filters.
+ *
+ * - Account names are split on `:` and assembled into a tree where every
+ *   intermediate segment becomes a node, even if no posting lands on it
+ *   directly.
+ * - Each node carries its own posting totals (`ownTotals`) and its
+ *   subtree-rolled-up totals (`rollupTotals`).
+ * - Children are returned in lexicographic order by segment.
+ * - `maxDepth` (if non-null) limits the tree to that many levels —
+ *   anything deeper is rolled into the closest ancestor's `rollupTotals`
+ *   (which already includes it) and not emitted as its own node.
+ */
+export function buildBalanceTree(
+  journal: Journal,
+  filters: ViewFilters,
+  maxDepth: number | null,
+): BalanceNode[] {
+  // Step 1: accumulate own-totals per full account name.
+  const own = new Map<string, Map<string, Decimal>>();
+  for (const { posting: p } of filteredPostings(journal, filters)) {
+    let totals = own.get(p.account);
+    if (!totals) {
+      totals = new Map();
+      own.set(p.account, totals);
+    }
+    for (const [c, v] of Object.entries(p.amount.byCommodity)) {
+      totals.set(c, (totals.get(c) ?? new Decimal(0)).plus(v));
+    }
+  }
+
+  // Step 2: assemble nodes for every segment, including ancestors with no
+  // direct postings.
+  const nodes = new Map<string, BalanceNode>(); // fullName → node
+  function ensureNode(fullName: string): BalanceNode {
+    const existing = nodes.get(fullName);
+    if (existing) return existing;
+    const segments = fullName.split(":");
+    const node: BalanceNode = {
+      segment: segments[segments.length - 1]!,
+      fullName,
+      depth: segments.length,
+      ownTotals: { byCommodity: {} },
+      rollupTotals: { byCommodity: {} },
+      children: [],
+    };
+    nodes.set(fullName, node);
+    if (segments.length > 1) {
+      const parentName = segments.slice(0, -1).join(":");
+      const parent = ensureNode(parentName);
+      parent.children.push(node);
+    }
+    return node;
+  }
+  for (const [fullName, totals] of own) {
+    const node = ensureNode(fullName);
+    for (const [c, v] of totals) {
+      node.ownTotals.byCommodity[c] = v;
+    }
+  }
+
+  // Step 3: roll up. Post-order traversal sums own + children.
+  function rollup(node: BalanceNode) {
+    const acc = new Map<string, Decimal>();
+    for (const [c, v] of Object.entries(node.ownTotals.byCommodity)) {
+      acc.set(c, (acc.get(c) ?? new Decimal(0)).plus(v));
+    }
+    for (const child of node.children) {
+      rollup(child);
+      for (const [c, v] of Object.entries(child.rollupTotals.byCommodity)) {
+        acc.set(c, (acc.get(c) ?? new Decimal(0)).plus(v));
+      }
+    }
+    for (const [c, v] of acc) {
+      if (!v.isZero()) node.rollupTotals.byCommodity[c] = v;
+    }
+  }
+
+  // Sort children by segment.
+  for (const node of nodes.values()) {
+    node.children.sort((a, b) => a.segment.localeCompare(b.segment));
+  }
+
+  // Top-level nodes are those whose fullName has no `:` parent; equivalently,
+  // those that no other node lists as a child.
+  const tops: BalanceNode[] = [];
+  for (const node of nodes.values()) {
+    if (node.depth === 1) tops.push(node);
+  }
+  tops.sort((a, b) => a.segment.localeCompare(b.segment));
+  for (const t of tops) rollup(t);
+
+  // Step 4: apply maxDepth by pruning children below the cap.
+  if (maxDepth !== null) {
+    function prune(node: BalanceNode) {
+      if (node.depth >= maxDepth!) {
+        node.children = [];
+      } else {
+        for (const c of node.children) prune(c);
+      }
+    }
+    for (const t of tops) prune(t);
+  }
+
+  // Drop subtrees whose rollup is entirely zero (everything cancelled).
+  function isAllZero(t: BalanceTotals): boolean {
+    return Object.keys(t.byCommodity).length === 0;
+  }
+  function pruneEmpty(node: BalanceNode): boolean {
+    node.children = node.children.filter(pruneEmpty);
+    return !isAllZero(node.rollupTotals);
+  }
+  return tops.filter(pruneEmpty);
+}

--- a/web/src/lib/views/chart.ts
+++ b/web/src/lib/views/chart.ts
@@ -1,0 +1,88 @@
+import Decimal from "decimal.js";
+import {
+  compareLocalDate,
+  type Journal,
+  type LocalDate,
+} from "@/lib/dop";
+import { dateInRange } from "./filter.js";
+
+export interface ChartPoint {
+  date: LocalDate;
+  value: Decimal;
+}
+
+/**
+ * Build a per-account balance time series in a chosen commodity.
+ *
+ * Iterates every transaction (sorted by date), accumulates the running
+ * balance contributed by `account` postings in `commodity`, and emits a
+ * data point on every date where the balance changes. Dates without a
+ * change are not duplicated — Chart.js's line chart spans them
+ * naturally.
+ *
+ * Virtual-unbalanced postings are excluded; they don't move the real
+ * balance.
+ *
+ * Returns an empty array if no postings on `account` ever touch
+ * `commodity`.
+ */
+export function buildAccountSeries(
+  journal: Journal,
+  account: string,
+  commodity: string,
+  begin: LocalDate | null,
+  end: LocalDate | null,
+): ChartPoint[] {
+  const sorted = [...journal.transactions].sort((a, b) =>
+    compareLocalDate(a.date, b.date),
+  );
+  let balance = new Decimal(0);
+  const points: ChartPoint[] = [];
+  let lastDate: LocalDate | null = null;
+  for (const t of sorted) {
+    if (!dateInRange(t.date, begin, end)) continue;
+    let dayChange = new Decimal(0);
+    for (const p of t.postings) {
+      if (p.kind === "virtualUnbalanced") continue;
+      if (p.account !== account) continue;
+      const v = p.amount.byCommodity[commodity];
+      if (v) dayChange = dayChange.plus(v);
+    }
+    if (dayChange.isZero()) continue;
+    balance = balance.plus(dayChange);
+    // Coalesce same-day points to a single end-of-day value.
+    if (lastDate && compareLocalDate(lastDate, t.date) === 0) {
+      points[points.length - 1] = { date: t.date, value: balance };
+    } else {
+      points.push({ date: t.date, value: balance });
+    }
+    lastDate = t.date;
+  }
+  return points;
+}
+
+/**
+ * Enumerate the (account, commodity) pairs that have at least one
+ * non-virtual posting in the journal. Useful for populating chart
+ * controls.
+ */
+export function accountCommodityPairs(journal: Journal): { account: string; commodity: string }[] {
+  const seen = new Set<string>();
+  const pairs: { account: string; commodity: string }[] = [];
+  for (const t of journal.transactions) {
+    for (const p of t.postings) {
+      if (p.kind === "virtualUnbalanced") continue;
+      for (const c of Object.keys(p.amount.byCommodity)) {
+        const key = `${p.account}${c}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        pairs.push({ account: p.account, commodity: c });
+      }
+    }
+  }
+  pairs.sort(
+    (a, b) =>
+      a.account.localeCompare(b.account) || a.commodity.localeCompare(b.commodity),
+  );
+  return pairs;
+}

--- a/web/src/lib/views/chart.ts
+++ b/web/src/lib/views/chart.ts
@@ -4,6 +4,7 @@ import {
   type Journal,
   type LocalDate,
 } from "@/lib/dop";
+import { displaySign } from "./accountType.js";
 import { dateInRange } from "./filter.js";
 
 export interface ChartPoint {
@@ -32,7 +33,9 @@ export function buildAccountSeries(
   commodity: string,
   begin: LocalDate | null,
   end: LocalDate | null,
+  naturalSigns = false,
 ): ChartPoint[] {
+  const sign = displaySign(account, naturalSigns);
   const sorted = [...journal.transactions].sort((a, b) =>
     compareLocalDate(a.date, b.date),
   );
@@ -46,7 +49,7 @@ export function buildAccountSeries(
       if (p.kind === "virtualUnbalanced") continue;
       if (p.account !== account) continue;
       const v = p.amount.byCommodity[commodity];
-      if (v) dayChange = dayChange.plus(v);
+      if (v) dayChange = dayChange.plus(sign === -1 ? v.neg() : v);
     }
     if (dayChange.isZero()) continue;
     balance = balance.plus(dayChange);

--- a/web/src/lib/views/filter.ts
+++ b/web/src/lib/views/filter.ts
@@ -1,0 +1,62 @@
+import { compareLocalDate, type Journal, type Posting, type Transaction, type LocalDate } from "@/lib/dop";
+
+/**
+ * Filters shared across the three views. The filter store carries the same
+ * fields; this type makes the pure-function utilities testable without a
+ * Pinia harness.
+ */
+export interface ViewFilters {
+  pattern: string;
+  clearedOnly: boolean;
+  begin: LocalDate | null;
+  end: LocalDate | null;
+}
+
+/**
+ * Test whether a transaction's date sits inside the [begin, end] window.
+ * Either bound may be null to leave that side unbounded.
+ */
+export function dateInRange(
+  date: LocalDate,
+  begin: LocalDate | null,
+  end: LocalDate | null,
+): boolean {
+  if (begin && compareLocalDate(date, begin) < 0) return false;
+  if (end && compareLocalDate(date, end) > 0) return false;
+  return true;
+}
+
+/**
+ * Lower-cased substring match against an account name. Empty pattern
+ * matches everything.
+ */
+export function accountMatches(account: string, pattern: string): boolean {
+  if (!pattern) return true;
+  return account.toLowerCase().includes(pattern.toLowerCase());
+}
+
+/**
+ * Walk every (transaction, posting) pair that survives the filters, in
+ * source order. Yields a (txn, posting) tuple per surviving posting.
+ *
+ * - Date-range filter applies to the transaction date.
+ * - clearedOnly drops the entire transaction unless its state is "cleared".
+ * - account-name pattern is per-posting (a transaction may contribute some
+ *   postings and not others).
+ * - virtual-unbalanced postings are excluded by default (they don't
+ *   participate in real balances).
+ */
+export function* filteredPostings(
+  journal: Journal,
+  filters: ViewFilters,
+): Generator<{ transaction: Transaction; posting: Posting }> {
+  for (const t of journal.transactions) {
+    if (!dateInRange(t.date, filters.begin, filters.end)) continue;
+    if (filters.clearedOnly && t.state !== "cleared") continue;
+    for (const p of t.postings) {
+      if (p.kind === "virtualUnbalanced") continue;
+      if (!accountMatches(p.account, filters.pattern)) continue;
+      yield { transaction: t, posting: p };
+    }
+  }
+}

--- a/web/src/lib/views/register.ts
+++ b/web/src/lib/views/register.ts
@@ -1,0 +1,46 @@
+import Decimal from "decimal.js";
+import type { Journal, LocalDate, Posting, Transaction } from "@/lib/dop";
+import { filteredPostings, type ViewFilters } from "./filter.js";
+
+export interface RegisterRow {
+  date: LocalDate;
+  description: string;
+  state: Transaction["state"];
+  account: string;
+  posting: Posting;
+  // Running total per commodity AFTER this row is applied. Zero entries
+  // are pruned at build time.
+  running: Record<string, Decimal>;
+}
+
+/**
+ * Project the journal into a flat list of register rows: one row per
+ * surviving posting, in source order, with running per-commodity totals
+ * carried across rows.
+ *
+ * The running total is computed only over rows that match `filters` —
+ * matching ledger-cli's convention that `register Expenses` shows the
+ * running total of just-Expenses postings, not of every posting.
+ */
+export function buildRegister(journal: Journal, filters: ViewFilters): RegisterRow[] {
+  const running = new Map<string, Decimal>();
+  const rows: RegisterRow[] = [];
+  for (const { transaction, posting } of filteredPostings(journal, filters)) {
+    for (const [c, v] of Object.entries(posting.amount.byCommodity)) {
+      running.set(c, (running.get(c) ?? new Decimal(0)).plus(v));
+    }
+    const snapshot: Record<string, Decimal> = {};
+    for (const [c, v] of running) {
+      if (!v.isZero()) snapshot[c] = v;
+    }
+    rows.push({
+      date: transaction.date,
+      description: transaction.description,
+      state: transaction.state,
+      account: posting.account,
+      posting,
+      running: snapshot,
+    });
+  }
+  return rows;
+}

--- a/web/src/lib/views/register.ts
+++ b/web/src/lib/views/register.ts
@@ -1,5 +1,6 @@
 import Decimal from "decimal.js";
 import type { Journal, LocalDate, Posting, Transaction } from "@/lib/dop";
+import { displaySign } from "./accountType.js";
 import { filteredPostings, type ViewFilters } from "./filter.js";
 
 export interface RegisterRow {
@@ -8,8 +9,13 @@ export interface RegisterRow {
   state: Transaction["state"];
   account: string;
   posting: Posting;
-  // Running total per commodity AFTER this row is applied. Zero entries
-  // are pruned at build time.
+  // Posting amount with the per-account display sign already applied.
+  // Identical to `posting.amount.byCommodity` when naturalSigns is off.
+  // Zero entries are pruned at build time.
+  amount: Record<string, Decimal>;
+  // Running total per commodity AFTER this row is applied. Computed
+  // from `amount` (sign-aware), not from the raw posting — so swapping
+  // naturalSigns at the call site re-computes the running consistently.
   running: Record<string, Decimal>;
 }
 
@@ -22,12 +28,20 @@ export interface RegisterRow {
  * matching ledger-cli's convention that `register Expenses` shows the
  * running total of just-Expenses postings, not of every posting.
  */
-export function buildRegister(journal: Journal, filters: ViewFilters): RegisterRow[] {
+export function buildRegister(
+  journal: Journal,
+  filters: ViewFilters,
+  naturalSigns = false,
+): RegisterRow[] {
   const running = new Map<string, Decimal>();
   const rows: RegisterRow[] = [];
   for (const { transaction, posting } of filteredPostings(journal, filters)) {
+    const sign = displaySign(posting.account, naturalSigns);
+    const amount: Record<string, Decimal> = {};
     for (const [c, v] of Object.entries(posting.amount.byCommodity)) {
-      running.set(c, (running.get(c) ?? new Decimal(0)).plus(v));
+      const flipped = sign === -1 ? v.neg() : v;
+      amount[c] = flipped;
+      running.set(c, (running.get(c) ?? new Decimal(0)).plus(flipped));
     }
     const snapshot: Record<string, Decimal> = {};
     for (const [c, v] of running) {
@@ -39,6 +53,7 @@ export function buildRegister(journal: Journal, filters: ViewFilters): RegisterR
       state: transaction.state,
       account: posting.account,
       posting,
+      amount,
       running: snapshot,
     });
   }

--- a/web/src/lib/views/views.test.ts
+++ b/web/src/lib/views/views.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import Decimal from "decimal.js";
+import { readDop, type Journal } from "@/lib/dop";
+import { buildBalanceTree } from "./balance.js";
+import { buildRegister } from "./register.js";
+import { accountCommodityPairs, buildAccountSeries } from "./chart.js";
+import type { ViewFilters } from "./filter.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const samplePath = resolve(here, "../../../public/sample.dop");
+const sampleBytes = (() => {
+  const b = readFileSync(samplePath);
+  return new Uint8Array(b.buffer, b.byteOffset, b.byteLength);
+})();
+const journal: Journal = readDop(sampleBytes);
+
+const noFilter: ViewFilters = { pattern: "", clearedOnly: false, begin: null, end: null };
+
+describe("buildBalanceTree", () => {
+  it("matches the journal's mid-year checking assertion at the leaf", () => {
+    const tree = buildBalanceTree(journal, noFilter, null);
+    function find(name: string, nodes = tree): any {
+      for (const n of nodes) {
+        if (n.fullName === name) return n;
+        const hit = find(name, n.children);
+        if (hit) return hit;
+      }
+      return null;
+    }
+    const checking = find("Assets:Bank:Checking");
+    expect(checking).toBeTruthy();
+    expect(
+      checking.rollupTotals.byCommodity["$"].equals(new Decimal("10318.88")),
+    ).toBe(true);
+  });
+
+  it("rolls up child totals into their parents", () => {
+    const tree = buildBalanceTree(journal, noFilter, null);
+    const assets = tree.find((n) => n.fullName === "Assets")!;
+    expect(assets).toBeDefined();
+    const sumOfChildrenUSD = assets.children.reduce(
+      (acc, c) => acc.plus(c.rollupTotals.byCommodity["$"] ?? new Decimal(0)),
+      new Decimal(0),
+    );
+    expect(assets.rollupTotals.byCommodity["$"].equals(sumOfChildrenUSD)).toBe(true);
+  });
+
+  it("respects maxDepth by clipping children below the cap", () => {
+    const tree = buildBalanceTree(journal, noFilter, 1);
+    expect(tree.every((n) => n.children.length === 0)).toBe(true);
+    // Rollups must still hold the deep totals — the child data only
+    // disappears from the tree, not from the parent's rollup.
+    const assets = tree.find((n) => n.fullName === "Assets")!;
+    expect(assets.rollupTotals.byCommodity["$"].toFixed(2)).toBe(
+      new Decimal("10318.88").plus(new Decimal("13500.00")).toFixed(2),
+    );
+  });
+
+  it("filters by date range — January only restricts to opening + Jan postings", () => {
+    const janOnly = buildBalanceTree(
+      journal,
+      {
+        pattern: "",
+        clearedOnly: false,
+        begin: { year: 2024, month: 1, day: 1 },
+        end: { year: 2024, month: 1, day: 31 },
+      },
+      null,
+    );
+    // Some transactions remain (the openings + January activity); not zero,
+    // but smaller than the full-period balance on rent.
+    const exp = janOnly.find((n) => n.fullName === "Expenses");
+    expect(exp).toBeDefined();
+    const rent = exp!.children.find((n) => n.fullName === "Expenses:Rent")!;
+    expect(rent.rollupTotals.byCommodity["$"].equals(new Decimal("1800.00"))).toBe(true);
+  });
+
+  it("substring-filters by account name", () => {
+    const tree = buildBalanceTree(
+      journal,
+      { ...noFilter, pattern: "checking" },
+      null,
+    );
+    // Only the Assets > Bank > Checking branch should contribute.
+    const flat: string[] = [];
+    function walk(ns: any[]) {
+      for (const n of ns) {
+        if (Object.keys(n.ownTotals.byCommodity).length > 0) flat.push(n.fullName);
+        walk(n.children);
+      }
+    }
+    walk(tree);
+    expect(flat).toEqual(["Assets:Bank:Checking"]);
+  });
+});
+
+describe("buildRegister", () => {
+  it("emits one row per matching posting in source order", () => {
+    const rows = buildRegister(journal, noFilter);
+    // Total postings in the journal = sum of all transactions' posting counts.
+    const expected = journal.transactions.reduce((acc, t) => acc + t.postings.length, 0);
+    expect(rows.length).toBe(expected);
+    // First row date matches first transaction date.
+    expect(rows[0]!.date).toEqual(journal.transactions[0]!.date);
+  });
+
+  it("running total at the last filtered row matches a flat sum", () => {
+    const rows = buildRegister(journal, { ...noFilter, pattern: "expenses:rent" });
+    const last = rows[rows.length - 1]!;
+    // Expenses:Rent = 6 monthly $1,800 entries.
+    expect(last.running["$"].equals(new Decimal("10800.00"))).toBe(true);
+  });
+
+  it("clearedOnly drops pending or uncleared transactions", () => {
+    const all = buildRegister(journal, noFilter);
+    const cleared = buildRegister(journal, { ...noFilter, clearedOnly: true });
+    expect(cleared.length).toBeLessThanOrEqual(all.length);
+    expect(cleared.every((r) => r.state === "cleared")).toBe(true);
+  });
+});
+
+describe("buildAccountSeries", () => {
+  it("ends at the journal's mid-year checking assertion", () => {
+    const series = buildAccountSeries(journal, "Assets:Bank:Checking", "$", null, null);
+    expect(series.length).toBeGreaterThan(0);
+    const last = series[series.length - 1]!;
+    expect(last.value.equals(new Decimal("10318.88"))).toBe(true);
+  });
+
+  it("is monotonically dated", () => {
+    const series = buildAccountSeries(journal, "Assets:Bank:Checking", "$", null, null);
+    for (let i = 1; i < series.length; i++) {
+      const a = series[i - 1]!.date;
+      const b = series[i]!.date;
+      const cmp = a.year - b.year || a.month - b.month || a.day - b.day;
+      expect(cmp).toBeLessThan(0);
+    }
+  });
+
+  it("returns empty when the account never touches the commodity", () => {
+    const series = buildAccountSeries(journal, "Assets:Bank:Checking", "EUR", null, null);
+    expect(series).toEqual([]);
+  });
+});
+
+describe("accountCommodityPairs", () => {
+  it("includes Assets:Bank:Checking $ and Assets:Cash:EUR EUR", () => {
+    const pairs = accountCommodityPairs(journal);
+    expect(pairs).toContainEqual({ account: "Assets:Bank:Checking", commodity: "$" });
+    expect(pairs).toContainEqual({ account: "Assets:Cash:EUR", commodity: "EUR" });
+  });
+
+  it("returns pairs sorted by (account, commodity)", () => {
+    const pairs = accountCommodityPairs(journal);
+    for (let i = 1; i < pairs.length; i++) {
+      const cmp =
+        pairs[i - 1]!.account.localeCompare(pairs[i]!.account) ||
+        pairs[i - 1]!.commodity.localeCompare(pairs[i]!.commodity);
+      expect(cmp).toBeLessThanOrEqual(0);
+    }
+  });
+});

--- a/web/src/lib/views/views.test.ts
+++ b/web/src/lib/views/views.test.ts
@@ -96,6 +96,21 @@ describe("buildBalanceTree", () => {
     expect(flat).toEqual(["Assets:Bank:Checking"]);
   });
 
+  it("preserves zero-balance accounts (e.g. a credit card cleared each period)", () => {
+    const tree = buildBalanceTree(journal, noFilter, null);
+    function find(name: string, nodes = tree): any {
+      for (const n of nodes) {
+        if (n.fullName === name) return n;
+        const hit = find(name, n.children);
+        if (hit) return hit;
+      }
+      return null;
+    }
+    const cc = find("Liabilities:CreditCard");
+    expect(cc).toBeTruthy();
+    expect(cc.rollupTotals.byCommodity["$"].isZero()).toBe(true);
+  });
+
   it("flips signs for credit-normal subtrees when naturalSigns is on", () => {
     const tree = buildBalanceTree(journal, noFilter, null, true);
     function find(name: string, nodes = tree): any {

--- a/web/src/lib/views/views.test.ts
+++ b/web/src/lib/views/views.test.ts
@@ -95,6 +95,26 @@ describe("buildBalanceTree", () => {
     walk(tree);
     expect(flat).toEqual(["Assets:Bank:Checking"]);
   });
+
+  it("flips signs for credit-normal subtrees when naturalSigns is on", () => {
+    const tree = buildBalanceTree(journal, noFilter, null, true);
+    function find(name: string, nodes = tree): any {
+      for (const n of nodes) {
+        if (n.fullName === name) return n;
+        const hit = find(name, n.children);
+        if (hit) return hit;
+      }
+      return null;
+    }
+    // Income flips: was -23800, displays as +23800.
+    expect(find("Income:Consulting").rollupTotals.byCommodity["$"].equals(new Decimal("23800"))).toBe(true);
+    // Equity flips: was -18500, displays as +18500.
+    expect(find("Equity:OpeningBalances").rollupTotals.byCommodity["$"].equals(new Decimal("18500"))).toBe(true);
+    // Assets does NOT flip — Checking stays at +10318.88.
+    expect(find("Assets:Bank:Checking").rollupTotals.byCommodity["$"].equals(new Decimal("10318.88"))).toBe(true);
+    // Expenses (debit-normal, outside the heuristic table) does NOT flip.
+    expect(find("Expenses:Rent").rollupTotals.byCommodity["$"].equals(new Decimal("10800.00"))).toBe(true);
+  });
 });
 
 describe("buildRegister", () => {
@@ -120,6 +140,22 @@ describe("buildRegister", () => {
     expect(cleared.length).toBeLessThanOrEqual(all.length);
     expect(cleared.every((r) => r.state === "cleared")).toBe(true);
   });
+
+  it("naturalSigns flips per-row amounts and the running total for credit-normal accounts", () => {
+    const rows = buildRegister(journal, { ...noFilter, pattern: "income:consulting" }, true);
+    expect(rows.length).toBeGreaterThan(0);
+    // Each Income row was -3400 raw; with natural signs, it displays as +3400.
+    expect(rows[0]!.amount["$"].equals(new Decimal("3400"))).toBe(true);
+    // Final running = 7 invoices × 3400 = 23800 (two in January, then monthly Feb-Jun).
+    const last = rows[rows.length - 1]!;
+    expect(last.running["$"].equals(new Decimal("23800.00"))).toBe(true);
+  });
+
+  it("naturalSigns leaves debit-normal accounts unchanged", () => {
+    const rows = buildRegister(journal, { ...noFilter, pattern: "expenses:rent" }, true);
+    const last = rows[rows.length - 1]!;
+    expect(last.running["$"].equals(new Decimal("10800.00"))).toBe(true);
+  });
 });
 
 describe("buildAccountSeries", () => {
@@ -143,6 +179,25 @@ describe("buildAccountSeries", () => {
   it("returns empty when the account never touches the commodity", () => {
     const series = buildAccountSeries(journal, "Assets:Bank:Checking", "EUR", null, null);
     expect(series).toEqual([]);
+  });
+
+  it("naturalSigns flips the entire series for credit-normal accounts", () => {
+    const raw = buildAccountSeries(journal, "Income:Consulting", "$", null, null);
+    const flipped = buildAccountSeries(journal, "Income:Consulting", "$", null, null, true);
+    expect(flipped.length).toBe(raw.length);
+    for (let i = 0; i < raw.length; i++) {
+      expect(flipped[i]!.value.equals(raw[i]!.value.neg())).toBe(true);
+    }
+    // And the closing point for income reads positive under natural signs.
+    expect(flipped[flipped.length - 1]!.value.equals(new Decimal("23800.00"))).toBe(true);
+  });
+
+  it("naturalSigns leaves Assets series unchanged", () => {
+    const raw = buildAccountSeries(journal, "Assets:Bank:Checking", "$", null, null);
+    const flipped = buildAccountSeries(journal, "Assets:Bank:Checking", "$", null, null, true);
+    for (let i = 0; i < raw.length; i++) {
+      expect(flipped[i]!.value.equals(raw[i]!.value)).toBe(true);
+    }
   });
 });
 

--- a/web/src/store/filters.ts
+++ b/web/src/store/filters.ts
@@ -1,0 +1,27 @@
+import { defineStore } from "pinia";
+import type { LocalDate } from "@/lib/dop";
+
+interface State {
+  // Substring filter applied to account names. Case-insensitive.
+  // Treated as plain substring (not regex) for now — simple and predictable.
+  pattern: string;
+  // If true, only cleared transactions/postings are included.
+  clearedOnly: boolean;
+  // Inclusive lower bound on transaction date.
+  begin: LocalDate | null;
+  // Inclusive upper bound on transaction date.
+  end: LocalDate | null;
+  // Maximum tree depth in the balance view (1 = top-level only).
+  // null means no limit.
+  depth: number | null;
+}
+
+export const useFiltersStore = defineStore("filters", {
+  state: (): State => ({
+    pattern: "",
+    clearedOnly: false,
+    begin: null,
+    end: null,
+    depth: null,
+  }),
+});

--- a/web/src/store/filters.ts
+++ b/web/src/store/filters.ts
@@ -14,6 +14,11 @@ interface State {
   // Maximum tree depth in the balance view (1 = top-level only).
   // null means no limit.
   depth: number | null;
+  // When true, credit-normal accounts (Income / Liabilities / Equity)
+  // display with their conventional natural sign — so "Income: \$3,400"
+  // reads as money earned. When false, raw double-entry signs are
+  // shown unchanged. See lib/views/accountType.ts for the heuristic.
+  naturalSigns: boolean;
 }
 
 export const useFiltersStore = defineStore("filters", {
@@ -23,5 +28,6 @@ export const useFiltersStore = defineStore("filters", {
     begin: null,
     end: null,
     depth: null,
+    naturalSigns: true,
   }),
 });

--- a/web/src/store/journal.ts
+++ b/web/src/store/journal.ts
@@ -1,9 +1,41 @@
 import { defineStore } from "pinia";
+import { DopError, readDop, type Journal } from "@/lib/dop";
 
-// Pinia store stub. Populated by the loader (#151) and consumed by the views (#150).
+interface State {
+  journal: Journal | null;
+  error: string | null;
+  loading: boolean;
+}
+
 export const useJournalStore = defineStore("journal", {
-  state: () => ({
-    loaded: false as boolean,
-    sourcePath: null as string | null,
+  state: (): State => ({
+    journal: null,
+    error: null,
+    loading: false,
   }),
+  actions: {
+    async loadFromUrl(url: string) {
+      this.loading = true;
+      this.error = null;
+      try {
+        const res = await fetch(url);
+        if (!res.ok) {
+          throw new Error(`fetch ${url} → HTTP ${res.status}`);
+        }
+        const buf = new Uint8Array(await res.arrayBuffer());
+        this.journal = readDop(buf);
+      } catch (e) {
+        this.journal = null;
+        if (e instanceof DopError) {
+          this.error = `[${e.kind}] ${e.message}`;
+        } else if (e instanceof Error) {
+          this.error = e.message;
+        } else {
+          this.error = String(e);
+        }
+      } finally {
+        this.loading = false;
+      }
+    },
+  },
 });

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from "vitest/config";
+import { fileURLToPath, URL } from "node:url";
 
 export default defineConfig({
   test: {
     include: ["src/**/*.test.ts"],
     environment: "node",
+  },
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
   },
 });


### PR DESCRIPTION
## Summary

Three Vue components consuming the Journal that #151 lands in the Pinia store, plus a shared FilterBar that lets all three views share filter state.

Closes #150.

### BalanceView
Hierarchical account tree. Each node carries `ownTotals` (postings on that exact account) and `rollupTotals` (own + descendants). Rendered with depth-based indentation; a depth slider in the FilterBar caps which nodes are visible without distorting parents' rollup math (deep totals still propagate up).

### RegisterView
Per-posting table with date, description, account, amount, and running totals per commodity. Running scope follows ledger-cli convention: filter to `Expenses:Rent` and the running total only reflects rent postings.

### ChartView
Chart.js line chart with a time-axis x scale (`chartjs-adapter-date-fns`). Account/commodity dropdown defaulting to `Assets:Bank:Checking ($)` if it exists. Same date-range filter applies. Tooltip and y-axis ticks share `formatAmount` with the table views so a shown value renders identically across views.

### Shared concerns

- **Filters** (`pattern`, `clearedOnly`, `begin`, `end`, `depth`) live in a Pinia store and feed the views via pure-function utilities (`buildBalanceTree`, `buildRegister`, `buildAccountSeries`).
- **View utilities are pure** and live under `src/lib/views/`. Tested independently of any Vue/Pinia harness.
- **Journal loading** moved from `App.vue` into the journal store; `App.vue` is now a thin tab dispatcher with a summary bar at the top.

## Tests

13 new vitest specs (41 total now) on the same `public/sample.dop` the loader tests use:

- Balance tree: leaf assertion (Checking = \$10,318.88), parent rollup equals the sum of children, depth=1 clips children but preserves parent rollup, January-only date filter restricts Expenses:Rent to one month, substring filter narrows to one account.
- Register: row count = total postings, running total on Expenses:Rent across six months = \$10,800, clearedOnly correctly filters by transaction state.
- Chart: series ends at the same Checking assertion, points are monotonically dated, returns empty for (account, commodity) pairs with no activity.

## Test plan

- [x] `npm test` — 41 passed
- [x] `npm run build` — green; bundle 425 KB / 142 KB gzipped (Chart.js + date-fns add ~235 KB ungzipped)
- [x] `cargo test --workspace` (no Rust changes; sanity)
- [ ] Visual confirmation on the deployed Pages URL after merge

## Bundle note

Bundle grew from 190 KB → 425 KB ungzipped (65 → 142 KB gzipped). Most of the delta is Chart.js + the date-fns adapter pulling in date-fns. We can revisit with code-splitting (lazy-load ChartView) post-1.0; for the demo I think the simpler unsplit bundle is fine.

## Follow-ups

- Wireframe / dashboard mock from the user — to consider implementing as a separate iteration on top of these primitives, either before or after 1.0
- #149 (post-1.0): drag-and-drop WASM source-parser shim
- #152 (post-1.0): inline categorizer suggestions in the new-transaction form