### PR TITLE
feat(grammar): Beancount pest grammar (#145)

### DIFF
--- a/crates/doppio/src/grammars/beancount/beancount.pest
+++ b/crates/doppio/src/grammars/beancount/beancount.pest
@@ -1,0 +1,294 @@
+// ============================================================
+// beancount.pest -- PEG grammar for the Beancount journal format.
+//
+// Conventions from pest (https://pest.rs/):
+//   UPPERCASE  -- built-in rules (NEWLINE, EOI, ANY, ASCII_DIGIT, ...)
+//   _{ ... }   -- silent rule: matched but not included in the pair tree
+//   @{ ... }   -- atomic rule: inner tokens are NOT individually paired
+//   ${ ... }   -- compound-atomic: inner named rules ARE paired but
+//                 implicit whitespace skipping is disabled
+//
+// Key differences from ledger.pest / hledger.pest:
+//   - Date format is strict ISO `YYYY-MM-DD` (no `/` or `.` separators).
+//   - Currencies are bare uppercase identifiers (`USD`, `EUR`, `AAPL`),
+//     not `$`-prefixed.
+//   - String literals `"..."` are explicit on most directives.
+//   - Tags `#tag` and links `^link` appear after a transaction's
+//     description.
+//   - Comments start with `;` only (Beancount uses `#` for tags).
+//   - The directive set is keyword-led after the date:
+//     `<date> open|close|commodity|pad|balance|price|note|document
+//      |event|query|custom <args...>`.
+//   - Transactions are flagged with `*` (complete), `!` (flagged),
+//     or the literal `txn`.
+//
+// NOT YET SUPPORTED:
+//   - String escape sequences (`\"`, `\n`, etc) inside quoted strings.
+//   - The `pushtag`/`poptag` and `pushmeta`/`popmeta` scoping forms.
+//   - Org-mode `*` headings at column 0 (treated as parse errors;
+//     prefix with `;` to comment out).
+//   - Beancount's lot syntax inside `{...}` is captured as raw text;
+//     the AST adapter (#146) is responsible for parsing the inner
+//     fields (cost, date, label).
+// ============================================================
+
+// --- Top Level ---
+
+journal = ${ (entry | NEWLINE)* ~ EOI }
+
+entry = _{
+    transaction
+    | open_directive
+    | close_directive
+    | commodity_directive
+    | pad_directive
+    | balance_directive
+    | price_directive
+    | note_directive
+    | document_directive
+    | event_directive
+    | query_directive
+    | custom_directive
+    | include_directive
+    | option_directive
+    | plugin_directive
+    | comment_line
+}
+
+// --- Transactions ---
+//
+// A transaction header is `<date> <flag> [<payee> <description> | <description>]
+// [#tag]* [^link]*`, optionally followed by indented metadata and posting lines.
+
+transaction = ${
+    txn_header ~ NEWLINE ~
+    (metadata_line | posting | empty_indented_line)*
+}
+
+txn_header = ${
+    date
+    ~ ws+ ~ flag
+    ~ (ws+ ~ string)?
+    ~ (ws+ ~ string)?
+    ~ (ws+ ~ tag_or_link)*
+    ~ (ws* ~ note)?
+}
+
+// Beancount transaction flags. `*` = complete, `!` = flagged for review,
+// `txn` = literal keyword form. Single-letter custom flags (P/S/T/C/U/R/M)
+// are technically valid but rarely used; not modelled here.
+flag = @{ "*" | "!" | "txn" }
+
+tag_or_link = _{ tag | link }
+tag  = @{ "#" ~ tag_or_link_chars }
+link = @{ "^" ~ tag_or_link_chars }
+tag_or_link_chars = @{ (ASCII_ALPHANUMERIC | "_" | "-" | ".")+ }
+
+// --- Postings ---
+
+posting = ${
+    indent+ ~ !NEWLINE ~
+    (flag ~ ws+)? ~
+    posting_account ~
+    (amount_logic)? ~
+    (ws* ~ note)? ~
+    (NEWLINE | EOI) ~
+    posting_meta*
+}
+
+posting_account = ${ account }
+
+// Two or more spaces (or a tab) separate the account from the amount.
+amount_logic = ${
+    (ws{2,} | "\t") ~ value_expr ~ (ws* ~ lot_annotation_or_price)*
+}
+
+// `{...}` is a Beancount lot specification (cost, date, label).
+// `{{...}}` is a total-cost variant. `@`/`@@` are inline price annotations
+// (per-unit / total). Try `{{` before `{` and `@@` before `@`.
+lot_annotation_or_price = _{ lot_annotation | lot_price }
+lot_annotation = ${ ("{{" ~ lot_inner_total ~ "}}") | ("{" ~ lot_inner ~ "}") }
+lot_inner       = @{ (!"}"  ~ ANY)* }
+lot_inner_total = @{ (!"}}" ~ ANY)* }
+lot_price = ${ ("@@" | "@") ~ ws* ~ value_expr }
+
+posting_meta = _{ metadata_line }
+
+// --- Metadata ---
+//
+// Indented `key: value` lines under a directive or posting. Keys are
+// lowercase identifiers (Beancount enforces lowercase; we accept any
+// identifier here and let the resolver decide).
+metadata_line = ${
+    indent+ ~ identifier ~ ":" ~ ws* ~ metadata_value ~ (NEWLINE | EOI)
+}
+metadata_value = @{ (!NEWLINE ~ ANY)* }
+
+empty_indented_line = _{ indent+ ~ NEWLINE }
+
+// --- Directives ---
+//
+// All Beancount directives except `include`/`option`/`plugin` lead with
+// the date. Each may carry indented metadata lines under it.
+
+open_directive = ${
+    date ~ ws+ ~ "open" ~ ws+ ~ account
+    ~ (ws+ ~ commodity_list)?
+    ~ (ws+ ~ booking_method)?
+    ~ (ws* ~ note)?
+    ~ (NEWLINE | EOI)
+    ~ metadata_line*
+}
+
+// Comma-separated currency list on `open Account USD,EUR`.
+commodity_list = ${ commodity ~ (ws* ~ "," ~ ws* ~ commodity)* }
+
+// Booking method on `open` directives: `STRICT`, `NONE`, `FIFO`, `LIFO`,
+// `AVERAGE`, etc. Quoted because they appear after the currency list.
+booking_method = ${ "\"" ~ booking_method_chars ~ "\"" }
+booking_method_chars = @{ (!"\"" ~ ANY)* }
+
+close_directive = ${
+    date ~ ws+ ~ "close" ~ ws+ ~ account
+    ~ (ws* ~ note)?
+    ~ (NEWLINE | EOI)
+    ~ metadata_line*
+}
+
+commodity_directive = ${
+    date ~ ws+ ~ "commodity" ~ ws+ ~ commodity
+    ~ (ws* ~ note)?
+    ~ (NEWLINE | EOI)
+    ~ metadata_line*
+}
+
+pad_directive = ${
+    date ~ ws+ ~ "pad" ~ ws+ ~ account ~ ws+ ~ account
+    ~ (ws* ~ note)?
+    ~ (NEWLINE | EOI)
+    ~ metadata_line*
+}
+
+balance_directive = ${
+    date ~ ws+ ~ "balance" ~ ws+ ~ account ~ ws+ ~ value_expr
+    ~ (ws* ~ note)?
+    ~ (NEWLINE | EOI)
+    ~ metadata_line*
+}
+
+price_directive = ${
+    date ~ ws+ ~ "price" ~ ws+ ~ commodity ~ ws+ ~ value_expr
+    ~ (ws* ~ note)?
+    ~ (NEWLINE | EOI)
+    ~ metadata_line*
+}
+
+note_directive = ${
+    date ~ ws+ ~ "note" ~ ws+ ~ account ~ ws+ ~ string
+    ~ (ws* ~ note)?
+    ~ (NEWLINE | EOI)
+    ~ metadata_line*
+}
+
+document_directive = ${
+    date ~ ws+ ~ "document" ~ ws+ ~ account ~ ws+ ~ string
+    ~ (ws* ~ note)?
+    ~ (NEWLINE | EOI)
+    ~ metadata_line*
+}
+
+event_directive = ${
+    date ~ ws+ ~ "event" ~ ws+ ~ string ~ ws+ ~ string
+    ~ (ws* ~ note)?
+    ~ (NEWLINE | EOI)
+    ~ metadata_line*
+}
+
+query_directive = ${
+    date ~ ws+ ~ "query" ~ ws+ ~ string ~ ws+ ~ string
+    ~ (ws* ~ note)?
+    ~ (NEWLINE | EOI)
+    ~ metadata_line*
+}
+
+// `<date> custom "type-name" <arg> <arg> ...` -- arguments may be strings,
+// numbers, accounts, commodities, dates, or booleans.
+custom_directive = ${
+    date ~ ws+ ~ "custom" ~ ws+ ~ string ~ (ws+ ~ custom_arg)*
+    ~ (ws* ~ note)?
+    ~ (NEWLINE | EOI)
+    ~ metadata_line*
+}
+custom_arg = _{ string | value_expr | account | commodity | date | bool_literal }
+bool_literal = @{ "TRUE" | "FALSE" }
+
+include_directive = ${ "include" ~ ws+ ~ string ~ (NEWLINE | EOI) }
+option_directive  = ${ "option"  ~ ws+ ~ string ~ ws+ ~ string ~ (NEWLINE | EOI) }
+plugin_directive  = ${
+    "plugin" ~ ws+ ~ string ~ (ws+ ~ string)? ~ (NEWLINE | EOI)
+}
+
+// --- Atoms ---
+
+date = ${ year ~ "-" ~ monthdate ~ "-" ~ monthdate }
+year = @{ ASCII_DIGIT{4} }
+monthdate = @{ ASCII_DIGIT{2} }
+
+// String literal: simple double-quoted form. Escape sequences are not
+// modelled (see header note).
+string = ${ "\"" ~ string_inner ~ "\"" }
+string_inner = @{ (!"\"" ~ ANY)* }
+
+// Account: colon-separated segments. Beancount accepts segments
+// starting with an uppercase letter or digit; we accept either case
+// to be permissive. Stops at whitespace, semicolon, or newline.
+account = @{ account_segment ~ (":" ~ account_segment)+ }
+account_segment = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_" | "-")* }
+
+indent = _{ " " | "\t" }
+ws = _{ " " | "\t" }
+
+note = ${ ";" ~ note_str }
+note_str = ${ (!NEWLINE ~ ANY)* }
+
+comment_line = @{ ";" ~ (!NEWLINE ~ ANY)* }
+
+identifier = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_" | "-")* }
+
+// --- Value expressions ---
+//
+// Beancount amounts are `<number> <currency>`. Bare numbers and infix
+// arithmetic via parentheses are also accepted (Beancount itself
+// permits expression-level arithmetic on totals).
+
+value_expr = ${ expr ~ (ws+ ~ commodity)? }
+expr = ${ term ~ (ws* ~ infix_op ~ ws* ~ term)* }
+term = ${ (prefix_op ~ ws*)? ~ primary }
+primary = { base_primary }
+
+base_primary = _{
+    "(" ~ expr ~ ")"
+    | amount
+}
+
+amount = ${
+    (number ~ ws+ ~ commodity)
+    | number
+}
+
+number = @{
+    "-"? ~ ASCII_DIGIT+ ~ ("," ~ ASCII_DIGIT{3})* ~ ("." ~ ASCII_DIGIT+)?
+    | "-"? ~ "." ~ ASCII_DIGIT+
+}
+
+// Beancount currency: must start with an uppercase letter; subsequent
+// characters may be uppercase, digits, or any of `'._-`. Length 1+
+// (Beancount itself enforces 2..24, but we don't need to here).
+commodity = @{ ASCII_ALPHA_UPPER ~ (ASCII_ALPHA_UPPER | ASCII_DIGIT | "'" | "." | "_" | "-")* }
+
+infix_op = _{ add | sub | mul | div }
+    add = { "+" }
+    sub = { "-" }
+    mul = { "*" }
+    div = { "/" }
+prefix_op = { "-" | "+" }

--- a/crates/doppio/src/grammars/beancount/mod.rs
+++ b/crates/doppio/src/grammars/beancount/mod.rs
@@ -1,0 +1,110 @@
+//! Beancount frontend (experimental): parse `.beancount` source text.
+//!
+//! This module currently ships only the pest-derived parser. The
+//! `Frontend` trait impl and the AST adapter that lowers a parsed
+//! Beancount file into [`crate::ast::Journal`] are tracked in #146.
+//! The `pad`-directive evaluator is tracked in #147.
+//!
+//! Marked **experimental** in line with the Beancount milestone (M#9):
+//! the directive set, lot syntax, and string-escape handling will
+//! evolve as real Beancount inputs surface gaps.
+
+use pest_derive::Parser;
+
+/// The raw pest parser generated from `beancount.pest` via `pest_derive`.
+///
+/// Internal-only: the public Beancount surface lands with the AST
+/// adapter in #146 (a `BeancountFrontend` implementing
+/// [`crate::frontend::Frontend`]). Until then, this struct is only
+/// referenced from `#[cfg(test)]` grammar-smoke-test code, so the
+/// non-test build flags it as dead -- legitimately so. The allow
+/// is removed when #146 wires the parser into a Frontend impl.
+#[allow(dead_code)]
+#[derive(Parser)]
+#[grammar = "grammars/beancount/beancount.pest"]
+pub(crate) struct BeancountParser;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pest::Parser as _;
+
+    /// The fixture covers every directive type the grammar supports;
+    /// it is the contract for #145.
+    const SAMPLE: &str = include_str!("../../../tests/fixtures/sample.beancount");
+
+    #[test]
+    fn sample_fixture_parses() {
+        BeancountParser::parse(Rule::journal, SAMPLE).unwrap_or_else(|e| {
+            panic!("sample.beancount failed to parse:\n{e}");
+        });
+    }
+
+    fn parse_one(rule: Rule, input: &str) {
+        BeancountParser::parse(rule, input)
+            .unwrap_or_else(|e| panic!("expected `{input}` to match {rule:?}, got: {e}"));
+    }
+
+    #[test]
+    fn date_iso_only() {
+        parse_one(Rule::date, "2024-01-15");
+    }
+
+    #[test]
+    fn date_rejects_slash_separator() {
+        // Beancount is strict about ISO format. hledger's `2024/01/15`
+        // is not accepted.
+        assert!(BeancountParser::parse(Rule::date, "2024/01/15").is_err());
+    }
+
+    #[test]
+    fn currency_uppercase_identifier() {
+        parse_one(Rule::commodity, "USD");
+        parse_one(Rule::commodity, "EUR");
+        parse_one(Rule::commodity, "AAPL");
+        parse_one(Rule::commodity, "BTC");
+        parse_one(Rule::commodity, "VHT_2024");
+    }
+
+    #[test]
+    fn currency_must_start_uppercase() {
+        // Beancount currencies are uppercase-led. Lowercase 'usd' is
+        // not a currency token; it would parse as something else.
+        assert!(BeancountParser::parse(Rule::commodity, "usd").is_err());
+    }
+
+    #[test]
+    fn account_colon_segments() {
+        parse_one(Rule::account, "Assets:Bank:Checking");
+        parse_one(Rule::account, "Equity:Opening-Balances");
+        parse_one(Rule::account, "Income:US:Acme:Salary");
+    }
+
+    #[test]
+    fn account_requires_at_least_two_segments() {
+        // Beancount accounts always have at least two segments
+        // (Type:Name minimum). A bare "Assets" is not a valid
+        // account token.
+        assert!(BeancountParser::parse(Rule::account, "Assets").is_err());
+    }
+
+    #[test]
+    fn string_double_quoted() {
+        parse_one(Rule::string, "\"hello world\"");
+        parse_one(Rule::string, "\"\"");
+    }
+
+    #[test]
+    fn flag_recognises_star_bang_txn() {
+        parse_one(Rule::flag, "*");
+        parse_one(Rule::flag, "!");
+        parse_one(Rule::flag, "txn");
+    }
+
+    #[test]
+    fn tag_and_link_chars() {
+        parse_one(Rule::tag, "#vacation");
+        parse_one(Rule::tag, "#trip-2024");
+        parse_one(Rule::link, "^statement-2024-01");
+    }
+}

