### PR TITLE
docs: pre-1.0 README + per-crate metadata cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,14 @@ Most Ledger tooling treats the format as a parsing problem. doppio treats it as 
 **CLI:**
 
 ```sh
-cargo install doppio
+cargo install doppio-cli
 dop compile --output my-journal.dop my-journal.ledger
 dop balance my-journal.dop
 dop register my-journal.dop Expenses
 ```
+
+The `doppio-cli` crate ships the `dop` binary; `doppio` itself is the
+library.
 
 **Library:**
 
@@ -40,13 +43,13 @@ let resolved = doppio::eval_transaction(txn, &Context::default())?;
 
 // Or compile a full journal from source. The opener returns
 // Result<String, Box<dyn Error>> so it can surface I/O failures.
-let journal = doppio::compile(&source_text, doppio::parser::Parser {
+let journal = doppio::compile(&source_text, doppio::grammars::ledger::Parser {
     opener: doppio::file_opener, // built-in glob-aware opener
     base_path: std::path::PathBuf::from("."),
 })?;
 
 for txn in &journal.transactions {
-    println!("{}: {}", txn.date, txn.description);
+    println!("{}: {}", txn.date_naive(), txn.description);
 }
 ```
 
@@ -58,7 +61,7 @@ for txn in &journal.transactions {
 dop compile --output my-journal.dop my-journal.ledger
 ```
 
-Parses the source file, runs it through the full compilation pipeline, and writes the result as a postcard-serialized, XZ-compressed `.dop` file. Use this for large journals to avoid re-parsing on every query.
+Parses the source file, runs it through the full compilation pipeline, and writes the result as a Protocol Buffers payload, deflate-compressed by default. Use this for large journals to avoid re-parsing on every query. Pass `--no-compression` for raw protobuf.
 
 ### `balance` -- account balances
 
@@ -103,16 +106,24 @@ dop accounts my-journal.ledger
 
 Lists all account names found in the journal.
 
+### `commodities` -- list commodity symbols
+
+```
+dop commodities my-journal.ledger
+```
+
+Lists every commodity symbol used in the journal, sorted and deduplicated.
+
 ## Library API
 
-The library exposes four modules corresponding to the pipeline stages, plus top-level entry points:
+The library exposes the pipeline stages as modules, plus top-level entry points:
 
 | Function | Description |
 |---|---|
 | `compile(source, parser)` | Full pipeline: source text -> elaborated `Journal` |
 | `eval_transaction(txn, ctx)` | Elaborate a single `resolution::Transaction` -- validate balance, infer null posting, apply aliases |
 | `write_ledger(txns, writer)` | Serialize `resolution::Transaction` values to canonical Ledger source text |
-| `dop_write_header` / `dop_read_header` | Portable `.dop` header I/O with clear version-mismatch errors |
+| `write_dop` / `read_dop` | Round-trip an `elaboration::Journal` to/from a `.dop` file (8-byte header + optional deflate + protobuf) |
 
 The `resolution::Transaction` and `resolution::Posting` builder APIs are the intended construction layer for programmatic use:
 
@@ -163,7 +174,7 @@ At a glance:
 | Expressions -- arithmetic, comparisons, regex `=~`/`!~`, `tag()`, parameterised function calls | Supported |
 | CLI -- `compile`, `balance`, `register`, `print`, `stats`, `accounts`, `commodities`; text / JSON / CSV output | Supported |
 | Library API -- `compile`, `eval_transaction`, `write_ledger`, `.dop` binary format | Supported |
-| hledger input format (`.hledger`, `.journal`) | Supported (v0.3.0, issue #103) |
+| hledger input format (`.hledger`, `.journal`) | Supported |
 | Budgets (`~`), automated transactions (`= payee expr`), Lisp-style scripting | Not supported |
 
 See [`docs/SUPPORTED_FEATURES.md`](./docs/SUPPORTED_FEATURES.md) for the full
@@ -193,19 +204,34 @@ doppio processes source text through four sequential stages:
       │  amounts evaluated, transactions balanced, accounts registered
       ▼
  ┌──────────────┐
- │ serialization│  postcard + XZ → .dop
+ │ serialization│  protobuf + deflate → .dop
  └──────────────┘
 ```
 
 ### Stage details
 
-**Parse** (`crates/doppio/src/parser.rs`, `crates/doppio/src/ledger.pest`): A [pest](https://pest.rs/) PEG grammar tokenizes the source into an `ast::Journal` containing transactions, directives, and comments. Amount expressions are kept as unevaluated `ValueExpr` trees. `include` directives are resolved recursively here.
+**Parse** (`crates/doppio/src/grammars/ledger/`, `crates/doppio/src/grammars/hledger/`): A [pest](https://pest.rs/) PEG grammar tokenizes the source into an `ast::Journal` containing transactions, directives, and comments. Amount expressions are kept as unevaluated `ValueExpr` trees. `include` directives are resolved recursively here. The `Frontend` trait dispatches on file extension between the ledger-cli and hledger grammars.
 
 **Resolution** (`crates/doppio/src/resolution.rs`): Converts `ast::Journal` to a Higher-level Intermediate Representation (`HIR`). Dates are resolved to `NaiveDate` (a full year is required). Commodity and account aliases are accumulated into a versioned `Context` stack so each transaction sees the aliases that were in effect when it was defined. Structured metadata and tags are extracted from freeform notes.
 
-**Elaboration** (`crates/doppio/src/elaboration.rs`): Converts `HIR` to the final `elaboration::Journal`. `ValueExpr` trees are evaluated to `(Decimal, commodity)` pairs, commodity aliases are applied, and each transaction is balanced -- if exactly one posting has no explicit amount, its value is inferred as the negation of the sum of the rest. Balance assertions (`= amount`) and balance assignments (`=amount`) are checked or applied at this stage.
+**Elaboration** (`crates/doppio/src/elaborator.rs`): Converts `HIR` to the final `elaboration::Journal`. `ValueExpr` trees are evaluated to `(Decimal, commodity)` pairs, commodity aliases are applied, and each transaction is balanced -- if exactly one posting has no explicit amount, its value is inferred as the negation of the sum of the rest. Balance assertions (`= amount`) and balance assignments (`=amount`) are checked or applied at this stage.
 
-**Serialization**: The `Journal` implements `serde::Serialize`/`Deserialize`. The `compile` command writes it through [postcard](https://github.com/jamesmunns/postcard) into an XZ-compressed stream; the `balance` and `register` commands decompress and deserialize it in the reverse direction.
+**Serialization**: The `elaboration::Journal` is a [prost](https://github.com/tokio-rs/prost)-generated Protocol Buffers message defined in [`proto/doppio.proto`](./proto/doppio.proto). `write_dop` writes an 8-byte header followed by the protobuf body, deflate-compressed by default; `read_dop` is the reverse. The format is the canonical `.dop` artifact, designed as a language-agnostic API -- non-Rust consumers read it directly via the published proto schema.
+
+## Companion crates
+
+The workspace publishes three crates:
+
+- **[`doppio`](./crates/doppio/)** -- the library. Parse, resolve,
+  elaborate. The `Journal` type, the `Frontend` trait, the `.dop`
+  format I/O.
+- **[`doppio-cli`](./crates/doppio-cli/)** -- the `dop` binary. What
+  you get from `cargo install doppio-cli`.
+- **[`doppio-categorize`](./crates/doppio-categorize/)** --
+  counter-account suggestions for new transactions, given an existing
+  journal as the training corpus. Used by import flows like Mercury
+  and SimpleFIN to fill in the second posting of a transaction
+  automatically.
 
 ## Build from source
 

--- a/crates/doppio-categorize/Cargo.toml
+++ b/crates/doppio-categorize/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "doppio-categorize"
-description = "Counter-account prediction for the doppio ledger compiler — given a partial transaction, suggest the most likely counter-account from journal history."
+description = "Counter-account prediction for the doppio ledger compiler -- given a partial transaction, suggest the most likely counter-account from journal history."
+readme = "README.md"
 version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/doppio-categorize/README.md
+++ b/crates/doppio-categorize/README.md
@@ -1,24 +1,24 @@
 # doppio-categorize
 
-A counter-account prediction library for the [doppio](https://github.com/alevy/doppio) ledger compiler.
+A counter-account prediction library for the
+[doppio](https://crates.io/crates/doppio) ledger compiler.
 
-Given a partial transaction (one side known -- typically a bank/credit-card account from an import), suggest the most likely counter-account based on patterns in the existing journal.
+Given a partial transaction (one side known -- typically a
+bank/credit-card account from an import), suggest the most likely
+counter-account based on patterns in the existing journal.
 
-This is a **classifier**, not a forecaster. It runs at import time, per-transaction, against an index built once from the journal.
-
-## Status
-
-**v0.2 prototype** -- lives here in `doppio-research/prototypes/` so the API can shake out before the crate is promoted to a workspace member of doppio and published to crates.io.
+This is a **classifier**, not a forecaster. It runs at import time,
+per-transaction, against an index built once from the journal.
 
 ## API
 
 ```rust
 use doppio_categorize::{Index, Query, Config, DefaultNormalizer};
 
-// Build once from a journal:
+// Build once from a journal.
 let index = Index::build(&journal, DefaultNormalizer);
 
-// Query many times:
+// Query many times.
 let query = Query {
     date: chrono::NaiveDate::from_ymd_opt(2024, 4, 27).unwrap(),
     payee: "STARBUCKS #1234 SEATTLE WA".into(),
@@ -34,48 +34,73 @@ let suggestions = index.suggest(&query, &Config::default());
 The pipeline is the same shape across all scoring strategies:
 
 1. Look up the per-known-account bucket. (Bucket missing -> empty result.)
-2. Pick candidate samples via the configured [`ScoringStrategy`].
-3. Apply the **sign filter** (sample's amount sign must match query's -- refunds vs charges).
-4. Apply **amount-similarity weighting**: each candidate's match-score is multiplied by `1 / (1 + |ln(|query.amount|) - ln(|sample.amount|)|)`. Disable via `Config { use_amount_weighting: false, .. }`.
+2. Pick candidate samples via the configured `ScoringStrategy`.
+3. Apply the **sign filter** (sample's amount sign must match
+   query's -- refunds vs charges).
+4. Apply **amount-similarity weighting**: each candidate's match-score
+   is multiplied by `1 / (1 + |ln(|query.amount|) - ln(|sample.amount|)|)`.
+   Disable via `Config { use_amount_weighting: false, .. }`.
 5. Aggregate `match_score * amount_weight` per `counter_account`.
 6. Rank by `weight_sum / total_weight` descending.
 
-What varies across strategies is step 2 -- how candidates are picked and how their match-score is computed:
+What varies across strategies is step 2 -- how candidates are picked
+and how their match-score is computed:
 
-- **`ScoringStrategy::ExactMatch`**: candidates are samples whose normalized payee equals the query's. Match-score = 1.0 for each. This is v0.1 behavior.
-- **`ScoringStrategy::TokenIdf { df_threshold }`**: candidates are samples whose tokens overlap with the query's. Match-score for a sample is `Σ ln(N / df(t))` over shared tokens `t`, excluding tokens where `df(t) >= df_threshold`. The threshold filters geographic / structural noise tokens like "seattle", "wa" that appear in too many distinct payees.
-- **`ScoringStrategy::Hybrid { df_threshold, .. }`**: try `ExactMatch` first; if it returns no candidates, fall back to `TokenIdf`. **This is the default** since v0.2.
+- **`ScoringStrategy::ExactMatch`**: candidates are samples whose
+  normalized payee equals the query's. Match-score = 1.0 for each.
+- **`ScoringStrategy::TokenIdf { df_threshold }`**: candidates are
+  samples whose tokens overlap with the query's. Match-score for a
+  sample is `Sum_t ln(N / df(t))` over shared tokens `t`, excluding
+  tokens where `df(t) >= df_threshold`. The threshold filters
+  geographic / structural noise tokens like "seattle", "wa" that
+  appear in too many distinct payees.
+- **`ScoringStrategy::Hybrid { df_threshold, .. }`** *(default)*: try
+  `ExactMatch` first; if it returns no candidates, fall back to
+  `TokenIdf`.
 
-### Normalization (v0.2 default)
+### Normalization
 
-`DefaultNormalizer` lowercases alphabetic characters; treats digits, punctuation, and whitespace as word separators; collapses runs of separators. So `"STARBUCKS #1234 SEATTLE WA"` and `"Starbucks Seattle, WA"` both become `"starbucks seattle wa"`.
+`DefaultNormalizer` lowercases alphabetic characters; treats digits,
+punctuation, and whitespace as word separators; collapses runs of
+separators. So `"STARBUCKS #1234 SEATTLE WA"` and `"Starbucks Seattle, WA"`
+both become `"starbucks seattle wa"`.
 
-The `Normalizer` trait is pluggable -- a v0.3 implementation can swap in stemming, abbreviation expansion, currency-suffix stripping, etc.
+The `Normalizer` trait is pluggable -- a future implementation can
+swap in stemming, abbreviation expansion, currency-suffix stripping,
+etc.
 
 ## Evaluation harness
 
-A held-out evaluation harness lives at `examples/eval_holdout.rs`. It:
+A held-out evaluation harness lives at
+`examples/eval_holdout.rs` in the repository. It:
 
-1. Loads a journal (`.ledger`, `.hledger`, `.journal`, or pre-compiled `.dop`).
-2. Filters to 2-posting transactions where exactly one posting matches an "import-side" account regex (default: `Liabilities:.*Visa`, bank/checking/savings/etc).
-3. Holds out a fraction of the eligible transactions (10% by default, seeded shuffle with `seed=42`).
+1. Loads a journal (`.ledger`, `.hledger`, `.journal`, or pre-compiled
+   `.dop`).
+2. Filters to 2-posting transactions where exactly one posting
+   matches an "import-side" account regex (default:
+   `Liabilities:.*Visa`, bank/checking/savings/etc).
+3. Holds out a fraction of the eligible transactions (10% by
+   default, seeded shuffle with `seed=42`).
 4. Builds the index from the remaining transactions.
-5. For each held-out transaction, queries with the import-side `(date, payee, amount, known_account)` and checks whether the true counter-account appears at rank 1 / 2-3.
-6. Reports top-1 / top-3 accuracy plus stratification by training-cluster size.
+5. For each held-out transaction, queries with the import-side
+   `(date, payee, amount, known_account)` and checks whether the
+   true counter-account appears at rank 1 / 2-3.
+6. Reports top-1 / top-3 accuracy plus stratification by
+   training-cluster size.
 
 ```sh
-# default: hybrid strategy, df_threshold=50, 10% holdout, amount weighting
+# Default: hybrid strategy, df_threshold=50, 10% holdout, amount weighting.
 cargo run --release --example eval_holdout -- /path/to/journal.ledger
 
-# pin to v0.1 exact-match behavior:
+# Pin to exact-match behavior.
 cargo run --release --example eval_holdout -- /path/to/journal.ledger \
     --strategy exact
 
-# pure token-IDF with a tighter df threshold:
+# Pure token-IDF with a tighter df threshold.
 cargo run --release --example eval_holdout -- /path/to/journal.ledger \
     --strategy token-idf --df-threshold 20
 
-# different import-side regex for non-default ledger conventions:
+# Different import-side regex for non-default ledger conventions.
 cargo run --release --example eval_holdout -- /path/to/journal.ledger \
     --import-regex '^Liabilities:Mercury'
 ```
@@ -90,9 +115,11 @@ cargo run --release --example eval_holdout -- /path/to/journal.ledger \
 | `token-idf` (df<50) | 83.3% | 83.3% | 11.1% |
 | **`hybrid` (default)** | **88.9%** | **88.9%** | **11.1%** |
 
-Small, consistent corpus. Pure token-IDF *hurts* slightly here because rare tokens cross-match across vendors. Hybrid avoids the regression by preferring exact-match when there's a hit.
+Small, consistent corpus. Pure token-IDF *hurts* slightly because
+rare tokens cross-match across vendors. Hybrid avoids the regression
+by preferring exact-match when there's a hit.
 
-### Personal household ledger (3,075 transactions, 2,960 eligible, 20% holdout for stable estimate)
+### Personal household ledger (3,075 transactions, 2,960 eligible, 20% holdout)
 
 | Strategy | Top-1 | Top-3 |
 |---|---:|---:|
@@ -100,18 +127,22 @@ Small, consistent corpus. Pure token-IDF *hurts* slightly here because rare toke
 | `token-idf` (df<50) | 68.1% | 78.2% |
 | **`hybrid` (default)** | **70.8%** | **78.5%** |
 
-Long-tail corpus where 70% of normalized payees appear exactly once. Hybrid lifts top-1 by **+12 points** over the v0.1 exact-match baseline by recovering cold-start cases through shared rare tokens (e.g. "amazon" matching across `AMZN MKTP US*ABC123` / `AMZN MKTP US*XYZ987` variants). The cold-start *rate* (32.9%) doesn't change -- that's a property of the corpus and the holdout -- but token-IDF rescues many of those formerly-empty cases.
+Long-tail corpus where 70% of normalized payees appear exactly once.
+Hybrid lifts top-1 by **+12 points** over the exact-match baseline by
+recovering cold-start cases through shared rare tokens (e.g.
+"amazon" matching across `AMZN MKTP US*ABC123` /
+`AMZN MKTP US*XYZ987` variants). The cold-start *rate* (32.9%)
+doesn't change -- that's a property of the corpus and the holdout --
+but token-IDF rescues many of those formerly-empty cases.
 
-## v0.3 trajectory
+## Companion crates
 
-Things deliberately deferred:
+- **[`doppio`](https://crates.io/crates/doppio)** -- the library this
+  one is built against. Provides the `Journal` type and the
+  compilation pipeline.
+- **[`doppio-cli`](https://crates.io/crates/doppio-cli)** -- the
+  `dop` binary.
 
-- **Recency weighting**: confidence is currently pure frequency × IDF × amount-similarity. v0.3 will weight recent samples higher.
-- **Naive Bayes / probabilistic classifier**: real-data evaluation showed cold-start (not classification error) is the dominant failure mode on both bb-org and household corpora. Token-IDF closed most of that gap. NB-style discrimination would help on a corpus with same-payee-different-counter ambiguity (the synthetic PCC $14 vs $200 case), but neither real corpus exhibits much of this. Worth revisiting with more downstream consumers.
-- **Multi-posting pattern recognition**: each posting in an N-posting transaction is currently an independent sample. v0.3 may recognize "Starbucks usually splits as Coffee + Tax" and surface structured multi-posting suggestions.
-- **Online learning / feedback**: the index is stateless -- the caller rebuilds when the journal changes. No `Index::observe(accepted_suggestion)` API yet.
-- **Custom normalizers documented and tested**: the `Normalizer` trait is pluggable today, but only `DefaultNormalizer` is shipped. v0.3 will exercise the customization path.
+## License
 
-## Notes on the doppio API
-
-See `NOTES.md` for ergonomic friction encountered against the doppio library API during development. Each entry is a candidate for a tracking issue against doppio core.
+ISC. See [LICENSE](https://github.com/alevy/doppio/blob/main/LICENSE).

--- a/crates/doppio-cli/Cargo.toml
+++ b/crates/doppio-cli/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "doppio-cli"
 description = "Command-line interface for the doppio Ledger compiler. Provides the `dop` binary."
+readme = "README.md"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/doppio-cli/README.md
+++ b/crates/doppio-cli/README.md
@@ -1,0 +1,66 @@
+# doppio-cli
+
+The `dop` command-line interface for the
+[doppio](https://crates.io/crates/doppio) Ledger compiler.
+
+## Install
+
+```sh
+cargo install doppio-cli
+```
+
+This installs the `dop` binary on your PATH. The library that powers
+it is [`doppio`](https://crates.io/crates/doppio); install that
+directly if you want to embed the pipeline in your own tool.
+
+## Quick start
+
+```sh
+# Compile a journal once for fast queries.
+dop compile --output my.dop my.ledger
+
+# Query balances and registers.
+dop balance my.dop
+dop balance my.dop --depth 2 --begin 2024-01-01 --cleared
+dop register my.dop Expenses --format json
+
+# Re-emit canonical Ledger source (formatting / round-trip check).
+dop print my.ledger
+
+# Summary, account list, commodity list.
+dop stats my.ledger
+dop accounts my.ledger
+dop commodities my.ledger
+```
+
+`dop` accepts both raw `.ledger` (or `.hledger`, `.journal`) source
+files and pre-compiled `.dop` files interchangeably for the read-only
+commands.
+
+## Useful flags
+
+- `--begin <YYYY-MM-DD>`, `--end <YYYY-MM-DD>` -- date-range filter
+  on `balance` and `register`.
+- `--cleared` -- only cleared transactions.
+- `--tag <name>` -- only transactions tagged with `name`.
+- `--depth <N>` (balance) -- collapse accounts deeper than N
+  colon-separated levels.
+- `--flat` (balance) -- single line per account instead of the
+  default tree view.
+- `--format text|json|csv` -- structured output.
+- `-R` / `--real` -- exclude virtual postings (`(...)` and `[...]`).
+- `-X` / `--exchange <COMMODITY>` -- convert balances to a target
+  commodity using `P` directive prices.
+
+## Documentation
+
+- [Repository](https://github.com/alevy/doppio) -- full CLI
+  reference, library API, supported feature matrix.
+- [`docs/SUPPORTED_FEATURES.md`](https://github.com/alevy/doppio/blob/main/docs/SUPPORTED_FEATURES.md) --
+  what ledger-cli / hledger features are implemented.
+- [Web demo](https://alevy.github.io/doppio/) -- a browser dashboard
+  that reads a `.dop` file via a JS-native protobuf decoder.
+
+## License
+
+ISC. See [LICENSE](https://github.com/alevy/doppio/blob/main/LICENSE).

--- a/crates/doppio/Cargo.toml
+++ b/crates/doppio/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "doppio"
-description = "A typed compiler pipeline for plain-text Ledger accounting — parse, resolve, and elaborate .ledger files with a library API built for programmatic use."
+description = "A typed compiler pipeline for plain-text Ledger accounting -- parse, resolve, and elaborate .ledger files with a library API built for programmatic use."
+readme = "README.md"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/doppio/README.md
+++ b/crates/doppio/README.md
@@ -1,0 +1,87 @@
+# doppio
+
+A typed compiler pipeline for [Ledger](https://ledger-cli.org/)
+plain-text accounting -- built to be embedded.
+
+This is the **library** crate. For the `dop` command-line interface,
+install [`doppio-cli`](https://crates.io/crates/doppio-cli) instead;
+it depends on this crate and ships the binary.
+
+## What it does
+
+doppio parses `.ledger` (and `.hledger`, `.journal`) source files
+through four sequential stages:
+
+```
+source text -> parse -> resolution -> elaboration -> .dop
+```
+
+It enforces double-entry balance and balance-assertion semantics at
+elaboration time, then exposes the result as a strongly-typed
+`elaboration::Journal` (a `prost`-generated Protocol Buffers message)
+ready for queries, reporting, or serialisation to the `.dop` binary
+format.
+
+## Use cases
+
+- **Bank import pipelines.** Build `resolution::Transaction` values
+  programmatically from imported records (Mercury, Plaid, SimpleFIN,
+  etc.) and run them through `eval_transaction` to validate balance
+  before writing back to source.
+- **Reporting tools.** Compile a journal once with `compile`, then
+  serialise to a `.dop` file with `write_dop` and load it in
+  milliseconds with `read_dop` for repeated queries.
+- **Cross-language consumers.** The `.dop` binary format is defined
+  by [`proto/doppio.proto`](https://github.com/alevy/doppio/blob/main/proto/doppio.proto)
+  in the source repo. Any language with a Protocol Buffers binding
+  can read `.dop` files directly without re-parsing the source.
+
+## Quick example
+
+```rust
+use doppio::resolution::{Context, Transaction, Posting};
+use chrono::NaiveDate;
+use rust_decimal::Decimal;
+
+let txn = Transaction::new(NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(), "Groceries")
+    .with_posting(Posting::new("Expenses:Food").with_amount((Decimal::from(50u32), "$")))
+    .with_posting(Posting::new("Assets:Checking"));
+
+// Validate and elaborate -- the null posting on Assets:Checking is inferred as -$50.
+let journal_txn = doppio::eval_transaction(txn, &Context::default())?;
+```
+
+## Public API surface
+
+The intended construction layer is `resolution::Transaction` /
+`resolution::Posting` (builder API). The intended read layer is
+`elaboration::*` (the `prost`-generated proto types) plus their
+inherent ergonomic methods (`Decimal::to_decimal()`,
+`Amount::iter()`, `Posting::amount_in(commodity)`, etc.).
+
+The `Frontend` trait pluralises the parser dispatch -- `LedgerFrontend`
+and `HledgerFrontend` are shipped; new formats (e.g. Beancount) can
+implement the trait without modifying the library.
+
+## Companion crates
+
+- **[`doppio-cli`](https://crates.io/crates/doppio-cli)** -- the `dop`
+  command-line interface (compile, balance, register, print, stats,
+  accounts, commodities, with `--exchange`, `--cleared`, `--depth`,
+  `--format text|json|csv`, etc.).
+- **[`doppio-categorize`](https://crates.io/crates/doppio-categorize)** --
+  counter-account suggestions for new transactions, given an existing
+  journal as the training corpus.
+
+## Documentation
+
+- [Repository](https://github.com/alevy/doppio) -- README, CLI
+  reference, supported feature matrix.
+- [`docs/`](https://github.com/alevy/doppio/tree/main/docs) -- proto
+  evolution policy, exchange-rate semantics, supported features.
+- [`proto/doppio.proto`](https://github.com/alevy/doppio/blob/main/proto/doppio.proto) --
+  the canonical wire format with multilingual reassembly recipes.
+
+## License
+
+ISC. See [LICENSE](https://github.com/alevy/doppio/blob/main/LICENSE).


### PR DESCRIPTION
## Summary

Pre-cut sweep across the documentation that the user-facing audience (crates.io, GitHub readers, CLI installers) sees. The top-level README accumulated stale prose from earlier release prep, and the workspace shipped without per-crate READMEs for `doppio` and `doppio-cli`.

## Top-level README (substantive corrections)

| Stale | Correct |
|---|---|
| `cargo install doppio` (the library has no binary) | `cargo install doppio-cli` |
| `doppio::parser::Parser` (removed in #159) | `doppio::grammars::ledger::Parser` |
| `txn.date` (proto-typed i32 epoch days now) | `txn.date_naive()` |
| "postcard-serialized, XZ-compressed `.dop`" (the v0.2 wire format) | "Protocol Buffers payload, deflate-compressed by default" |
| Pipeline diagram: `postcard + XZ -> .dop` | `protobuf + deflate -> .dop` |
| `crates/doppio/src/parser.rs`, `ledger.pest` | `crates/doppio/src/grammars/ledger/` |
| `crates/doppio/src/elaboration.rs` | `crates/doppio/src/elaborator.rs` (the runtime; `elaboration` is the proto-generated module) |
| Library API table: `dop_write_header / dop_read_header` (now `pub(crate)`) | `write_dop` / `read_dop` (the public wrappers) |
| hledger row in features table: "(v0.3.0, issue #103)" -- v0.3 never published | "Supported" |

Plus added the missing `commodities` CLI subcommand to the CLI reference and a new "Companion crates" section so the install-the-right-thing answer is visible at a glance.

## Per-crate READMEs (new)

- **`crates/doppio/README.md`** -- intro, use cases (bank import pipelines, reporting, cross-language consumers), quick example, companion-crate cross-links.
- **`crates/doppio-cli/README.md`** -- install + quick start + flag reference. Anchored on `cargo install doppio-cli`.
- **`crates/doppio-categorize/README.md`** refreshed -- removed "v0.2 prototype" / "lives in `doppio-research/prototypes/`" references that haven't been true since the crate graduated to a workspace member.

## Per-crate Cargo.toml metadata

- Added `readme = "README.md"` to all three crates so crates.io picks up the per-crate README instead of falling through to the workspace one.
- Replaced unicode em-dash in `description` with `--` (consistent with the repo-wide ASCII pass).

## Verification

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` -- all 389 tests pass
- [x] `npm test` (web) -- 58 tests pass
- [x] Library example in top-level README compile-checked against the current crate via a scratch project (verified `grammars::ledger::Parser`, `eval_transaction`, `compile`, and `date_naive()` all resolve).