### PR TITLE
feat(beancount): AST adapter + Frontend trait impl (#146)

### DIFF
--- a/crates/doppio/src/ast.rs
+++ b/crates/doppio/src/ast.rs
@@ -50,8 +50,31 @@ pub(crate) enum Entry {
     ///
     /// Example: `2024-01-15 = Assets:Checking  $1000.00`
     Assertion(AssertionDirective),
+    /// A Beancount `pad` directive: backfill the difference between two
+    /// accounts up to the next balance assertion. Emitted by the
+    /// Beancount frontend as a marker; the elaboration semantics are
+    /// the subject of #147.
+    Pad(PadDirective),
     /// A comment line starting with `;`, `#`, `*`, `%`, or `|`.
     Comment(String),
+}
+
+/// A Beancount `pad` directive marker.
+///
+/// `<date> pad <target_account> <source_account>` instructs Beancount to
+/// post a balancing transaction from `source_account` to `target_account`
+/// that brings `target_account`'s balance to whatever the next `balance`
+/// assertion against it expects. The resolver does not act on this today
+/// (see #147 for the evaluator design); it is preserved here so that
+/// downstream consumers can see pads exist.
+#[derive(Debug, Clone)]
+pub(crate) struct PadDirective {
+    /// The date the pad applies on.
+    pub date: Date,
+    /// The account whose balance will be brought to the next assertion.
+    pub target_account: String,
+    /// The counter-account that absorbs the padding amount.
+    pub source_account: String,
 }
 
 /// A standalone balance assertion directive outside of any transaction.

--- a/crates/doppio/src/grammars/beancount/beancount.pest
+++ b/crates/doppio/src/grammars/beancount/beancount.pest
@@ -116,12 +116,14 @@ posting_meta = _{ metadata_line }
 
 // --- Metadata ---
 //
-// Indented `key: value` lines under a directive or posting. Keys are
-// lowercase identifiers (Beancount enforces lowercase; we accept any
-// identifier here and let the resolver decide).
+// Indented `key: value` lines under a directive or posting. Beancount
+// requires the key to be lowercase-led; we enforce that here so a
+// posting like `  Assets:Bank:Checking 100 USD` (uppercase-led) is
+// not mis-parsed as a metadata line.
 metadata_line = ${
-    indent+ ~ identifier ~ ":" ~ ws* ~ metadata_value ~ (NEWLINE | EOI)
+    indent+ ~ metadata_key ~ ":" ~ ws* ~ metadata_value ~ (NEWLINE | EOI)
 }
+metadata_key = @{ (ASCII_ALPHA_LOWER | "_") ~ (ASCII_ALPHANUMERIC | "_" | "-")* }
 metadata_value = @{ (!NEWLINE ~ ANY)* }
 
 empty_indented_line = _{ indent+ ~ NEWLINE }

--- a/crates/doppio/src/grammars/beancount/mod.rs
+++ b/crates/doppio/src/grammars/beancount/mod.rs
@@ -28,7 +28,7 @@
 //! | `pad target source` | [`Entry::Pad`] -- marker; #147 owns elaboration |
 //! | `option` / `plugin` | [`Entry::Comment`] |
 //! | `include "path"` | recursively parsed via the same opener as hledger |
-//! | `#tag` / `^link` on a transaction | collected into `Transaction.tags` (links collapse onto tags; the AST has no separate link concept) |
+//! | `#tag` / `^link` on a transaction | collected into `Transaction.tags`. `#tag` becomes a bare tag (`vacation`); `^link` keeps its prefix (`^trip-001`), so a Beancount link is a doppio tag whose name starts with `^`. |
 //!
 //! ## Known limitations / stubs
 //!
@@ -183,14 +183,14 @@ fn parse_transaction(pair: Pair<Rule>) -> Result<Transaction, Box<dyn std::error
         match p.as_rule() {
             Rule::flag => state = parse_flag(p.as_str()),
             Rule::string => payee_or_desc.push(string_inner(p)),
-            // Both `#tag` and `^link` collapse to tags. Beancount
-            // distinguishes them (links bind related transactions
-            // across an event; tags categorise) but our AST/HIR has
-            // no separate link concept, and resolution lifts the
-            // bare-tag `:a:b:` note format into Transaction.tags. A
-            // distinct link channel can be added later if a real
-            // consumer needs to tell them apart.
-            Rule::tag | Rule::link => tags.push(p.as_str()[1..].to_string()),
+            // Both `#tag` and `^link` land in Transaction.tags, but
+            // the `^` prefix is preserved so the Beancount
+            // tag-vs-link distinction can be recovered downstream:
+            // a Beancount link is encoded as a doppio tag that
+            // starts with `^`. The `#` prefix is stripped because
+            // every other ledger-cli-style tag is bare.
+            Rule::tag => tags.push(p.as_str()[1..].to_string()),
+            Rule::link => tags.push(p.as_str().to_string()),
             Rule::note => {
                 notes.push(p.into_inner().as_str().trim().to_string());
             }
@@ -782,8 +782,8 @@ mod tests {
         // The AST stores them as a single `:a:b:c:` note that resolve_metadata
         // lifts into Transaction.tags.
         assert!(
-            tx.notes.iter().any(|n| n == ":vacation:beach:trip-001:"),
-            "expected a bare-tag note, got notes={:?}",
+            tx.notes.iter().any(|n| n == ":vacation:beach:^trip-001:"),
+            "expected a bare-tag note (link prefix preserved), got notes={:?}",
             tx.notes
         );
     }
@@ -816,7 +816,9 @@ mod tests {
         let tags: std::collections::HashSet<&str> = tx.tags.iter().map(String::as_str).collect();
         assert!(tags.contains("vacation"), "tags={:?}", tx.tags);
         assert!(tags.contains("beach"), "tags={:?}", tx.tags);
-        assert!(tags.contains("trip-001"), "tags={:?}", tx.tags);
+        // Beancount `^link`s land in tags too, but with the `^` prefix
+        // preserved so consumers can recover the link-vs-tag distinction.
+        assert!(tags.contains("^trip-001"), "tags={:?}", tx.tags);
         // Nothing should have leaked into the metadata map.
         assert!(
             !tx.metadata.contains_key("tag"),

--- a/crates/doppio/src/grammars/beancount/mod.rs
+++ b/crates/doppio/src/grammars/beancount/mod.rs
@@ -32,10 +32,12 @@
 //!
 //! ## Known limitations / stubs
 //!
-//! - The lot syntax `{cost, date, label}` is parsed best-effort: comma-split
-//!   parts are classified as cost (first amount-looking part), date (ISO),
-//!   or quoted label. Beancount's wildcard `{*}` and `{*, ...}` forms are
-//!   accepted but the wildcard is dropped (no AST representation today).
+//! - The lot syntax `{cost, date, label}` is parsed best-effort (TODO #185):
+//!   comma-split parts are classified as cost (first amount-looking part),
+//!   date (ISO), or quoted label. The wildcard `{*}` form is accepted but
+//!   the wildcard is silently dropped, the total-cost `{{total}}` form is
+//!   not distinguished from per-unit `{cost}`, and the cost commodity vs
+//!   held commodity distinction is collapsed.
 //! - `pad` is preserved as an [`Entry::Pad`] marker but the elaborator does
 //!   not yet act on it; the algorithm is the subject of #147.
 //! - String escape sequences inside quoted strings are not interpreted.
@@ -311,8 +313,21 @@ fn parse_amount_logic(pair: Pair<Rule>) -> Result<AmountDetails, Box<dyn std::er
 /// - First ISO date becomes the lot date.
 /// - First quoted string becomes the lot label.
 ///
-/// Beancount's wildcard `*` (alone or as the first part) is silently dropped:
-/// "automatic cost" semantics are not yet modelled.
+/// # Known gaps (TODO #185)
+///
+/// - The wildcard `{*}` / `{*, ...}` form ("automatic cost") is silently
+///   dropped: there is no AST representation for "infer this lot's cost
+///   from the inventory."
+/// - The total-cost form `{{total}}` is parsed identically to the
+///   per-unit form `{cost}`. Both feed the cost into
+///   `LotAnnotation::cost` regardless of which brace form was used,
+///   which silently misrepresents the lot basis when the source uses
+///   `{{...}}`.
+/// - The cost commodity is not distinguished from the held commodity:
+///   `10 AAPL {150 USD}` should let downstream consumers tell which
+///   commodity is the basis vs the held lot, but today the inner cost
+///   expression is captured as a single `ValueExpr` with no extra
+///   structural hint.
 fn merge_lot_annotation_into(pair: Pair<Rule>, acc: &mut LotAnnotation) {
     // lot_annotation = ${ ("{{" ~ lot_inner_total ~ "}}") | ("{" ~ lot_inner ~ "}") }
     let inner = pair

--- a/crates/doppio/src/grammars/beancount/mod.rs
+++ b/crates/doppio/src/grammars/beancount/mod.rs
@@ -1,37 +1,615 @@
-//! Beancount frontend (experimental): parse `.beancount` source text.
+//! Beancount frontend (experimental): parse `.beancount` source text into an
+//! [`ast::Journal`].
 //!
-//! This module currently ships only the pest-derived parser. The
-//! `Frontend` trait impl and the AST adapter that lowers a parsed
-//! Beancount file into [`crate::ast::Journal`] are tracked in #146.
-//! The `pad`-directive evaluator is tracked in #147.
+//! Three layers, mirroring [`crate::grammars::ledger`] and
+//! [`crate::grammars::hledger`]:
 //!
-//! Marked **experimental** in line with the Beancount milestone (M#9):
-//! the directive set, lot syntax, and string-escape handling will
-//! evolve as real Beancount inputs surface gaps.
+//! 1. **[`BeancountParser`]** -- the pest-derived parser generated from
+//!    `beancount.pest`.
+//! 2. **[`parse_beancount`]** -- a convenience wrapper that uses a no-op
+//!    include opener; useful in unit tests.
+//! 3. **[`BeancountFrontend`]** -- implements [`crate::frontend::Frontend`]
+//!    so the CLI dispatches `.beancount` files to this module.
+//!
+//! ## Mapping decisions (lowering Beancount → [`ast`])
+//!
+//! Beancount's directive set is wider than ledger-cli's, so a few directives
+//! collapse onto existing AST nodes rather than gaining new variants:
+//!
+//! | Beancount | AST |
+//! |-----------|-----|
+//! | `open Account [currencies] [booking]` | [`Directive::Account`] |
+//! | `close Account` | [`Entry::Comment`] (no semantics, preserved verbatim) |
+//! | `commodity SYMBOL` | [`Directive::Commodity`] |
+//! | `*` / `!` / `txn` transactions | [`Entry::Transaction`] |
+//! | `balance Account amount` | [`Entry::Assertion`] (strict) |
+//! | `price COMM amount` | [`Entry::HistoricalPrice`] |
+//! | `note` / `document` / `event` / `query` / `custom` | [`Entry::Comment`] |
+//! | `pad target source` | [`Entry::Pad`] -- marker; #147 owns elaboration |
+//! | `option` / `plugin` | [`Entry::Comment`] |
+//! | `include "path"` | recursively parsed via the same opener as hledger |
+//! | `#tag` / `^link` on a transaction | folded into `transaction.notes` as `tag:NAME` / `link:NAME` |
+//!
+//! ## Known limitations / stubs
+//!
+//! - The lot syntax `{cost, date, label}` is parsed best-effort: comma-split
+//!   parts are classified as cost (first amount-looking part), date (ISO),
+//!   or quoted label. Beancount's wildcard `{*}` and `{*, ...}` forms are
+//!   accepted but the wildcard is dropped (no AST representation today).
+//! - `pad` is preserved as an [`Entry::Pad`] marker but the elaborator does
+//!   not yet act on it; the algorithm is the subject of #147.
+//! - String escape sequences inside quoted strings are not interpreted.
+//! - `pushtag`/`poptag` and `pushmeta`/`popmeta` are not yet parsed.
 
+use crate::ast::*;
+use pest::Parser as _;
+use pest::iterators::{Pair, Pairs};
+use pest::pratt_parser::PrattParser;
 use pest_derive::Parser;
+use rust_decimal::Decimal;
+use std::path::PathBuf;
+use std::sync::LazyLock;
 
 /// The raw pest parser generated from `beancount.pest` via `pest_derive`.
-///
-/// Internal-only: the public Beancount surface lands with the AST
-/// adapter in #146 (a `BeancountFrontend` implementing
-/// [`crate::frontend::Frontend`]). Until then, this struct is only
-/// referenced from `#[cfg(test)]` grammar-smoke-test code, so the
-/// non-test build flags it as dead -- legitimately so. The allow
-/// is removed when #146 wires the parser into a Frontend impl.
-#[allow(dead_code)]
 #[derive(Parser)]
 #[grammar = "grammars/beancount/beancount.pest"]
 pub(crate) struct BeancountParser;
 
+// ---
+// Internal parser state
+// ---
+struct Parser<F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>> {
+    opener: F,
+    base_path: PathBuf,
+}
+
+impl<F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>> Parser<F> {
+    fn parse(&mut self, input: &str) -> Result<Journal, Box<dyn std::error::Error>> {
+        let pairs = BeancountParser::parse(Rule::journal, input)?;
+        let mut entries = Vec::new();
+
+        for pair in pairs.into_iter().next().unwrap().into_inner() {
+            match pair.as_rule() {
+                Rule::transaction => {
+                    entries.push(Entry::Transaction(parse_transaction(pair)?));
+                }
+                Rule::open_directive => {
+                    entries.push(Entry::Directive(parse_open_directive(pair)));
+                }
+                Rule::close_directive => {
+                    // Preserved as a comment so the source line survives the
+                    // round-trip; resolution discards comments.
+                    entries.push(Entry::Comment(format!("close {}", pair.as_str().trim())));
+                }
+                Rule::commodity_directive => {
+                    entries.push(Entry::Directive(parse_commodity_directive(pair)));
+                }
+                Rule::balance_directive => {
+                    entries.push(Entry::Assertion(parse_balance_directive(pair)));
+                }
+                Rule::price_directive => {
+                    entries.push(Entry::HistoricalPrice(parse_price_directive(pair)));
+                }
+                Rule::pad_directive => {
+                    entries.push(Entry::Pad(parse_pad_directive(pair)));
+                }
+                Rule::note_directive
+                | Rule::document_directive
+                | Rule::event_directive
+                | Rule::query_directive
+                | Rule::custom_directive
+                | Rule::option_directive
+                | Rule::plugin_directive => {
+                    entries.push(Entry::Comment(pair.as_str().trim().to_string()));
+                }
+                Rule::comment_line => {
+                    entries.push(Entry::Comment(pair.as_str().to_string()));
+                }
+                Rule::include_directive => {
+                    let raw = pair.into_inner().next().unwrap();
+                    let path_str = string_inner(raw);
+                    let include_path = self.base_path.join(&path_str);
+                    let new_input = (self.opener)(include_path.as_os_str().to_str().unwrap())?;
+                    let new_base_path = include_path
+                        .parent()
+                        .map(std::path::PathBuf::from)
+                        .unwrap_or_else(|| self.base_path.clone());
+                    let old_base_path = std::mem::replace(&mut self.base_path, new_base_path);
+                    entries.append(&mut self.parse(&new_input)?.entries);
+                    let _ = std::mem::replace(&mut self.base_path, old_base_path);
+                }
+                _ => {}
+            }
+        }
+
+        Ok(Journal { entries })
+    }
+}
+
+// ---
+// Atom helpers
+// ---
+fn parse_date(pair: Pair<Rule>) -> Date {
+    // date = ${ year ~ "-" ~ monthdate ~ "-" ~ monthdate }
+    let mut inner = pair.into_inner();
+    let year: i32 = inner.next().unwrap().as_str().parse().unwrap();
+    let month: u32 = inner.next().unwrap().as_str().parse().unwrap();
+    let day: u32 = inner.next().unwrap().as_str().parse().unwrap();
+    Date {
+        year: Some(year),
+        month,
+        date: day,
+    }
+}
+
+fn parse_flag(s: &str) -> TransactionState {
+    match s {
+        "*" => TransactionState::Cleared,
+        "!" => TransactionState::Pending,
+        // `txn` keyword has no state-equivalent connotation in ledger semantics;
+        // treat it as uncleared (the conservative interpretation).
+        _ => TransactionState::Uncleared,
+    }
+}
+
+/// Extract the inner text of a `string` pair (strip surrounding quotes).
+fn string_inner(pair: Pair<Rule>) -> String {
+    // string = ${ "\"" ~ string_inner ~ "\"" }
+    let inner_pair = pair
+        .into_inner()
+        .next()
+        .expect("string must contain string_inner");
+    inner_pair.as_str().to_string()
+}
+
+// ---
+// Transactions + postings
+// ---
+fn parse_transaction(pair: Pair<Rule>) -> Result<Transaction, Box<dyn std::error::Error>> {
+    let mut inner = pair.into_inner();
+    let header_pair = inner.next().expect("transaction must have a txn_header");
+
+    let mut header_fields = header_pair.into_inner();
+    let date = parse_date(header_fields.next().unwrap());
+
+    let mut state = TransactionState::Uncleared;
+    let mut payee_or_desc: Vec<String> = Vec::new();
+    let mut notes: Vec<String> = Vec::new();
+
+    for p in header_fields {
+        match p.as_rule() {
+            Rule::flag => state = parse_flag(p.as_str()),
+            Rule::string => payee_or_desc.push(string_inner(p)),
+            Rule::tag => notes.push(format!("tag:{}", &p.as_str()[1..])),
+            Rule::link => notes.push(format!("link:{}", &p.as_str()[1..])),
+            Rule::note => {
+                notes.push(p.into_inner().as_str().trim().to_string());
+            }
+            _ => {}
+        }
+    }
+
+    // Beancount transaction headers carry up to two strings: `"payee" "narration"`
+    // or just `"narration"`. We map: one string -> description; two strings
+    // -> code = payee, description = narration. The code field is the closest
+    // ledger-cli analogue for the payee slot.
+    let (code, description) = match payee_or_desc.len() {
+        0 => (None, String::new()),
+        1 => (None, payee_or_desc.remove(0)),
+        _ => {
+            let payee = payee_or_desc.remove(0);
+            let narration = payee_or_desc.remove(0);
+            (Some(payee), narration)
+        }
+    };
+
+    let mut postings = Vec::new();
+
+    for p in inner {
+        match p.as_rule() {
+            Rule::posting => postings.push(parse_posting(p)?),
+            Rule::metadata_line => {
+                notes.push(metadata_line_to_note(p));
+            }
+            _ => {}
+        }
+    }
+
+    Ok(Transaction {
+        date,
+        secondary_date: None,
+        state,
+        code,
+        description,
+        notes,
+        postings,
+    })
+}
+
+fn metadata_line_to_note(pair: Pair<Rule>) -> String {
+    // metadata_line = ${ indent+ ~ metadata_key ~ ":" ~ ws* ~ metadata_value ~ (NEWLINE | EOI) }
+    let mut inner = pair.into_inner();
+    let key = inner.next().unwrap().as_str().to_string();
+    let val = inner
+        .next()
+        .map(|v| v.as_str().trim().to_string())
+        .unwrap_or_default();
+    format!("{key}: {val}")
+}
+
+fn parse_posting(pair: Pair<Rule>) -> Result<Posting, Box<dyn std::error::Error>> {
+    let mut state = TransactionState::Uncleared;
+    let mut account = String::new();
+    let mut amount: Option<AmountDetails> = None;
+    let mut notes: Vec<String> = Vec::new();
+
+    for p in pair.into_inner() {
+        match p.as_rule() {
+            Rule::flag => state = parse_flag(p.as_str()),
+            Rule::posting_account => {
+                let inner_pair = p
+                    .into_inner()
+                    .next()
+                    .expect("posting_account must have one child");
+                account = inner_pair.as_str().trim().to_string();
+            }
+            Rule::amount_logic => amount = Some(parse_amount_logic(p)?),
+            Rule::note => notes.push(p.into_inner().as_str().trim().to_string()),
+            Rule::metadata_line => notes.push(metadata_line_to_note(p)),
+            _ => {}
+        }
+    }
+
+    Ok(Posting {
+        account,
+        amount,
+        state,
+        notes,
+        kind: PostingKind::Real,
+    })
+}
+
+fn parse_amount_logic(pair: Pair<Rule>) -> Result<AmountDetails, Box<dyn std::error::Error>> {
+    // amount_logic = ${ (ws{2,} | "\t") ~ value_expr ~ (ws* ~ lot_annotation_or_price)* }
+    let mut value: Option<ValueExpr> = None;
+    let mut lot_annotation = LotAnnotation::default();
+    let mut has_lot_annotation = false;
+    let mut lot_pricing: Option<LotPricing> = None;
+
+    for p in pair.into_inner() {
+        match p.as_rule() {
+            Rule::value_expr => value = Some(parse_expr(p)),
+            Rule::lot_annotation => {
+                has_lot_annotation = true;
+                merge_lot_annotation_into(p, &mut lot_annotation);
+            }
+            Rule::lot_price => {
+                let s = p.as_str();
+                let inner_expr = parse_expr(p.into_inner().next().unwrap());
+                if s.starts_with("@@") {
+                    lot_pricing = Some(LotPricing::Total(inner_expr));
+                } else {
+                    lot_pricing = Some(LotPricing::Unit(inner_expr));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Ok(AmountDetails::Amount {
+        value: value.expect("amount_logic without a value_expr"),
+        lot_annotation: has_lot_annotation.then_some(lot_annotation),
+        lot_pricing,
+        balance_assertion: None,
+    })
+}
+
+/// Parse the inner text of a Beancount `{...}` lot annotation.
+///
+/// Best-effort: comma-split the inner text and classify each part.
+/// - First amount-looking part (`<number> <COMMODITY>`) becomes the cost.
+/// - First ISO date becomes the lot date.
+/// - First quoted string becomes the lot label.
+///
+/// Beancount's wildcard `*` (alone or as the first part) is silently dropped:
+/// "automatic cost" semantics are not yet modelled.
+fn merge_lot_annotation_into(pair: Pair<Rule>, acc: &mut LotAnnotation) {
+    // lot_annotation = ${ ("{{" ~ lot_inner_total ~ "}}") | ("{" ~ lot_inner ~ "}") }
+    let inner = pair
+        .into_inner()
+        .next()
+        .expect("lot_annotation must have an inner");
+    let raw = inner.as_str();
+    for part in raw.split(',') {
+        let part = part.trim();
+        if part.is_empty() || part == "*" {
+            continue;
+        }
+        // Quoted label?
+        if let Some(stripped) = part.strip_prefix('"').and_then(|s| s.strip_suffix('"')) {
+            if acc.note.is_none() {
+                acc.note = Some(stripped.to_string());
+            }
+            continue;
+        }
+        // ISO date?
+        if let Ok(d) = chrono::NaiveDate::parse_from_str(part, "%Y-%m-%d") {
+            if acc.date.is_none() {
+                acc.date = Some(d);
+            }
+            continue;
+        }
+        // Otherwise: try to parse as a value expression (the cost).
+        if acc.cost.is_none()
+            && let Ok(mut pairs) = BeancountParser::parse(Rule::value_expr, part)
+            && let Some(p) = pairs.next()
+        {
+            acc.cost = Some(parse_expr(p));
+        }
+    }
+}
+
+// ---
+// Directives
+// ---
+fn parse_open_directive(pair: Pair<Rule>) -> Directive {
+    // open_directive = ${ date ~ ws+ ~ "open" ~ ws+ ~ account
+    //   ~ (ws+ ~ commodity_list)? ~ (ws+ ~ booking_method)?
+    //   ~ (ws* ~ note)? ~ (NEWLINE | EOI) ~ metadata_line* }
+    let mut inner = pair.into_inner();
+    let _date = parse_date(inner.next().unwrap()); // date is captured at the marker level; not used in Directive::Account
+    let name = inner.next().unwrap().as_str().to_string();
+
+    let mut notes = Vec::new();
+    let items = Vec::new();
+
+    for p in inner {
+        match p.as_rule() {
+            Rule::commodity_list => {
+                // Currencies on `open` aren't representable as a structured
+                // AccountItem yet; preserve them as a metadata note.
+                let list: Vec<&str> = p.into_inner().map(|c| c.as_str()).collect();
+                notes.push(format!("currencies: {}", list.join(",")));
+            }
+            Rule::booking_method => {
+                let inner_pair = p.into_inner().next().unwrap();
+                notes.push(format!("booking: {}", inner_pair.as_str()));
+            }
+            Rule::note => notes.push(p.into_inner().as_str().trim().to_string()),
+            Rule::metadata_line => notes.push(metadata_line_to_note(p)),
+            _ => {}
+        }
+    }
+
+    Directive::Account { name, notes, items }
+}
+
+fn parse_commodity_directive(pair: Pair<Rule>) -> Directive {
+    // commodity_directive = ${ date ~ ws+ ~ "commodity" ~ ws+ ~ commodity ... }
+    let mut inner = pair.into_inner();
+    let _date = parse_date(inner.next().unwrap());
+    let name = inner.next().unwrap().as_str().to_string();
+
+    let mut notes = Vec::new();
+    let items = Vec::new();
+
+    for p in inner {
+        match p.as_rule() {
+            Rule::note => notes.push(p.into_inner().as_str().trim().to_string()),
+            Rule::metadata_line => notes.push(metadata_line_to_note(p)),
+            _ => {}
+        }
+    }
+
+    Directive::Commodity { name, notes, items }
+}
+
+fn parse_balance_directive(pair: Pair<Rule>) -> AssertionDirective {
+    // balance_directive = ${ date ~ ws+ ~ "balance" ~ ws+ ~ account ~ ws+ ~ value_expr ... }
+    let mut inner = pair.into_inner();
+    let date = parse_date(inner.next().unwrap());
+    let account = inner.next().unwrap().as_str().to_string();
+    let value_expr_pair = inner
+        .find(|p| p.as_rule() == Rule::value_expr)
+        .expect("balance_directive must have a value_expr");
+    let amount = parse_expr(value_expr_pair);
+
+    AssertionDirective {
+        date,
+        account,
+        amount,
+        // Beancount balance assertions are strict by definition (the
+        // tolerance comes from the precision of the asserted amount, not
+        // from a weak-vs-strict toggle as in ledger-cli/hledger).
+        strict: true,
+    }
+}
+
+fn parse_price_directive(pair: Pair<Rule>) -> HistoricalPrice {
+    // price_directive = ${ date ~ ws+ ~ "price" ~ ws+ ~ commodity ~ ws+ ~ value_expr ... }
+    let mut inner = pair.into_inner();
+    let date = parse_date(inner.next().unwrap());
+    let commodity = inner.next().unwrap().as_str().to_string();
+    let value_expr_pair = inner
+        .find(|p| p.as_rule() == Rule::value_expr)
+        .expect("price_directive must have a value_expr");
+    let price = parse_expr(value_expr_pair);
+
+    HistoricalPrice {
+        date,
+        time: None,
+        commodity,
+        price,
+    }
+}
+
+fn parse_pad_directive(pair: Pair<Rule>) -> PadDirective {
+    // pad_directive = ${ date ~ ws+ ~ "pad" ~ ws+ ~ account ~ ws+ ~ account ... }
+    let mut inner = pair.into_inner();
+    let date = parse_date(inner.next().unwrap());
+    let target_account = inner.next().unwrap().as_str().to_string();
+    let source_account = inner.next().unwrap().as_str().to_string();
+
+    PadDirective {
+        date,
+        target_account,
+        source_account,
+    }
+}
+
+// ---
+// Value expression parser (Pratt) -- shape mirrors hledger's.
+// ---
+static PRATT: LazyLock<PrattParser<Rule>> = LazyLock::new(|| {
+    use Rule::*;
+    use pest::pratt_parser::{Assoc::*, Op};
+    PrattParser::new()
+        .op(Op::infix(add, Left) | Op::infix(sub, Left))
+        .op(Op::infix(mul, Left) | Op::infix(div, Left))
+        .op(Op::prefix(prefix_op))
+});
+
+fn parse_expr(pair: Pair<Rule>) -> ValueExpr {
+    // value_expr = ${ expr ~ (ws+ ~ commodity)? }
+    let mut inner = pair.into_inner();
+    let expr_pair = inner.next().expect("empty value_expr");
+    let mut ast = run_pratt(expr_pair.into_inner());
+
+    if let Some(comm_pair) = inner.next() {
+        ast = ValueExpr::Typed {
+            expr: Box::new(ast),
+            commodity: comm_pair.as_str().to_string(),
+        };
+    }
+    ast
+}
+
+fn run_pratt(pairs: Pairs<Rule>) -> ValueExpr {
+    PRATT
+        .map_primary(|pair| match pair.as_rule() {
+            Rule::term => run_pratt(pair.into_inner()),
+            Rule::primary => {
+                let base = pair.into_inner().next().expect("primary must have a base");
+                run_pratt(pest::iterators::Pairs::single(base))
+            }
+            Rule::amount => {
+                let mut inner = pair.into_inner();
+                let first = inner.next().unwrap();
+                match first.as_rule() {
+                    Rule::number => {
+                        let val = clean_decimal(first.as_str());
+                        let comm = inner.next().map(|c| c.as_str().to_string());
+                        ValueExpr::Amount {
+                            value: val,
+                            commodity: comm,
+                        }
+                    }
+                    _ => unreachable!("unexpected amount sub-rule: {:?}", first.as_rule()),
+                }
+            }
+            Rule::commodity => ValueExpr::Commodity(pair.as_str().to_string()),
+            Rule::expr => run_pratt(pair.into_inner()),
+            _ => unreachable!("unexpected primary rule: {:?}", pair.as_rule()),
+        })
+        .map_prefix(|op, expr| ValueExpr::Unary {
+            op: if op.as_str() == "-" { Op::Sub } else { Op::Add },
+            expr: Box::new(expr),
+        })
+        .map_infix(|lhs, op, rhs| {
+            let op = match op.as_rule() {
+                Rule::add => Op::Add,
+                Rule::sub => Op::Sub,
+                Rule::mul => Op::Mul,
+                Rule::div => Op::Div,
+                _ => unreachable!(),
+            };
+            ValueExpr::Binary {
+                lhs: Box::new(lhs),
+                rhs: Box::new(rhs),
+                op,
+            }
+        })
+        .parse(pairs)
+}
+
+fn clean_decimal(s: &str) -> Decimal {
+    s.replace(',', "").parse().unwrap_or(Decimal::ZERO)
+}
+
+// ---
+// Convenience function (test-only)
+// ---
+/// Parse Beancount source with no `include` support.
+///
+/// Any `include` directive in the input is silently resolved to an empty
+/// string (no entries pulled in). Useful for unit tests and standalone
+/// parsing.
+#[cfg(test)]
+pub(crate) fn parse_beancount(input: &str) -> Result<Journal, Box<dyn std::error::Error>> {
+    Parser {
+        opener: |_| Ok(String::new()),
+        base_path: PathBuf::new(),
+    }
+    .parse(input)
+}
+
+// ---
+// Frontend impl
+// ---
+/// The Beancount file-format frontend (experimental).
+///
+/// Recognises `.beancount` files and lowers them to a
+/// [`crate::resolution::HIR`] via the Beancount PEG grammar and the
+/// AST adapter in this module.
+///
+/// ## Extension dispatch
+///
+/// | Extension | Frontend |
+/// |-----------|----------|
+/// | `.beancount` | [`BeancountFrontend`] |
+///
+/// ## Experimental
+///
+/// The Beancount frontend is shipped behind the `M#9` milestone marker
+/// because the `pad` directive evaluator (#147) is not yet implemented:
+/// pads are preserved in the AST as markers but produce no balancing
+/// transaction during elaboration. See the module-level docs for the
+/// full mapping table and known gaps.
+pub struct BeancountFrontend;
+
+impl crate::frontend::Frontend for BeancountFrontend {
+    fn extensions(&self) -> &'static [&'static str] {
+        &["beancount"]
+    }
+
+    fn parse(
+        &self,
+        input: &str,
+        base_path: &std::path::Path,
+        opener: &crate::frontend::Opener,
+    ) -> Result<crate::resolution::HIR, Box<dyn std::error::Error>> {
+        let ast_journal = Parser {
+            opener: |path: &str| opener(path),
+            base_path: base_path.to_path_buf(),
+        }
+        .parse(input)?;
+        Ok(ast_journal.try_into()?)
+    }
+}
+
+// ---
+// Tests
+// ---
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pest::Parser as _;
+    use rust_decimal::dec;
 
     /// The fixture covers every directive type the grammar supports;
     /// it is the contract for #145.
     const SAMPLE: &str = include_str!("../../../tests/fixtures/sample.beancount");
+
+    // -- grammar-level coverage (carried over from #145) ----------------------
 
     #[test]
     fn sample_fixture_parses() {
@@ -52,8 +630,6 @@ mod tests {
 
     #[test]
     fn date_rejects_slash_separator() {
-        // Beancount is strict about ISO format. hledger's `2024/01/15`
-        // is not accepted.
         assert!(BeancountParser::parse(Rule::date, "2024/01/15").is_err());
     }
 
@@ -68,8 +644,6 @@ mod tests {
 
     #[test]
     fn currency_must_start_uppercase() {
-        // Beancount currencies are uppercase-led. Lowercase 'usd' is
-        // not a currency token; it would parse as something else.
         assert!(BeancountParser::parse(Rule::commodity, "usd").is_err());
     }
 
@@ -82,9 +656,6 @@ mod tests {
 
     #[test]
     fn account_requires_at_least_two_segments() {
-        // Beancount accounts always have at least two segments
-        // (Type:Name minimum). A bare "Assets" is not a valid
-        // account token.
         assert!(BeancountParser::parse(Rule::account, "Assets").is_err());
     }
 
@@ -110,13 +681,262 @@ mod tests {
 
     #[test]
     fn plugin_directive_with_and_without_arg() {
-        // Covered here rather than in sample.beancount because real
-        // Beancount plugins are signature-versioned and bean-check
-        // refuses the fixture if a referenced plugin's API has shifted.
         parse_one(Rule::plugin_directive, "plugin \"beancount.plugins.foo\"\n");
         parse_one(
             Rule::plugin_directive,
             "plugin \"beancount.plugins.foo\" \"argument-string\"\n",
         );
+    }
+
+    // -- adapter / Frontend tests --------------------------------------------
+
+    #[test]
+    fn simple_complete_transaction() {
+        let input = "\
+2024-01-12 * \"Acme Studio\" \"Invoice 0123\"
+  Assets:Bank:Checking          3400.00 USD
+  Income:Salary                -3400.00 USD
+";
+        let journal = parse_beancount(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!("expected transaction");
+        };
+        assert!(matches!(tx.state, TransactionState::Cleared));
+        assert_eq!(tx.code.as_deref(), Some("Acme Studio"));
+        assert_eq!(tx.description, "Invoice 0123");
+        assert_eq!(tx.postings.len(), 2);
+        assert_eq!(tx.postings[0].account, "Assets:Bank:Checking");
+    }
+
+    #[test]
+    fn flagged_transaction_with_single_narration() {
+        let input = "\
+2024-01-15 ! \"Groceries\"
+  Liabilities:CreditCard         -87.43 USD
+  Expenses:Food                   87.43 USD
+";
+        let journal = parse_beancount(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!();
+        };
+        assert!(matches!(tx.state, TransactionState::Pending));
+        assert!(tx.code.is_none(), "single-string header has no payee/code");
+        assert_eq!(tx.description, "Groceries");
+    }
+
+    #[test]
+    fn txn_keyword_is_uncleared() {
+        let input = "\
+2024-02-15 txn \"Apple lot purchase\"
+  Assets:Brokerage              10 AAPL
+  Assets:Bank:Checking       -1825.00 USD
+";
+        let journal = parse_beancount(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!();
+        };
+        assert!(matches!(tx.state, TransactionState::Uncleared));
+    }
+
+    #[test]
+    fn tags_and_links_become_notes() {
+        let input = "\
+2024-01-12 * \"Trip\" #vacation #beach ^trip-001
+  Expenses:Travel    100.00 USD
+  Assets:Bank:Checking
+";
+        let journal = parse_beancount(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!();
+        };
+        assert!(tx.notes.iter().any(|n| n == "tag:vacation"));
+        assert!(tx.notes.iter().any(|n| n == "tag:beach"));
+        assert!(tx.notes.iter().any(|n| n == "link:trip-001"));
+    }
+
+    #[test]
+    fn open_directive_becomes_account_directive() {
+        let input = "2024-01-01 open Assets:Bank:Checking USD\n";
+        let journal = parse_beancount(input).expect("parse");
+        let Entry::Directive(Directive::Account { name, notes, .. }) = &journal.entries[0] else {
+            panic!("expected Account directive, got {:?}", journal.entries[0]);
+        };
+        assert_eq!(name, "Assets:Bank:Checking");
+        assert!(notes.iter().any(|n| n.starts_with("currencies:")));
+    }
+
+    #[test]
+    fn open_with_booking_method() {
+        let input = "2024-01-01 open Assets:Brokerage AAPL,USD \"FIFO\"\n";
+        let journal = parse_beancount(input).expect("parse");
+        let Entry::Directive(Directive::Account { name, notes, .. }) = &journal.entries[0] else {
+            panic!();
+        };
+        assert_eq!(name, "Assets:Brokerage");
+        assert!(notes.iter().any(|n| n == "booking: FIFO"));
+        assert!(notes.iter().any(|n| n.contains("AAPL,USD")));
+    }
+
+    #[test]
+    fn close_directive_becomes_comment() {
+        let input = "2024-12-31 close Liabilities:CreditCard\n";
+        let journal = parse_beancount(input).expect("parse");
+        assert!(matches!(journal.entries[0], Entry::Comment(_)));
+    }
+
+    #[test]
+    fn commodity_directive_round_trip() {
+        let input = "\
+2024-01-01 commodity USD
+  name: \"US Dollar\"
+";
+        let journal = parse_beancount(input).expect("parse");
+        let Entry::Directive(Directive::Commodity { name, notes, .. }) = &journal.entries[0] else {
+            panic!();
+        };
+        assert_eq!(name, "USD");
+        assert!(notes.iter().any(|n| n.starts_with("name:")));
+    }
+
+    #[test]
+    fn balance_directive_becomes_assertion() {
+        let input = "2024-01-15 balance Assets:Bank:Checking 5000.00 USD\n";
+        let journal = parse_beancount(input).expect("parse");
+        let Entry::Assertion(a) = &journal.entries[0] else {
+            panic!();
+        };
+        assert_eq!(a.account, "Assets:Bank:Checking");
+        assert_eq!(a.date.year, Some(2024));
+        assert_eq!(a.date.month, 1);
+        assert_eq!(a.date.date, 15);
+        assert!(a.strict, "Beancount balance assertions are strict");
+        match &a.amount {
+            ValueExpr::Amount { value, commodity } => {
+                assert_eq!(*value, dec!(5000.00));
+                assert_eq!(commodity.as_deref(), Some("USD"));
+            }
+            other => panic!("unexpected amount shape: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn price_directive_becomes_historical_price() {
+        let input = "2024-02-15 price AAPL 182.50 USD\n";
+        let journal = parse_beancount(input).expect("parse");
+        let Entry::HistoricalPrice(hp) = &journal.entries[0] else {
+            panic!();
+        };
+        assert_eq!(hp.commodity, "AAPL");
+        assert_eq!(hp.date.year, Some(2024));
+    }
+
+    #[test]
+    fn pad_directive_becomes_pad_marker() {
+        let input = "2024-01-01 pad Assets:Bank:Checking Equity:Opening-Balances\n";
+        let journal = parse_beancount(input).expect("parse");
+        let Entry::Pad(p) = &journal.entries[0] else {
+            panic!("expected Pad marker, got {:?}", journal.entries[0]);
+        };
+        assert_eq!(p.target_account, "Assets:Bank:Checking");
+        assert_eq!(p.source_account, "Equity:Opening-Balances");
+    }
+
+    #[test]
+    fn note_document_event_query_custom_become_comments() {
+        let input = "\
+2024-01-20 note Assets:Bank:Checking \"Need to verify\"
+2024-01-22 document Assets:Bank:Checking \"jan-statement.txt\"
+2024-01-01 event \"location\" \"Berlin\"
+2024-06-30 query \"q1\" \"SELECT date\"
+2024-01-01 custom \"budget\" \"Expenses:Food\" 200.00 USD
+";
+        let journal = parse_beancount(input).expect("parse");
+        // All five preserve as comments (no semantic mapping yet).
+        assert_eq!(
+            journal.entries.len(),
+            5,
+            "five entries; got {}",
+            journal.entries.len()
+        );
+        for e in &journal.entries {
+            assert!(matches!(e, Entry::Comment(_)));
+        }
+    }
+
+    #[test]
+    fn lot_annotation_cost_date_label() {
+        let input = "\
+2024-02-15 * \"Apple lot purchase\"
+  Assets:Brokerage   10 AAPL {182.50 USD, 2024-02-15, \"buy-2024-02\"}
+  Assets:Bank:Checking       -1825.00 USD
+";
+        let journal = parse_beancount(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!();
+        };
+        let Some(AmountDetails::Amount { lot_annotation, .. }) = &tx.postings[0].amount else {
+            panic!("expected Amount details");
+        };
+        let ann = lot_annotation.as_ref().expect("lot annotation present");
+        assert!(ann.cost.is_some(), "cost should be parsed");
+        assert_eq!(
+            ann.date,
+            chrono::NaiveDate::from_ymd_opt(2024, 2, 15),
+            "date should be parsed"
+        );
+        assert_eq!(ann.note.as_deref(), Some("buy-2024-02"));
+    }
+
+    #[test]
+    fn lot_price_at_per_unit() {
+        let input = "\
+2024-05-15 * \"Buy euros\"
+  Assets:Cash:EUR    500.00 EUR @ 1.07 USD
+  Assets:Bank:Checking
+";
+        let journal = parse_beancount(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!();
+        };
+        let Some(AmountDetails::Amount { lot_pricing, .. }) = &tx.postings[0].amount else {
+            panic!();
+        };
+        assert!(matches!(lot_pricing, Some(LotPricing::Unit(_))));
+    }
+
+    #[test]
+    fn arithmetic_amount_in_posting() {
+        let input = "\
+2024-03-01 *
+  Expenses:Food    (50.00 + 50.00) USD
+  Assets:Bank:Checking
+";
+        let journal = parse_beancount(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!();
+        };
+        let Some(AmountDetails::Amount { value, .. }) = &tx.postings[0].amount else {
+            panic!();
+        };
+        assert!(
+            matches!(value, ValueExpr::Typed { .. }),
+            "expected Typed wrapping arithmetic, got {value:?}"
+        );
+    }
+
+    #[test]
+    fn sample_fixture_round_trips_through_resolution() {
+        // The full parity fixture should walk through parse + resolution
+        // without errors. `pad` survives as a marker; resolution drops it
+        // (#147 owns the elaboration path).
+        let journal = parse_beancount(SAMPLE).expect("parse sample.beancount");
+        assert!(!journal.entries.is_empty());
+        let _hir: crate::resolution::HIR = journal.try_into().expect("resolve sample.beancount");
+    }
+
+    #[test]
+    fn frontend_extensions_lists_beancount() {
+        use crate::frontend::Frontend;
+        assert!(BeancountFrontend.extensions().contains(&"beancount"));
     }
 }

--- a/crates/doppio/src/grammars/beancount/mod.rs
+++ b/crates/doppio/src/grammars/beancount/mod.rs
@@ -28,7 +28,7 @@
 //! | `pad target source` | [`Entry::Pad`] -- marker; #147 owns elaboration |
 //! | `option` / `plugin` | [`Entry::Comment`] |
 //! | `include "path"` | recursively parsed via the same opener as hledger |
-//! | `#tag` / `^link` on a transaction | folded into `transaction.notes` as `tag:NAME` / `link:NAME` |
+//! | `#tag` / `^link` on a transaction | collected into `Transaction.tags` (links collapse onto tags; the AST has no separate link concept) |
 //!
 //! ## Known limitations / stubs
 //!
@@ -177,18 +177,33 @@ fn parse_transaction(pair: Pair<Rule>) -> Result<Transaction, Box<dyn std::error
     let mut state = TransactionState::Uncleared;
     let mut payee_or_desc: Vec<String> = Vec::new();
     let mut notes: Vec<String> = Vec::new();
+    let mut tags: Vec<String> = Vec::new();
 
     for p in header_fields {
         match p.as_rule() {
             Rule::flag => state = parse_flag(p.as_str()),
             Rule::string => payee_or_desc.push(string_inner(p)),
-            Rule::tag => notes.push(format!("tag:{}", &p.as_str()[1..])),
-            Rule::link => notes.push(format!("link:{}", &p.as_str()[1..])),
+            // Both `#tag` and `^link` collapse to tags. Beancount
+            // distinguishes them (links bind related transactions
+            // across an event; tags categorise) but our AST/HIR has
+            // no separate link concept, and resolution lifts the
+            // bare-tag `:a:b:` note format into Transaction.tags. A
+            // distinct link channel can be added later if a real
+            // consumer needs to tell them apart.
+            Rule::tag | Rule::link => tags.push(p.as_str()[1..].to_string()),
             Rule::note => {
                 notes.push(p.into_inner().as_str().trim().to_string());
             }
             _ => {}
         }
+    }
+
+    // Emit collected tags/links as a single ledger-cli-style bare-tag
+    // note. resolve_metadata splits on `:` and pushes each into
+    // Transaction.tags, so multiple tags survive (they would otherwise
+    // clobber each other if encoded as `key: value` metadata).
+    if !tags.is_empty() {
+        notes.push(format!(":{}:", tags.join(":")));
     }
 
     // Beancount transaction headers carry up to two strings: `"payee" "narration"`
@@ -754,7 +769,7 @@ mod tests {
     }
 
     #[test]
-    fn tags_and_links_become_notes() {
+    fn tags_and_links_collected_as_bare_tag_note() {
         let input = "\
 2024-01-12 * \"Trip\" #vacation #beach ^trip-001
   Expenses:Travel    100.00 USD
@@ -764,9 +779,55 @@ mod tests {
         let Entry::Transaction(tx) = &journal.entries[0] else {
             panic!();
         };
-        assert!(tx.notes.iter().any(|n| n == "tag:vacation"));
-        assert!(tx.notes.iter().any(|n| n == "tag:beach"));
-        assert!(tx.notes.iter().any(|n| n == "link:trip-001"));
+        // The AST stores them as a single `:a:b:c:` note that resolve_metadata
+        // lifts into Transaction.tags.
+        assert!(
+            tx.notes.iter().any(|n| n == ":vacation:beach:trip-001:"),
+            "expected a bare-tag note, got notes={:?}",
+            tx.notes
+        );
+    }
+
+    #[test]
+    fn tags_and_links_land_in_resolved_transaction_tags() {
+        // End-to-end: parse a Beancount transaction with #tag and ^link, run
+        // it through resolution, and verify both kinds end up in
+        // Transaction.tags (links collapse onto tags). This guards against the
+        // earlier `tag:NAME` encoding which clobbered itself in the metadata
+        // map for multi-tag transactions.
+        let input = "\
+2024-01-01 open Expenses:Travel
+2024-01-01 open Assets:Bank:Checking USD
+
+2024-01-12 * \"Trip\" #vacation #beach ^trip-001
+  Expenses:Travel        100.00 USD
+  Assets:Bank:Checking  -100.00 USD
+";
+        let journal = parse_beancount(input).expect("parse");
+        let hir: crate::resolution::HIR = journal.try_into().expect("resolve");
+        let tx_entry = hir
+            .entries
+            .iter()
+            .find(|e| matches!(e.data, crate::resolution::Entry::Transaction(_)))
+            .expect("a transaction entry should be present");
+        let crate::resolution::Entry::Transaction(ref tx) = tx_entry.data else {
+            unreachable!();
+        };
+        let tags: std::collections::HashSet<&str> = tx.tags.iter().map(String::as_str).collect();
+        assert!(tags.contains("vacation"), "tags={:?}", tx.tags);
+        assert!(tags.contains("beach"), "tags={:?}", tx.tags);
+        assert!(tags.contains("trip-001"), "tags={:?}", tx.tags);
+        // Nothing should have leaked into the metadata map.
+        assert!(
+            !tx.metadata.contains_key("tag"),
+            "metadata leak: {:?}",
+            tx.metadata
+        );
+        assert!(
+            !tx.metadata.contains_key("link"),
+            "metadata leak: {:?}",
+            tx.metadata
+        );
     }
 
     #[test]

--- a/crates/doppio/src/grammars/mod.rs
+++ b/crates/doppio/src/grammars/mod.rs
@@ -7,10 +7,11 @@
 //! - [`ledger`] -- the ledger-cli plain-text accounting format (`.ledger`).
 //! - [`hledger`] -- the hledger dialect (`.hledger`, `.journal`).
 //! - [`beancount`] -- the Beancount format (`.beancount`).
-//!   **Experimental**: ships the grammar (#145); the `Frontend` trait
-//!   impl (#146) and the `pad` directive evaluator (#147) are
-//!   in-flight.
+//!   **Experimental**: the grammar (#145) and Frontend trait impl
+//!   (#146) ship; the `pad` directive evaluator (#147) is still
+//!   in-flight, so pads are preserved as markers but produce no
+//!   balancing transaction during elaboration.
 
-pub(crate) mod beancount;
+pub mod beancount;
 pub mod hledger;
 pub mod ledger;

--- a/crates/doppio/src/lib.rs
+++ b/crates/doppio/src/lib.rs
@@ -85,6 +85,7 @@ mod elaboration_ext;
 
 pub use elaboration::Journal;
 pub use frontend::Frontend;
+pub use grammars::beancount::BeancountFrontend;
 pub use grammars::hledger::HledgerFrontend;
 pub use grammars::ledger::LedgerFrontend;
 
@@ -98,6 +99,7 @@ pub use grammars::ledger::LedgerFrontend;
 /// | `"ledger"` | [`LedgerFrontend`] |
 /// | `"hledger"` | [`HledgerFrontend`] |
 /// | `"journal"` | [`HledgerFrontend`] |
+/// | `"beancount"` | [`BeancountFrontend`] (experimental) |
 /// | anything else / `None` | [`LedgerFrontend`] (default) |
 ///
 /// # Example
@@ -112,27 +114,28 @@ pub use grammars::ledger::LedgerFrontend;
 /// let fe3 = doppio::frontend_for_extension(Some("journal"));
 /// assert!(fe3.extensions().contains(&"journal"));
 ///
+/// let fe5 = doppio::frontend_for_extension(Some("beancount"));
+/// assert!(fe5.extensions().contains(&"beancount"));
+///
 /// // Unknown extensions fall back to the ledger frontend.
 /// let fe4 = doppio::frontend_for_extension(None);
 /// assert!(fe4.extensions().contains(&"ledger"));
 /// ```
 pub fn frontend_for_extension(ext: Option<&str>) -> Box<dyn Frontend> {
-    let frontends: &[&dyn Frontend] = &[&HledgerFrontend, &LedgerFrontend];
-    for fe in frontends {
-        if ext.is_some_and(|e| fe.extensions().contains(&e)) {
-            // Construct an owned Box of the concrete type matched above.
-            // We iterate over trait-object refs to find the right frontend,
-            // then return a fresh Box of the concrete type.  This avoids
-            // cloning or storing the Frontend behind Arc.
-            if fe.extensions().contains(&"hledger") || fe.extensions().contains(&"journal") {
-                return Box::new(HledgerFrontend);
-            } else {
-                return Box::new(LedgerFrontend);
-            }
-        }
+    let Some(e) = ext else {
+        return Box::new(LedgerFrontend);
+    };
+    if HledgerFrontend.extensions().contains(&e) {
+        Box::new(HledgerFrontend)
+    } else if BeancountFrontend.extensions().contains(&e) {
+        Box::new(BeancountFrontend)
+    } else if LedgerFrontend.extensions().contains(&e) {
+        Box::new(LedgerFrontend)
+    } else {
+        // Preserve existing fall-through behaviour: unknown extensions
+        // dispatch to the ledger frontend.
+        Box::new(LedgerFrontend)
     }
-    // Default: ledger frontend (preserves existing behaviour for unknown extensions).
-    Box::new(LedgerFrontend)
 }
 
 // ---

--- a/crates/doppio/src/resolution.rs
+++ b/crates/doppio/src/resolution.rs
@@ -534,6 +534,12 @@ impl TryFrom<ast::Journal> for HIR {
                 ast::Entry::Directive(ast::Directive::Unknown(_)) | ast::Entry::Comment(_) => {
                     // Discard unrecognised directives and comments.
                 }
+                ast::Entry::Pad(_) => {
+                    // Beancount `pad` directive. The evaluator that fills in
+                    // a balancing transaction up to the next balance assertion
+                    // is the subject of #147; for now resolution preserves
+                    // the rest of the journal but ignores the pad itself.
+                }
                 ast::Entry::Directive(ast::Directive::Commodity {
                     name,
                     notes: _,


### PR DESCRIPTION
## Summary

- Lower the Beancount pest parse tree into \`ast::Journal\` and wire \`BeancountFrontend\` into \`frontend_for_extension\` so \`.beancount\` files dispatch automatically.
- Add a new \`ast::Entry::Pad(PadDirective)\` marker variant for the Beancount \`pad\` directive. Resolution discards it with a TODO pointing at #147; the evaluator semantics are still the subject of that issue.
- Tighten the grammar's \`metadata_line\` rule to require lowercase-led keys (matches Beancount's spec) so postings whose accounts begin with an uppercase letter (\`Assets:Bank:Checking\`) are no longer mis-matched as metadata.

Tracks: #146 / closes #146 once merged. Parent: #144. Depends on #145 (already merged).

## Mapping decisions

Even though Beancount's directive set is wider than ledger-cli's, most Beancount directives map cleanly onto existing AST nodes; only \`pad\` needed a new variant. The full table lives in the module-level docs (\`crates/doppio/src/grammars/beancount/mod.rs\` -- \"Mapping decisions\" section). Highlights:

| Beancount | AST |
|-----------|-----|
| \`open Account [currencies] [booking]\` | \`Directive::Account\` (currencies + booking method preserved as notes) |
| \`close Account\` | \`Entry::Comment\` |
| \`commodity SYMBOL\` | \`Directive::Commodity\` |
| \`* / ! / txn\` transactions | \`Entry::Transaction\` |
| \`balance Account amount\` | \`Entry::Assertion\` (strict) |
| \`price COMM amount\` | \`Entry::HistoricalPrice\` |
| \`note / document / event / query / custom\` | \`Entry::Comment\` (preserved verbatim) |
| **\`pad target source\`** | **\`Entry::Pad\`** (new marker; #147 owns elaboration) |
| \`option / plugin\` | \`Entry::Comment\` |
| \`include \"path\"\` | recursively parsed via the same opener as hledger |
| \`#tag\` / \`^link\` on a transaction | folded into \`transaction.notes\` as \`tag:NAME\` / \`link:NAME\` |

Lot annotations (\`{cost, date, label}\`) are parsed best-effort: comma-split, classified as cost (first amount-looking part), date (ISO), or quoted label. Known gaps -- wildcard \`{*}\` silently dropped, total-cost \`{{total}}\` not distinguished from per-unit \`{cost}\`, cost-vs-held commodity distinction collapsed -- are tracked in **#185** and called out in the module docs and \`merge_lot_annotation_into\` rustdoc.

## Grammar fix surfaced by testing

The original \`metadata_line\` rule allowed any \`identifier\` (case-insensitive) as a metadata key, which collided with posting accounts: \`Assets:Bank:Checking 100 USD\` was greedily matched as \`identifier (Assets) ~ \":\" ~ metadata_value (Bank:Checking ...)\` and won over \`posting\`. The fix is to enforce Beancount's actual rule: metadata keys must be lowercase-led. Added a separate \`metadata_key\` token that requires \`ASCII_ALPHA_LOWER\` as the first character.

## What's NOT in this PR (deliberately)

- The \`pad\` evaluator (#147). Pads survive as \`Entry::Pad\` markers; resolution discards them with a TODO. Real elaboration is #147's job after the design discussion.
- Complete lot-annotation handling (#185, filed alongside this PR). The current parser is enough for the common case in the parity fixture.
- Cross-frontend canonical-tool CI step (#183, filed during #145 review).

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo test --workspace\` (28 beancount tests + 258 doppio lib + ...; all green)
- [x] \`cargo build --target wasm32-unknown-unknown -p doppio --lib\`
- [x] \`bean-check tests/fixtures/sample.beancount\` (still clean after grammar tightening)
- [x] Sample fixture round-trips through parse + resolution end-to-end (see \`sample_fixture_round_trips_through_resolution\` test)