--- a/crates/doppio/src/grammars/beancount/mod.rs
+++ b/crates/doppio/src/grammars/beancount/mod.rs
@@ -107,4 +107,16 @@ mod tests {
         parse_one(Rule::tag, "#trip-2024");
         parse_one(Rule::link, "^statement-2024-01");
     }
+
+    #[test]
+    fn plugin_directive_with_and_without_arg() {
+        // Covered here rather than in sample.beancount because real
+        // Beancount plugins are signature-versioned and bean-check
+        // refuses the fixture if a referenced plugin's API has shifted.
+        parse_one(Rule::plugin_directive, "plugin \"beancount.plugins.foo\"\n");
+        parse_one(
+            Rule::plugin_directive,
+            "plugin \"beancount.plugins.foo\" \"argument-string\"\n",
+        );
+    }
 }

--- a/crates/doppio/src/grammars/mod.rs
+++ b/crates/doppio/src/grammars/mod.rs
@@ -6,6 +6,11 @@
 //! Currently available:
 //! - [`ledger`] -- the ledger-cli plain-text accounting format (`.ledger`).
 //! - [`hledger`] -- the hledger dialect (`.hledger`, `.journal`).
+//! - [`beancount`] -- the Beancount format (`.beancount`).
+//!   **Experimental**: ships the grammar (#145); the `Frontend` trait
+//!   impl (#146) and the `pad` directive evaluator (#147) are
+//!   in-flight.
 
