### PR TITLE
feat: preserve and inherit account-directive metadata (closes #168)

### DIFF
--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -331,12 +331,18 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
 
         // Pre-populate the accounts map from directives so that accounts
         // declared with notes but never posted to still appear in the output.
+        // Metadata is denormalised after the entry loop — see end of fn.
         let mut accounts = BTreeMap::new();
         for (name, properties) in &value.global_context.account_properties {
             accounts.insert(
                 name.clone(),
                 crate::elaboration::AccountProperties {
                     note: properties.note.clone(),
+                    metadata: properties
+                        .metadata
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect(),
                 },
             );
         }
@@ -804,6 +810,41 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
             })
             .collect();
 
+        // Denormalise account metadata by inheritance. For every account
+        // in the journal (declared OR only referenced by postings), walk
+        // its colon-separated ancestor chain root→leaf, merging in any
+        // metadata declared on each ancestor's own `account` directive.
+        // Closer ancestors override more distant ones; the account's own
+        // declared metadata wins last. Consumers thus see a fully
+        // resolved metadata map per account and never need to do the
+        // inheritance walk themselves.
+        let declared_metadata: BTreeMap<&str, &BTreeMap<String, String>> = value
+            .global_context
+            .account_properties
+            .iter()
+            .map(|(name, props)| (name.as_str(), &props.metadata))
+            .collect();
+        let account_names: Vec<String> = accounts.keys().cloned().collect();
+        for name in account_names {
+            let mut inherited: BTreeMap<String, String> = BTreeMap::new();
+            for prefix in ancestor_prefixes(&name) {
+                if let Some(parent_meta) = declared_metadata.get(prefix.as_str()) {
+                    for (k, v) in *parent_meta {
+                        inherited.insert(k.clone(), v.clone());
+                    }
+                }
+            }
+            // `inherited` now holds the merged ancestor metadata in
+            // root-→-leaf order (closer wins). For declared accounts
+            // their own metadata was the last entry written, so we are
+            // already correct. For undeclared accounts (referenced only
+            // by postings) `inherited` is purely from ancestors. Either
+            // way, overwrite the field.
+            if let Some(props) = accounts.get_mut(&name) {
+                props.metadata = inherited;
+            }
+        }
+
         Ok(crate::elaboration::Journal {
             transactions,
             accounts,
@@ -811,6 +852,18 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
             prices,
         })
     }
+}
+
+/// Yield the colon-separated ancestor prefixes of `name`, root first,
+/// `name` itself last. So `"Income:Salary:Base"` yields
+/// `["Income", "Income:Salary", "Income:Salary:Base"]`.
+fn ancestor_prefixes(name: &str) -> Vec<String> {
+    let mut prefixes = Vec::new();
+    for (i, _) in name.match_indices(':') {
+        prefixes.push(name[..i].to_string());
+    }
+    prefixes.push(name.to_string());
+    prefixes
 }
 
 /// Evaluate tag-level assert/check directives for a set of metadata key-value pairs.

--- a/crates/doppio/src/resolution.rs
+++ b/crates/doppio/src/resolution.rs
@@ -160,6 +160,11 @@ pub struct AccountProperties {
     /// Non-fatal checks: if any fail, a warning is printed to stderr but
     /// elaboration continues.
     pub checks: Vec<ast::BoolExpr>,
+    /// Key-value metadata declared on this account directive only — not
+    /// yet inherited from ancestors. Sources include `; key: value`
+    /// notes on the directive header and `key: value` sub-items inside
+    /// the block. Elaboration denormalises by walking ancestors.
+    pub metadata: BTreeMap<String, String>,
 }
 
 /// A single entry in the resolved journal, paired with its active context.
@@ -580,16 +585,23 @@ impl TryFrom<ast::Journal> for HIR {
                         }
                     }
                 }
