### PR TITLE
feat(beancount): pad directive evaluator (#147)

### DIFF
--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -50,6 +50,22 @@ struct AccountBalances {
 #[derive(Default, Clone, Debug)]
 struct RunningState {
     account_balances: BTreeMap<String, AccountBalances>,
+    /// Beancount `pad` markers awaiting their next `balance` assertion,
+    /// keyed by the pad's target account. A new pad on the same target
+    /// account overwrites any earlier one (Beancount's
+    /// "most-recent-pad-wins" rule for back-to-back pads on a single
+    /// account). A pad that never sees a follow-up balance assertion is
+    /// silently discarded at end-of-journal.
+    pending_pads: BTreeMap<String, PendingPad>,
+}
+
+/// A pad directive observed but not yet consumed by a balance assertion.
+#[derive(Clone, Debug)]
+struct PendingPad {
+    /// The pad's own date -- used as the synthesized transaction's date.
+    date: chrono::NaiveDate,
+    /// The counter-account that will absorb the padding amount.
+    source_account: String,
 }
 
 /// A commodity name (e.g. `"USD"`, `"BTC"`, `"$"`).
@@ -350,6 +366,19 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
         for entry in value.entries {
             let entry_context = &value.contexts[entry.context_id];
             match entry.data {
+                resolution::Entry::Pad(p) => {
+                    // Beancount `pad`: remember the (target, source) pair until
+                    // the next balance assertion on `target` consumes it. A
+                    // second pad on the same target before any assertion
+                    // overwrites the first (most-recent-pad-wins).
+                    state.pending_pads.insert(
+                        p.target_account,
+                        PendingPad {
+                            date: p.date,
+                            source_account: p.source_account,
+                        },
+                    );
+                }
                 resolution::Entry::Assertion(assertion) => {
                     // Evaluate the expected amount expression.
                     let (expected_amount, expected_commodity) =
@@ -360,12 +389,105 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                         )?;
 
                     // Look up the account's current balance for this commodity.
-                    let actual_amount = state
+                    let mut actual_amount = state
                         .account_balances
                         .get(&assertion.account)
                         .and_then(|ab| ab.commodity.get(&expected_commodity))
                         .copied()
                         .unwrap_or(Decimal::ZERO);
+
+                    // If a pad on this account is pending, synthesize a
+                    // balancing transaction (back-dated to the pad's date)
+                    // that brings `actual_amount` up to `expected_amount`,
+                    // and apply it to the running state so the assertion
+                    // below passes by construction. The synthesized
+                    // transaction is also pushed into the output journal so
+                    // downstream consumers see the inserted postings.
+                    if let Some(pad) = state.pending_pads.remove(&assertion.account) {
+                        let diff = expected_amount - actual_amount;
+                        if !diff.is_zero() {
+                            // Ensure both accounts exist in the accounts map
+                            // (so callers iterating accounts see them).
+                            for acct in [&assertion.account, &pad.source_account] {
+                                if !accounts.contains_key(acct.as_str()) {
+                                    accounts.insert(acct.clone(), Default::default());
+                                }
+                            }
+
+                            // Update running balances: target += diff, source -= diff.
+                            let target_bal = state
+                                .account_balances
+                                .entry(assertion.account.clone())
+                                .or_default();
+                            *(target_bal
+                                .commodity
+                                .entry(expected_commodity.clone())
+                                .or_default()) += diff;
+                            let source_bal = state
+                                .account_balances
+                                .entry(pad.source_account.clone())
+                                .or_default();
+                            *(source_bal
+                                .commodity
+                                .entry(expected_commodity.clone())
+                                .or_default()) -= diff;
+
+                            // Build the synthesized transaction.
+                            let pad_marker_meta: BTreeMap<String, String> =
+                                [("pad".to_string(), pad.source_account.clone())]
+                                    .into_iter()
+                                    .collect();
+                            let target_amount = crate::elaboration::Amount {
+                                by_commodity: BTreeMap::from([(
+                                    expected_commodity.clone(),
+                                    crate::decimal_to_proto(diff),
+                                )]),
+                            };
+                            let source_amount = crate::elaboration::Amount {
+                                by_commodity: BTreeMap::from([(
+                                    expected_commodity.clone(),
+                                    crate::decimal_to_proto(-diff),
+                                )]),
+                            };
+                            let synthesized_postings = vec![
+                                crate::elaboration::Posting {
+                                    account: assertion.account.clone(),
+                                    payee: String::from("(pad)"),
+                                    amount: Some(target_amount),
+                                    state: crate::state_to_proto(&TransactionState::Cleared),
+                                    tags: vec![],
+                                    metadata: BTreeMap::new(),
+                                    kind: crate::posting_kind_to_proto(ast::PostingKind::Real),
+                                    lot: None,
+                                },
+                                crate::elaboration::Posting {
+                                    account: pad.source_account.clone(),
+                                    payee: String::from("(pad)"),
+                                    amount: Some(source_amount),
+                                    state: crate::state_to_proto(&TransactionState::Cleared),
+                                    tags: vec![],
+                                    metadata: BTreeMap::new(),
+                                    kind: crate::posting_kind_to_proto(ast::PostingKind::Real),
+                                    lot: None,
+                                },
+                            ];
+                            transactions.push(crate::elaboration::Transaction {
+                                date: pad.date.to_epoch_days(),
+                                secondary_date: None,
+                                state: crate::state_to_proto(&TransactionState::Cleared),
+                                code: None,
+                                description: String::from(
+                                    "(padding inserted for balance assertion)",
+                                ),
+                                tags: vec![],
+                                metadata: pad_marker_meta,
+                                postings: synthesized_postings,
+                            });
+
+                            // The assertion now holds by construction.
+                            actual_amount = expected_amount;
+                        }
+                    }
 
                     // NOTE: strict (`==`) is currently treated identically to
                     // weak (`=`). Both check that the account balance for the

--- a/crates/doppio/src/grammars/beancount/mod.rs
+++ b/crates/doppio/src/grammars/beancount/mod.rs
@@ -567,20 +567,50 @@ fn clean_decimal(s: &str) -> Decimal {
 }
 
 // ---
+// Date-order normalisation
+// ---
+/// Beancount evaluates entries in **date order**, not source order, which
+/// matters for `pad` + `balance` (a pad must see all transactions on its
+/// target account between its date and the next assertion's date before
+/// computing the gap to fill).
+///
+/// We stable-sort the AST entries here so the resolver and elaborator can
+/// stay source-order-agnostic. Undated entries (directives, comments)
+/// keep their original relative position and sort before any dated entry
+/// because directives are setup that should apply before the journal's
+/// time-evolving state begins.
+fn sort_entries_by_date(entries: &mut [Entry]) {
+    entries.sort_by_key(entry_date_key);
+}
+
+fn entry_date_key(entry: &Entry) -> Option<Date> {
+    match entry {
+        Entry::Transaction(t) => Some(t.date.clone()),
+        Entry::Assertion(a) => Some(a.date.clone()),
+        Entry::HistoricalPrice(hp) => Some(hp.date.clone()),
+        Entry::Pad(p) => Some(p.date.clone()),
+        Entry::Directive(_) | Entry::Comment(_) => None,
+    }
+}
+
+// ---
 // Convenience function (test-only)
 // ---
 /// Parse Beancount source with no `include` support.
 ///
 /// Any `include` directive in the input is silently resolved to an empty
 /// string (no entries pulled in). Useful for unit tests and standalone
-/// parsing.
+/// parsing. Entries are date-sorted before return (matching the
+/// Beancount language semantics).
 #[cfg(test)]
 pub(crate) fn parse_beancount(input: &str) -> Result<Journal, Box<dyn std::error::Error>> {
-    Parser {
+    let mut journal = Parser {
         opener: |_| Ok(String::new()),
         base_path: PathBuf::new(),
     }
-    .parse(input)
+    .parse(input)?;
+    sort_entries_by_date(&mut journal.entries);
+    Ok(journal)
 }
 
 // ---
@@ -618,11 +648,16 @@ impl crate::frontend::Frontend for BeancountFrontend {
         base_path: &std::path::Path,
         opener: &crate::frontend::Opener,
     ) -> Result<crate::resolution::HIR, Box<dyn std::error::Error>> {
-        let ast_journal = Parser {
+        let mut ast_journal = Parser {
             opener: |path: &str| opener(path),
             base_path: base_path.to_path_buf(),
         }
         .parse(input)?;
+        // Beancount is date-ordered, not source-ordered. Sort once at the
+        // outermost call (after include resolution has flattened the tree)
+        // so resolver + elaborator can treat the entries as already in
+        // chronological order.
+        sort_entries_by_date(&mut ast_journal.entries);
         Ok(ast_journal.try_into()?)
     }
 }
@@ -1005,16 +1040,215 @@ mod tests {
     #[test]
     fn sample_fixture_round_trips_through_resolution() {
         // The full parity fixture should walk through parse + resolution
-        // without errors. `pad` survives as a marker; resolution drops it
-        // (#147 owns the elaboration path).
+        // without errors.
         let journal = parse_beancount(SAMPLE).expect("parse sample.beancount");
         assert!(!journal.entries.is_empty());
         let _hir: crate::resolution::HIR = journal.try_into().expect("resolve sample.beancount");
     }
 
     #[test]
+    fn sample_fixture_round_trips_through_elaboration() {
+        // End-to-end: parse + resolve + elaborate. The pad+balance pair
+        // in the fixture (`pad Assets:Bank:Checking Equity:Opening-Balances`
+        // followed by `balance Assets:Bank:Checking 5000.00 USD` after a
+        // 3400 USD deposit on Jan 12) should reconcile cleanly: the pad
+        // synthesizes a 1600 USD balancing transaction so the assertion
+        // passes.
+        let journal = parse_beancount(SAMPLE).expect("parse sample.beancount");
+        let hir: crate::resolution::HIR = journal.try_into().expect("resolve sample.beancount");
+        let elab: crate::elaboration::Journal = hir
+            .try_into()
+            .expect("elaborate sample.beancount (pad+balance must reconcile)");
+        // The synthesized pad transaction is tagged with metadata `pad: <source>`.
+        let pad_tx_count = elab
+            .transactions
+            .iter()
+            .filter(|t| t.metadata.contains_key("pad"))
+            .count();
+        assert_eq!(
+            pad_tx_count, 1,
+            "exactly one synthesized pad transaction expected"
+        );
+    }
+
+    #[test]
     fn frontend_extensions_lists_beancount() {
         use crate::frontend::Frontend;
         assert!(BeancountFrontend.extensions().contains(&"beancount"));
+    }
+
+    // -- pad evaluator (#147) -----------------------------------------------
+
+    fn elaborate(input: &str) -> Result<crate::elaboration::Journal, Box<dyn std::error::Error>> {
+        let journal = parse_beancount(input)?;
+        let hir: crate::resolution::HIR = journal.try_into()?;
+        Ok(hir.try_into()?)
+    }
+
+    #[test]
+    fn pad_fills_gap_to_next_balance_assertion() {
+        // Pad on Jan 1, 3400 USD deposit on Jan 12, balance assertion on
+        // Jan 15 expects 5000 USD. The pad must synthesize a 1600 USD
+        // (= 5000 - 3400) balancing transaction back-dated to Jan 1.
+        let input = "\
+2024-01-01 open Assets:Bank:Checking USD
+2024-01-01 open Income:Salary USD
+2024-01-01 open Equity:Opening-Balances
+
+2024-01-01 pad Assets:Bank:Checking Equity:Opening-Balances
+2024-01-15 balance Assets:Bank:Checking 5000.00 USD
+
+2024-01-12 *
+  Assets:Bank:Checking      3400.00 USD
+  Income:Salary            -3400.00 USD
+";
+        let elab = elaborate(input).expect("elaborate (pad+balance must reconcile)");
+        let pad_txs: Vec<_> = elab
+            .transactions
+            .iter()
+            .filter(|t| t.metadata.contains_key("pad"))
+            .collect();
+        assert_eq!(pad_txs.len(), 1, "expected exactly one synthesized pad txn");
+        let pad_tx = pad_txs[0];
+        assert_eq!(
+            pad_tx.metadata.get("pad").map(String::as_str),
+            Some("Equity:Opening-Balances"),
+            "pad provenance metadata should record the source account"
+        );
+        // Date is Jan 1 (pad's date), epoch days. NaiveDate::from_ymd(2024,1,1) -> 19723
+        assert_eq!(
+            pad_tx.date,
+            chrono::NaiveDate::from_ymd_opt(2024, 1, 1)
+                .unwrap()
+                .signed_duration_since(chrono::NaiveDate::from_ymd_opt(1970, 1, 1).unwrap())
+                .num_days() as i32,
+            "synthesized pad txn should be back-dated to the pad directive"
+        );
+        assert_eq!(pad_tx.postings.len(), 2);
+        // Target gets +1600, source gets -1600.
+        let target = pad_tx
+            .postings
+            .iter()
+            .find(|p| p.account == "Assets:Bank:Checking")
+            .expect("target posting present");
+        let source = pad_tx
+            .postings
+            .iter()
+            .find(|p| p.account == "Equity:Opening-Balances")
+            .expect("source posting present");
+        let target_usd = target
+            .amount
+            .as_ref()
+            .and_then(|a| a.by_commodity.get("USD"))
+            .expect("target amount in USD");
+        let source_usd = source
+            .amount
+            .as_ref()
+            .and_then(|a| a.by_commodity.get("USD"))
+            .expect("source amount in USD");
+        // 1600.00 -> mantissa 160000, scale 2; mantissa_high == 0 (positive)
+        assert_eq!(
+            (
+                target_usd.mantissa_low,
+                target_usd.mantissa_high,
+                target_usd.scale
+            ),
+            (160000, 0, 2),
+            "target should receive +1600.00"
+        );
+        // -1600.00 -> sign-extended high half is -1
+        assert_eq!(
+            source_usd.mantissa_high, -1,
+            "source amount should be negative"
+        );
+        assert_eq!(source_usd.scale, 2);
+    }
+
+    #[test]
+    fn pad_without_following_balance_is_silently_dropped() {
+        // No `balance` directive on Assets:Bank:Checking after the pad ->
+        // pad is silently discarded; no synthesized transaction.
+        let input = "\
+2024-01-01 open Assets:Bank:Checking USD
+2024-01-01 open Equity:Opening-Balances
+
+2024-01-01 pad Assets:Bank:Checking Equity:Opening-Balances
+";
+        let elab = elaborate(input).expect("elaborate");
+        let pad_txs = elab
+            .transactions
+            .iter()
+            .filter(|t| t.metadata.contains_key("pad"))
+            .count();
+        assert_eq!(
+            pad_txs, 0,
+            "pad without a follow-up balance assertion must be dropped, not error"
+        );
+    }
+
+    #[test]
+    fn most_recent_pad_wins_when_multiple_precede_one_balance() {
+        // Two pads on the same target account before any balance assertion;
+        // Beancount keeps only the most recent. The Jan 5 pad's source
+        // (Equity:Late-Init) should be the synthesized txn's source, not
+        // the Jan 1 pad's (Equity:Opening-Balances).
+        let input = "\
+2024-01-01 open Assets:Bank:Checking USD
+2024-01-01 open Equity:Opening-Balances
+2024-01-01 open Equity:Late-Init
+
+2024-01-01 pad Assets:Bank:Checking Equity:Opening-Balances
+2024-01-05 pad Assets:Bank:Checking Equity:Late-Init
+2024-01-15 balance Assets:Bank:Checking 1000.00 USD
+";
+        let elab = elaborate(input).expect("elaborate");
+        let pad_txs: Vec<_> = elab
+            .transactions
+            .iter()
+            .filter(|t| t.metadata.contains_key("pad"))
+            .collect();
+        assert_eq!(pad_txs.len(), 1, "exactly one synthesized pad txn");
+        let pad_tx = pad_txs[0];
+        assert_eq!(
+            pad_tx.metadata.get("pad").map(String::as_str),
+            Some("Equity:Late-Init"),
+            "the most recent pad's source must be used"
+        );
+        // The synthesized txn's date matches the *winning* pad's date (Jan 5).
+        assert_eq!(
+            pad_tx.date,
+            chrono::NaiveDate::from_ymd_opt(2024, 1, 5)
+                .unwrap()
+                .signed_duration_since(chrono::NaiveDate::from_ymd_opt(1970, 1, 1).unwrap())
+                .num_days() as i32,
+        );
+    }
+
+    #[test]
+    fn pad_with_zero_gap_emits_no_transaction() {
+        // If the running balance already equals the asserted amount, the
+        // pad has nothing to fill -- no synthesized transaction.
+        let input = "\
+2024-01-01 open Assets:Bank:Checking USD
+2024-01-01 open Income:Salary USD
+2024-01-01 open Equity:Opening-Balances
+
+2024-01-01 pad Assets:Bank:Checking Equity:Opening-Balances
+2024-01-15 balance Assets:Bank:Checking 1000.00 USD
+
+2024-01-10 *
+  Assets:Bank:Checking      1000.00 USD
+  Income:Salary            -1000.00 USD
+";
+        let elab = elaborate(input).expect("elaborate");
+        let pad_txs = elab
+            .transactions
+            .iter()
+            .filter(|t| t.metadata.contains_key("pad"))
+            .count();
+        assert_eq!(
+            pad_txs, 0,
+            "pad whose gap is zero should not emit a synthesized transaction"
+        );
     }
 }

--- a/crates/doppio/src/resolution.rs
+++ b/crates/doppio/src/resolution.rs
@@ -184,6 +184,27 @@ pub(crate) enum Entry {
     Transaction(Transaction),
     /// A standalone balance assertion directive.
     Assertion(AssertionDirective),
+    /// A Beancount `pad` marker, threaded through to the elaborator.
+    ///
+    /// The resolver does not act on pads; it only resolves the date so the
+    /// elaborator can compare against the next balance assertion.
+    Pad(PadDirective),
+}
+
+/// A Beancount `pad` directive with its date resolved.
+///
+/// The elaborator interprets a pad as: "if the next balance assertion on
+/// `target_account` would otherwise fail, insert a balancing transaction
+/// (back-dated to `date`) that posts the difference between
+/// `target_account` and `source_account`."
+#[derive(Debug)]
+pub(crate) struct PadDirective {
+    /// The date the pad applies on.
+    pub date: chrono::NaiveDate,
+    /// The account whose balance will be brought to the next assertion.
+    pub target_account: String,
+    /// The counter-account that absorbs the padding amount.
+    pub source_account: String,
 }
 
 /// A resolved standalone balance assertion directive.
@@ -534,11 +555,14 @@ impl TryFrom<ast::Journal> for HIR {
                 ast::Entry::Directive(ast::Directive::Unknown(_)) | ast::Entry::Comment(_) => {
                     // Discard unrecognised directives and comments.
                 }
-                ast::Entry::Pad(_) => {
-                    // Beancount `pad` directive. The evaluator that fills in
-                    // a balancing transaction up to the next balance assertion
-                    // is the subject of #147; for now resolution preserves
-                    // the rest of the journal but ignores the pad itself.
+                ast::Entry::Pad(p) => {
+                    let date = Self::resolve_date(&p.date, current_default_year)?;
+                    let data = Entry::Pad(PadDirective {
+                        date,
+                        target_account: p.target_account,
+                        source_account: p.source_account,
+                    });
+                    result.entries.push(ResolutionEntry { context_id, data });
                 }
                 ast::Entry::Directive(ast::Directive::Commodity {
                     name,


### PR DESCRIPTION
## Summary

Implements the Beancount \`pad\` directive end-to-end. With this PR, the three concrete sub-issues filed under the Beancount milestone (#145 grammar, #146 adapter, #147 evaluator) are done; \`.beancount\` files now parse, resolve, and elaborate including the one Beancount construct without a clean ledger-cli analogue.

The Beancount frontend remains **experimental**, and #144 (the umbrella) stays open until the remaining gaps are closed:

- **#185** -- complete lot annotation handling (wildcard \`{*}\`, \`{{total}}\` total-cost form, cost-vs-held commodity distinction)
- **#183** -- cross-frontend canonical-tool CI step (so we can validate against a real Beancount corpus, not just our own fixture)
- The carve-outs documented at the top of \`beancount.pest\` (string escape sequences, \`pushtag\`/\`poptag\`, \`pushmeta\`/\`popmeta\`, org-mode \`*\` headings)

The \"experimental\" marker should stay until those land and we have a real Beancount corpus passing differential testing.

Closes #147 once merged.

## Design decisions (per the agreed discussion)

| Q | Decision | Why |
|---|----------|-----|
| 1: AST representation | Already settled in #146 via \`ast::Entry::Pad\` | -- |
| 2: resolver vs elaborator | Elaborator | Pad needs running per-account balance; that's elaborator state |
| 3: multiple pads on one target | Most-recent-pad-wins | Matches Beancount; \`state.pending_pads.insert(target, _)\` overwrites |
| 4: pad without follow-up balance | Silently dropped | Matches Beancount default; pending pads at end of journal are discarded |
| 5: assertion after pad | Always passes by construction | Pad fills the gap exactly via \`diff = expected - actual\` |

## Cross-cutting change: date-sort for Beancount

Beancount evaluates entries in **date order**, not source order (unlike ledger-cli / hledger). Without this, the pad+balance pair in our parity fixture would compute the wrong gap when transactions appearing later in source come earlier in time. \`BeancountFrontend::parse\` now stable-sorts the AST entries by date after include resolution flattens the tree. Undated entries (directives, comments) keep their relative position and sort before any dated entry -- they're setup that applies before the journal's time-evolving state begins.

This change is scoped to the Beancount frontend; ledger-cli and hledger keep source-order semantics.

## Synthesized pad transactions

When a pad is consumed by a balance assertion with a non-zero gap:

- Date: the pad's date (back-dated)
- Description: \`(padding inserted for balance assertion)\`
- Postings: target gets +diff, source gets -diff. Each posting's payee is \`(pad)\`.
- Metadata: \`{ \"pad\": \"<source-account>\" }\` -- preserves provenance so downstream consumers can distinguish synthesized postings from user-authored ones.

## Tests

Four focused pad-evaluator unit tests:

- \`pad_fills_gap_to_next_balance_assertion\` -- happy path: 3400 USD deposit + 5000 USD assertion → 1600 USD pad txn back-dated to the pad's date
- \`pad_without_following_balance_is_silently_dropped\` -- Q4: no synthesized transaction, no error
- \`most_recent_pad_wins_when_multiple_precede_one_balance\` -- Q3: source account and date both come from the *later* pad
- \`pad_with_zero_gap_emits_no_transaction\` -- when the running balance already equals the asserted amount, no transaction is synthesized

Plus an end-to-end test \`sample_fixture_round_trips_through_elaboration\` that runs the existing #145 parity fixture all the way through.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo test --workspace\` (264 doppio lib + 49 elaborator + ...; all green; 4 new pad tests)
- [x] \`cargo build --target wasm32-unknown-unknown -p doppio --lib\`
- [x] \`bean-check tests/fixtures/sample.beancount\` (still clean)