+pub(crate) mod beancount;
 pub mod hledger;
 pub mod ledger;

--- a/crates/doppio/tests/fixtures/jan-statement.txt
+++ b/crates/doppio/tests/fixtures/jan-statement.txt
@@ -1,0 +1,2 @@
+Stub statement file referenced by sample.beancount's `document` directive.
+The contents do not matter; bean-check only verifies that the file exists.

--- a/crates/doppio/tests/fixtures/sample.beancount
+++ b/crates/doppio/tests/fixtures/sample.beancount
@@ -1,0 +1,89 @@
+; Sample Beancount journal exercising every directive the grammar
+; supports. Used by the grammar smoke test in
+; `crates/doppio/src/grammars/beancount/mod.rs::tests::sample_fixture_parses`.
+;
+; Names, payees, and amounts are entirely synthetic. The file is
+; intended for parser tests only; do not use it as a real-bookkeeping
+; template.
+
+option "title" "Sample Journal"
+option "operating_currency" "USD"
+
+plugin "beancount.plugins.implicit_prices"
+plugin "beancount.plugins.auto" "argument-string"
+
+include "secondary.beancount"
+
+;; --- Account lifecycle ---
+
+2024-01-01 open Assets:Bank:Checking USD
+2024-01-01 open Assets:Brokerage AAPL,USD "FIFO"
+2024-01-01 open Liabilities:CreditCard USD
+2024-01-01 open Income:Salary USD
+2024-01-01 open Expenses:Food
+2024-01-01 open Equity:Opening-Balances
+
+;; --- Commodity declarations + metadata ---
+
+2024-01-01 commodity USD
+  name: "US Dollar"
+  asset-class: "cash"
+
+2024-01-01 commodity AAPL
+  name: "Apple Inc."
+  asset-class: "stock"
+
+;; --- Pad + balance reconciliation ---
+
+2024-01-01 pad Assets:Bank:Checking Equity:Opening-Balances
+2024-01-15 balance Assets:Bank:Checking 5000.00 USD
+
+;; --- Transactions: complete (`*`), flagged (`!`), and `txn` keyword ---
+
+2024-01-12 * "Acme Studio" "Invoice 0123" #work ^invoice-0123
+  Assets:Bank:Checking          3400.00 USD
+  Income:Salary                -3400.00 USD
+
+2024-01-15 ! "Whole Foods Market" "Groceries"
+  Liabilities:CreditCard         -87.43 USD
+  Expenses:Food                   87.43 USD
+
+2024-02-15 txn "Apple lot purchase"
+  Assets:Brokerage              10 AAPL {182.50 USD, 2024-02-15, "buy-2024-02"}
+  Assets:Bank:Checking       -1825.00 USD
+
+2024-05-15 * "Buy euros at airport kiosk"
+  Assets:Cash:EUR              500.00 EUR @ 1.07 USD
+  Assets:Bank:Checking        -535.00 USD
+
+;; --- Per-posting metadata + bare numbers + arithmetic ---
+
+2024-03-01 * "Mixed-detail transaction"
+  description: "Demonstrates posting metadata and per-posting flags"
+  reference: "RX-1234"
+  ! Liabilities:CreditCard      -100.00 USD
+    statement-line: "ACH-77821"
+  * Expenses:Food               (50.00 + 50.00) USD
+
+;; --- Historical price ---
+
+2024-01-02 price USD 0.92 EUR
+2024-02-15 price AAPL 182.50 USD
+
+;; --- Notes, documents, events, queries, custom ---
+
+2024-01-20 note Assets:Bank:Checking "Need to verify January statement"
+
+2024-01-22 document Assets:Bank:Checking "/scans/jan-statement.pdf"
+
+2024-01-01 event "location" "Berlin"
+2024-06-30 event "location" "Lisbon"
+
+2024-06-30 query "lunches-q2" "SELECT date, payee, amount WHERE account ~ 'Expenses:Food'"
+
+2024-01-01 custom "budget" "Expenses:Food" 200.00 USD
+2024-01-01 custom "fava-option" "language" "en"
+
+;; --- Account closure ---
+
+2024-12-31 close Liabilities:CreditCard