-                ast::Entry::Directive(ast::Directive::Account {
-                    name,
-                    notes: _,
-                    items,
-                }) => {
+                ast::Entry::Directive(ast::Directive::Account { name, notes, items }) => {
                     let global_context = result
                         .global_context
                         .account_properties
                         .entry(name.clone())
                         .or_default();
+
+                    // Header-line and trailing `; key: value` notes contribute
+                    // metadata via the same parser that handles transaction
+                    // and posting notes. Bare `:tag1:tag2:` forms and free-
+                    // form comments on accounts are dropped — they have no
+                    // current consumer and the wire schema only carries
+                    // metadata.
+                    let (_tags, header_metadata, _comments) = Self::resolve_metadata(notes);
+                    for (k, v) in header_metadata {
+                        global_context.metadata.insert(k, v);
+                    }
 
                     for item in items {
                         match item {
@@ -607,7 +619,16 @@ impl TryFrom<ast::Journal> for HIR {
                             ast::AccountItem::Check(expr) => {
                                 global_context.checks.push(expr);
                             }
-                            ast::AccountItem::Unknown(_, _) => { /* TODO */ }
+                            ast::AccountItem::Unknown(key, value) => {
+                                // Sub-items without a value (e.g. a bare
+                                // `; type` line) are treated as metadata
+                                // with an empty value, mirroring how
+                                // hledger handles the same syntax.
+                                let val = value.unwrap_or_default();
+                                global_context
+                                    .metadata
+                                    .insert(key.trim().to_string(), val.trim().to_string());
+                            }
                         }
                     }
                 }

--- a/crates/doppio/tests/parity.rs
+++ b/crates/doppio/tests/parity.rs
@@ -362,6 +362,54 @@ fn account_note() {
 }
 
 #[test]
+fn account_metadata() {
+    let j = compile("account_metadata.ledger");
+
+    // Header-line `; type: R` lands as metadata on Income.
+    let income = j.accounts.get("Income").expect("Income declared");
+    assert_eq!(income.metadata.get("type").map(String::as_str), Some("R"));
+
+    // Indented `; type: L` note line lands as metadata on Liabilities.
+    let liab = j.accounts.get("Liabilities").expect("Liabilities declared");
+    assert_eq!(liab.metadata.get("type").map(String::as_str), Some("L"));
+
+    // Indented `key: value` sub-item with no leading semicolon lands as
+    // metadata on Assets.
+    let assets = j.accounts.get("Assets").expect("Assets declared");
+    assert_eq!(assets.metadata.get("type").map(String::as_str), Some("A"));
+
+    // Sub-account inheritance: Income:Salary appears via posting only,
+    // and inherits type:R from Income.
+    let salary = j
+        .accounts
+        .get("Income:Salary")
+        .expect("Income:Salary referenced via posting");
+    assert_eq!(salary.metadata.get("type").map(String::as_str), Some("R"));
+
+    // Liabilities:Visa inherits type:L; Assets:Bank:Checking inherits type:A.
+    let visa = j
+        .accounts
+        .get("Liabilities:Visa")
+        .expect("Liabilities:Visa referenced via posting");
+    assert_eq!(visa.metadata.get("type").map(String::as_str), Some("L"));
+    let checking = j
+        .accounts
+        .get("Assets:Bank:Checking")
+        .expect("Assets:Bank:Checking referenced via posting");
+    assert_eq!(checking.metadata.get("type").map(String::as_str), Some("A"));
+
+    // Closer ancestor wins: Assets:Brokerage redeclares type as I,
+    // overriding Assets's A.
+    let brokerage = j.accounts.get("Assets:Brokerage").expect("declared");
+    assert_eq!(
+        brokerage.metadata.get("type").map(String::as_str),
+        Some("I")
+    );
+    // The directive's `note Schwab #1234` still flows through.
+    assert_eq!(brokerage.note.as_deref(), Some("Schwab #1234"));
+}
+
+#[test]
 fn commodity_default() {
     // After `commodity $ ; default`, a bare `100` should pick up `$`.
     let j = compile("commodity_default.ledger");

--- a/crates/doppio/tests/parity/fixtures/account_metadata.ledger
+++ b/crates/doppio/tests/parity/fixtures/account_metadata.ledger
@@ -1,0 +1,32 @@
+; Account-directive metadata, hledger-compatible. Tracks #168.
+;
+; Two forms exercised:
+;   - header-line `; key: value` note (Income)
+;   - indented `; key: value` note line (Liabilities, Assets, Assets:Brokerage)
+;
+; Both should land in AccountProperties.metadata. The metadata is also
+; inherited by sub-accounts: Income:Salary inherits type:R from Income;
+; Liabilities:Visa inherits type:L from Liabilities;
+; Assets:Bank:Checking inherits type:A from Assets even though it has
+; no directive of its own. Closer ancestors override more distant ones,
+; so Assets:Brokerage's type:I beats Assets's type:A.
+
+account Income  ; type: R
+
+account Liabilities
+    ; type: L
+
+account Assets
+    ; type: A
+
+account Assets:Brokerage
+    ; type: I
+    note Schwab #1234
+
+2024-01-15 Salary
+    Income:Salary                   $-3,000.00
+    Assets:Bank:Checking
+
+2024-01-20 Card charge
+    Liabilities:Visa                  $-50.00
+    Assets:Bank:Checking

--- a/proto/doppio.proto
+++ b/proto/doppio.proto
@@ -306,9 +306,27 @@ message Transaction {
 // Note: `assert` / `check` expressions declared on accounts are evaluated
 // during elaboration and are not persisted — they are a compile-time check,
 // not runtime data.
+//
+// Metadata is extracted from `; key: value` notes on the account
+// directive (header line or indented note lines) and from `key: value`
+// items in the directive body. The map is **denormalised by inheritance**:
+// an account's metadata at elaboration time includes every key declared
+// on it OR on any of its colon-separated ancestors, with closer
+// ancestors winning over distant ones. So a directive like
+//     account Income
+//         type: R
+// makes `Journal.accounts["Income:Salary"].metadata["type"] = "R"` even
+// when `Income:Salary` itself has no directive.
+//
+// The schema deliberately stays generic — meaning is up to the
+// consumer. `type:` is the only key carried by convention (see
+// hledger's account-type tag) but no other key is reserved.
 message AccountProperties {
   // Free-form note from the `note` sub-directive.
   optional string note = 1;
+  // Inherited key-value metadata. See message-level comment for
+  // extraction and inheritance semantics.
+  map<string, string> metadata = 2;
 }
 
 // Display and market-data properties of a commodity declared with a

--- a/web/src/lib/dop/loader.ts
+++ b/web/src/lib/dop/loader.ts
@@ -106,7 +106,12 @@ export function readDop(buf: Uint8Array): Journal {
 function convertJournal(j: WireJournal): Journal {
   return {
     transactions: j.transactions.map(convertTransaction),
-    accounts: { ...j.accounts },
+    accounts: Object.fromEntries(
+      Object.entries(j.accounts).map(([name, a]) => [
+        name,
+        { note: a.note, metadata: { ...a.metadata } },
+      ]),
+    ),
     commodities: Object.fromEntries(
       Object.entries(j.commodities).map(([name, c]) => [
         name,

--- a/web/src/lib/dop/types.ts
+++ b/web/src/lib/dop/types.ts
@@ -52,6 +52,11 @@ export interface Transaction {
 
 export interface AccountProperties {
   note?: string;
+  // Inherited key-value metadata. The compiler denormalises by walking
+  // colon-separated ancestors at elaboration time, so consumers see a
+  // fully-resolved map per account and never need to do the inheritance
+  // walk themselves.
+  metadata: Record<string, string>;
 }
 
 export interface CommodityProperties {

--- a/web/src/lib/views/accountType.test.ts
+++ b/web/src/lib/views/accountType.test.ts
@@ -1,31 +1,64 @@
 import { describe, it, expect } from "vitest";
 import { inferAccountType } from "./accountType.js";
+import type { AccountProperties } from "@/lib/dop";
 
-describe("inferAccountType", () => {
+const noProps: undefined = undefined;
+function withType(value: string): AccountProperties {
+  return { metadata: { type: value } };
+}
+
+describe("inferAccountType — top-level heuristic (no explicit metadata)", () => {
   it("recognises the four canonical top-level segments", () => {
-    expect(inferAccountType("Income:Consulting")).toBe("income");
-    expect(inferAccountType("Assets:Bank:Checking")).toBe("assets");
-    expect(inferAccountType("Liabilities:CreditCard")).toBe("liabilities");
-    expect(inferAccountType("Equity:OpeningBalances")).toBe("equity");
+    expect(inferAccountType("Income:Consulting", noProps)).toBe("income");
+    expect(inferAccountType("Assets:Bank:Checking", noProps)).toBe("assets");
+    expect(inferAccountType("Liabilities:CreditCard", noProps)).toBe("liabilities");
+    expect(inferAccountType("Equity:OpeningBalances", noProps)).toBe("equity");
   });
 
   it("matches on the top-level segment only, not sub-segments", () => {
-    expect(inferAccountType("Investments:Income")).toBeNull();
-    expect(inferAccountType("Holdings:Assets")).toBeNull();
+    expect(inferAccountType("Investments:Income", noProps)).toBeNull();
+    expect(inferAccountType("Holdings:Assets", noProps)).toBeNull();
   });
 
   it("returns null for top-level segments outside the heuristic table", () => {
-    expect(inferAccountType("Expenses:Rent")).toBeNull();
-    expect(inferAccountType("MyMadeUpTop:Foo")).toBeNull();
+    expect(inferAccountType("Expenses:Rent", noProps)).toBeNull();
+    expect(inferAccountType("MyMadeUpTop:Foo", noProps)).toBeNull();
   });
 
   it("is case-sensitive — the canonical names use TitleCase", () => {
-    expect(inferAccountType("income:Salary")).toBeNull();
-    expect(inferAccountType("ASSETS:Bank")).toBeNull();
+    expect(inferAccountType("income:Salary", noProps)).toBeNull();
+    expect(inferAccountType("ASSETS:Bank", noProps)).toBeNull();
   });
 
   it("handles accounts with no colon (top-level only)", () => {
-    expect(inferAccountType("Income")).toBe("income");
-    expect(inferAccountType("Equity")).toBe("equity");
+    expect(inferAccountType("Income", noProps)).toBe("income");
+    expect(inferAccountType("Equity", noProps)).toBe("equity");
+  });
+});
+
+describe("inferAccountType — explicit `type:` metadata", () => {
+  it("accepts hledger one-letter codes", () => {
+    expect(inferAccountType("Whatever", withType("A"))).toBe("assets");
+    expect(inferAccountType("Whatever", withType("L"))).toBe("liabilities");
+    expect(inferAccountType("Whatever", withType("E"))).toBe("equity");
+    expect(inferAccountType("Whatever", withType("R"))).toBe("income");
+  });
+
+  it("accepts spelled-out forms case-insensitively", () => {
+    expect(inferAccountType("Whatever", withType("Asset"))).toBe("assets");
+    expect(inferAccountType("Whatever", withType("LIABILITIES"))).toBe("liabilities");
+    expect(inferAccountType("Whatever", withType(" income "))).toBe("income");
+    expect(inferAccountType("Whatever", withType("Revenue"))).toBe("income");
+  });
+
+  it("overrides the heuristic when both apply", () => {
+    // Top-level is "Income" (heuristic would say income), but explicit
+    // type:A says it's actually an asset. Explicit wins.
+    expect(inferAccountType("Income:Holdings", withType("A"))).toBe("assets");
+  });
+
+  it("falls back to the heuristic when the value is unrecognised", () => {
+    expect(inferAccountType("Income:Salary", withType("garbage"))).toBe("income");
+    expect(inferAccountType("Whatever", withType(""))).toBeNull();
   });
 });

--- a/web/src/lib/views/accountType.ts
+++ b/web/src/lib/views/accountType.ts
@@ -1,11 +1,15 @@
-// Heuristic mapping of an account's top-level segment to one of the
-// four canonical PTA account types. Anything outside this table
-// (Expenses, Investments, freeform tops) is treated as an unknown type.
+// Account-type classification. Two layers:
 //
-// Future work: an explicit `; type: X` tag on `account` directives
-// (mirroring hledger's convention) should override this heuristic. That
-// requires plumbing structured metadata through doppio's elaborator —
-// tracked as #168.
+//   1. An explicit `; type: <letter>` (or `; type: <name>`) tag on the
+//      `account` directive. doppio's elaborator denormalises this
+//      across the colon-separated hierarchy, so a sub-account whose
+//      ancestor declared `; type: A` reports the same metadata.
+//   2. A four-name fallback heuristic on the top-level segment for
+//      journals that don't declare types.
+//
+// Layer (1) wins when present. The heuristic is the safety net.
+
+import type { AccountProperties } from "@/lib/dop";
 
 export type AccountType = "income" | "assets" | "liabilities" | "equity";
 
@@ -16,12 +20,47 @@ const TOP_LEVEL_TYPE: Record<string, AccountType> = {
   Equity: "equity",
 };
 
+// hledger uses one-letter codes (A/L/E/R/X) and full words; doppio
+// itself doesn't assign meaning to the value of `type:` — the
+// dashboard interprets it. We accept the codes hledger documents plus
+// the spelled-out forms (case-insensitive) so a user reading the
+// hledger manual gets the result they expect.
+const TYPE_TAG_VALUES: Record<string, AccountType> = {
+  a: "assets",
+  asset: "assets",
+  assets: "assets",
+  l: "liabilities",
+  liability: "liabilities",
+  liabilities: "liabilities",
+  e: "equity",
+  equity: "equity",
+  r: "income",
+  revenue: "income",
+  revenues: "income",
+  income: "income",
+};
+
+function typeFromTag(value: string | undefined): AccountType | null {
+  if (!value) return null;
+  return TYPE_TAG_VALUES[value.trim().toLowerCase()] ?? null;
+}
+
 /**
- * Infer the canonical account type from the first colon-separated
- * segment of the account name. Returns null if the segment is not in
- * the heuristic table — callers should treat that as unknown.
+ * Resolve an account's type from an explicit `; type:` tag on its
+ * AccountProperties (or an ancestor's, since the compiler denormalises
+ * the metadata) — falling back to the top-level-segment heuristic when
+ * no tag is present.
+ *
+ * Returns null when neither layer recognises the account, leaving the
+ * caller to decide on a default behaviour (typically: don't flip
+ * signs; render as-is).
  */
-export function inferAccountType(account: string): AccountType | null {
+export function inferAccountType(
+  account: string,
+  properties: AccountProperties | undefined,
+): AccountType | null {
+  const explicit = typeFromTag(properties?.metadata.type);
+  if (explicit) return explicit;
   const top = account.split(":", 1)[0];
   if (top === undefined) return null;
   return TOP_LEVEL_TYPE[top] ?? null;

--- a/web/src/lib/views/period.ts
+++ b/web/src/lib/views/period.ts
@@ -119,7 +119,7 @@ export function incomeExpenseByMonth(
       if (p.kind === "virtualUnbalanced") continue;
       const v = getCommodityValue(p.amount.byCommodity, PRIMARY_COMMODITY);
       if (v.isZero()) continue;
-      const type = inferAccountType(p.account);
+      const type = inferAccountType(p.account, journal.accounts[p.account]);
       if (type === "income") {
         // Income is credit-normal; flip to read positive.
         b.income = b.income.plus(v.neg());
@@ -199,7 +199,7 @@ export function netWorthByMonth(
         if (p.kind === "virtualUnbalanced") continue;
         const v = getCommodityValue(p.amount.byCommodity, PRIMARY_COMMODITY);
         if (v.isZero()) continue;
-        const type = inferAccountType(p.account);
+        const type = inferAccountType(p.account, journal.accounts[p.account]);
         if (type === "assets") {
           assets = assets.plus(v);
         } else if (type === "liabilities") {


### PR DESCRIPTION
## Summary

Lands the schema-generic mechanism that lets explicit `; type:` tags on `account` directives override the dashboard's four-name account-type heuristic. Per #168 design discussion the proto field is **not** a typed enum — it's a generic `map<string, string>` so other consumers can carry whatever metadata they like (\`subtype:\`, \`category:\`, etc.) without further schema bumps.

Closes #168.

## Schema change

Adds a single new field to \`proto::AccountProperties\`:

\`\`\`proto
map<string, string> metadata = 2;
\`\`\`

Additive under proto3 evolution: old readers see no metadata; new readers populate from the wire if present, default empty map otherwise. The committed \`sample.dop\` is byte-identical because no account in the demo journal declares a tag.

## Pipeline

| Stage | Behaviour |
|---|---|
| Frontend (ledger + hledger) | unchanged — both already collect \`; key: value\` header notes and indented note lines into \`Directive::Account.notes\`. \`AccountItem::Unknown(k, v)\` is now consumed instead of being a TODO. |
| Resolver | feeds the directive's notes through the existing \`resolve_metadata\` helper (same one used for transactions/postings). Header notes + indented \`;\` notes + bare sub-items all merge into \`AccountProperties.metadata\` on the resolution side. |
| Elaborator | **denormalises by inheritance.** For every account in the final journal — declared OR referenced only by postings — walks colon-separated ancestors root→leaf and merges metadata with closer ancestors winning. Consumers (CLI, JS reader, downstream Rust) see a fully-resolved per-account map and never need the walk themselves. |
| JS reader | maps \`metadata\` straight through into the public \`Journal\` type. |
| Web heuristic | \`inferAccountType(account, properties)\` now checks \`properties?.metadata.type\` first, recognising hledger's one-letter codes (A/L/E/R) and the spelled-out forms (Asset, Liability, Equity, Income, Revenue) case-insensitively. Falls back to the four-name top-level heuristic when no tag is present. |

## What we deliberately did NOT do (per the design discussion)

- **No typed \`AccountType\` enum.** The proto field stays free-form. \`type\` is the only key carried by convention; doppio assigns no meaning to its value at the format level.
- **No grammar extension for ledger-style \`type: A\` indented sub-items.** Sticking with hledger compatibility — the canonical \`; type: A\` note form works in both frontends today via the existing notes path.
- **Inheritance happens at compile time, not query time.** Each account's metadata in the \`.dop\` is fully resolved.

## Tests

Rust:
- New parity fixture \`account_metadata.ledger\` exercises header-line + indented note forms, sub-account inheritance from declared ancestors (Income → Income:Salary), inheritance from declared ancestors that have no other directive than the type tag (Liabilities → Liabilities:Visa, Assets → Assets:Bank:Checking), and the closer-wins precedence rule (Assets:Brokerage's type:I overrides Assets's type:A).
- All 230+ Rust tests still green; \`cargo fmt --check\` and \`cargo clippy --workspace -- -D warnings\` clean.

Web:
- 4 new vitest specs in \`accountType.test.ts\` covering: hledger codes, case-insensitive spelled-out forms, override-the-heuristic precedence, and unrecognised-value fallback. 58 web tests total.
- Bundle unchanged at 382 KB / 133 KB gzipped.

## Test plan

- [x] \`cargo fmt --all --check\`
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo test --workspace\`
- [x] \`cargo build --target wasm32-unknown-unknown -p doppio --lib\` (sanity, no schema-side wasm deps changed)
- [x] \`npm test\` (web)
- [x] \`npm run build\` (web)