--- a/crates/doppio/tests/fixtures/sample.beancount
+++ b/crates/doppio/tests/fixtures/sample.beancount
@@ -1,6 +1,14 @@
 ; Sample Beancount journal exercising every directive the grammar
-; supports. Used by the grammar smoke test in
+; supports (except `plugin`, which is exercised at the grammar-rule
+; level in `mod.rs` -- including a real plugin name here would tie the
+; fixture to a specific Beancount runtime version). Used by the grammar
+; smoke test in
 ; `crates/doppio/src/grammars/beancount/mod.rs::tests::sample_fixture_parses`.
+;
+; This fixture is also valid Beancount: it is expected to pass `bean-check`
+; cleanly, with the sibling stub files `secondary.beancount` (for the
+; `include` directive) and `jan-statement.txt` (for the `document`
+; directive) sitting alongside it in the same directory.
 ;
 ; Names, payees, and amounts are entirely synthetic. The file is
 ; intended for parser tests only; do not use it as a real-bookkeeping
@@ -9,15 +17,13 @@
 option "title" "Sample Journal"
 option "operating_currency" "USD"
 
-plugin "beancount.plugins.implicit_prices"
-plugin "beancount.plugins.auto" "argument-string"
-
 include "secondary.beancount"
 
 ;; --- Account lifecycle ---
 
 2024-01-01 open Assets:Bank:Checking USD
 2024-01-01 open Assets:Brokerage AAPL,USD "FIFO"
+2024-01-01 open Assets:Cash:EUR EUR
 2024-01-01 open Liabilities:CreditCard USD
 2024-01-01 open Income:Salary USD
 2024-01-01 open Expenses:Food
@@ -74,7 +80,7 @@ include "secondary.beancount"
 
 2024-01-20 note Assets:Bank:Checking "Need to verify January statement"
 
-2024-01-22 document Assets:Bank:Checking "/scans/jan-statement.pdf"
+2024-01-22 document Assets:Bank:Checking "jan-statement.txt"
 
 2024-01-01 event "location" "Berlin"
 2024-06-30 event "location" "Lisbon"

--- a/crates/doppio/tests/fixtures/secondary.beancount
+++ b/crates/doppio/tests/fixtures/secondary.beancount
@@ -1,0 +1,3 @@
+; Stub include target referenced by sample.beancount's `include` directive.
+; Kept intentionally empty: the parity fixture only needs this file to exist
+; so bean-check resolves the include without erroring.


### PR DESCRIPTION
## Summary

First sub-issue of the Beancount frontend (M#9). Lands the pest grammar plus a parity fixture covering every directive the grammar supports. Closes #145.

The AST adapter (Frontend trait impl) is #146; the \`pad\` evaluator is #147; #144 is the umbrella.

## What's in the grammar

Modelled on \`hledger.pest\` with Beancount-specific deltas:

| Area | Beancount choice |
|---|---|
| Dates | strict ISO \`YYYY-MM-DD\`; no \`/\` or \`.\` separators |
| Currencies | uppercase identifiers (\`USD\`, \`EUR\`, \`AAPL\`, \`VHT_2024\`); no \`$\`-prefix form |
| String literals | \`\"...\"\` (escape sequences not yet modelled -- header comment calls this out) |
| Tags / links | \`#tag\` and \`^link\` after a transaction's description |
| Comments | \`;\` only (Beancount reserves \`#\` for tags) |
| Transactions | flagged with \`*\` (complete), \`!\` (review-flagged), or the literal \`txn\` |
| Directives | \`<date> open|close|commodity|pad|balance|price|note|document|event|query|custom <args>\`, plus top-level \`include\` / \`option\` / \`plugin\` |
| Postings | \`indent <account> <amount>\` with optional \`{...}\` / \`{{...}}\` lot specs and \`@\` / \`@@\` price annotations |
| Metadata | indented \`key: value\` lines under any directive or posting |

## What's deliberately not modelled (header comment in the .pest file)

- String escape sequences (\`\\\\\"\`, \`\\\\n\`, etc) inside \`\"...\"\`.
- \`pushtag\`/\`poptag\` and \`pushmeta\`/\`popmeta\` scoping forms.
- Org-mode \`*\` headings at column 0 (treated as parse errors; users prefix with \`;\` to comment out).
- Internal structure of \`{...}\` lot specifications -- captured as raw text for the AST adapter (#146) to parse.

## Test coverage

\`crates/doppio/tests/fixtures/sample.beancount\` is the contract: a 12-entry-class fixture that covers every directive type the grammar supports. The grammar's smoke test parses it end-to-end. Plus nine targeted unit tests for the format-specific deltas (date strictness, currency uppercase rule, account two-segment minimum, etc.).

10 new tests, all pass.

## Layout

- \`crates/doppio/src/grammars/beancount/beancount.pest\` -- the grammar
- \`crates/doppio/src/grammars/beancount/mod.rs\` -- pest-derived \`BeancountParser\` struct (crate-private; \`#[allow(dead_code)]\` until #146 wires it into a Frontend impl) plus the test module
- \`crates/doppio/src/grammars/mod.rs\` -- module registration with a \"see #146 for Frontend impl\" doc note
- \`crates/doppio/tests/fixtures/sample.beancount\` -- parity fixture

## Test plan

- [x] \`cargo fmt --all --check\`
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo test --workspace\` -- 240 doppio lib + 49 elaborator + 28 categorizer + the test crates, all passing
- [x] \`cargo build --target wasm32-unknown-unknown -p doppio --lib\` clean

## Up next

- #146 -- AST adapter / Frontend trait impl (mechanical port of the hledger \`mod.rs\` shape; lowers Beancount directives into \`ast::*\`)
- #147 -- \`pad\` directive evaluator (the design-heavy piece; the issue body has five questions to settle before code)