### PR TITLE
feat(beancount): accept org-mode outline headings

### DIFF
--- a/crates/doppio/src/grammars/beancount/beancount.pest
+++ b/crates/doppio/src/grammars/beancount/beancount.pest
@@ -25,8 +25,6 @@
 // NOT YET SUPPORTED:
 //   - String escape sequences (`\"`, `\n`, etc) inside quoted strings.
 //   - The `pushtag`/`poptag` and `pushmeta`/`popmeta` scoping forms.
-//   - Org-mode `*` headings at column 0 (treated as parse errors;
-//     prefix with `;` to comment out).
 //   - Beancount's lot syntax inside `{...}` is captured as raw text;
 //     the AST adapter (#146) is responsible for parsing the inner
 //     fields (cost, date, label).
@@ -53,6 +51,7 @@ entry = _{
     | option_directive
     | plugin_directive
     | comment_line
+    | org_mode_heading
 }
 
 // --- Transactions ---
@@ -254,6 +253,17 @@ note = ${ ";" ~ note_str }
 note_str = ${ (!NEWLINE ~ ANY)* }
 
 comment_line = @{ ";" ~ (!NEWLINE ~ ANY)* }
+
+// Org-mode outline headings: `*`, `**`, `***`, ... at column 0,
+// followed by free-form heading text. Beancount silently accepts
+// these so journals can be edited as Org-mode outlines (and the
+// outline structure is preserved for any tool that reads it).
+// Single `*` followed by a transaction header would be ambiguous
+// only if the next token were a date-like token at column 1; the
+// transaction header rule starts with a digit, so a top-level entry
+// beginning with `*` cannot be a transaction (transactions are
+// `<date> <flag> ...`, not `<flag> <date>`).
+org_mode_heading = @{ "*" ~ (!NEWLINE ~ ANY)* }
 
 identifier = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_" | "-")* }
 

--- a/crates/doppio/src/grammars/beancount/mod.rs
+++ b/crates/doppio/src/grammars/beancount/mod.rs
@@ -42,6 +42,8 @@
 //!   not yet act on it; the algorithm is the subject of #147.
 //! - String escape sequences inside quoted strings are not interpreted.
 //! - `pushtag`/`poptag` and `pushmeta`/`popmeta` are not yet parsed.
+//! - Org-mode outline headings (`*`, `**`, `***`, ... at column 0) are
+//!   accepted and silently dropped, matching Beancount itself.
 
 use crate::ast::*;
 use pest::Parser as _;
@@ -105,6 +107,12 @@ impl<F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>> Parser<F> {
                     entries.push(Entry::Comment(pair.as_str().trim().to_string()));
                 }
                 Rule::comment_line => {
+                    entries.push(Entry::Comment(pair.as_str().to_string()));
+                }
+                Rule::org_mode_heading => {
+                    // Beancount accepts org-mode `*` outline headings as
+                    // top-level no-ops. Preserve as a comment so the source
+                    // line survives the round-trip; resolution discards it.
                     entries.push(Entry::Comment(pair.as_str().to_string()));
                 }
                 Rule::include_directive => {
@@ -753,6 +761,13 @@ mod tests {
         );
     }
 
+    #[test]
+    fn org_mode_heading_grammar_rule() {
+        parse_one(Rule::org_mode_heading, "* Personal");
+        parse_one(Rule::org_mode_heading, "** Bank accounts");
+        parse_one(Rule::org_mode_heading, "*** Deeply nested");
+    }
+
     // -- adapter / Frontend tests --------------------------------------------
 
     #[test]
@@ -1075,6 +1090,60 @@ mod tests {
     fn frontend_extensions_lists_beancount() {
         use crate::frontend::Frontend;
         assert!(BeancountFrontend.extensions().contains(&"beancount"));
+    }
+
+    #[test]
+    fn org_mode_outline_journal_parses_and_resolves() {
+        // Beancount accepts journals edited as Org-mode outlines (Emacs
+        // org-mode is the canonical case but the language itself permits
+        // these lines anywhere -- they are top-level no-ops). The
+        // headings round-trip through parse + resolution without
+        // affecting the directives that follow.
+        let input = "\
+* Personal
+** Bank accounts
+2024-01-01 open Assets:Bank:Checking USD
+*** Transactions
+2024-01-12 * \"Salary\"
+  Assets:Bank:Checking      3400.00 USD
+  Income:Salary            -3400.00 USD
+";
+        let journal = parse_beancount(input).expect("parse with org-mode headings");
+
+        // Three headings preserved as Entry::Comment (alongside the
+        // open and the transaction).
+        let comment_count = journal
+            .entries
+            .iter()
+            .filter(|e| matches!(e, Entry::Comment(_)))
+            .count();
+        assert_eq!(
+            comment_count, 3,
+            "three org-mode headings preserved as comments, got entries={:?}",
+            journal.entries
+        );
+
+        let open_count = journal
+            .entries
+            .iter()
+            .filter(|e| matches!(e, Entry::Directive(Directive::Account { .. })))
+            .count();
+        assert_eq!(open_count, 1);
+        let txn_count = journal
+            .entries
+            .iter()
+            .filter(|e| matches!(e, Entry::Transaction(_)))
+            .count();
+        assert_eq!(txn_count, 1);
+
+        // Resolution discards the headings (they are comments).
+        let hir: crate::resolution::HIR = journal.try_into().expect("resolve");
+        let resolved_txn_count = hir
+            .entries
+            .iter()
+            .filter(|e| matches!(e.data, crate::resolution::Entry::Transaction(_)))
+            .count();
+        assert_eq!(resolved_txn_count, 1);
     }
 
     // -- pad evaluator (#147) -----------------------------------------------

--- a/crates/doppio/tests/fixtures/sample.beancount
+++ b/crates/doppio/tests/fixtures/sample.beancount
@@ -19,6 +19,9 @@ option "operating_currency" "USD"
 
 include "secondary.beancount"
 
+* Personal
+** 2024 Journal
+
 ;; --- Account lifecycle ---
 
 2024-01-01 open Assets:Bank:Checking USD


### PR DESCRIPTION
## Summary

Beancount accepts lines beginning with one or more \`*\` at column 0 as top-level no-ops -- a Beancount grammar feature that lets users edit journals as Org-mode outlines without breaking the parser. \`bean-check\` ignores them silently; we now do too.

The canonical use case is Emacs Org-mode outlining, but the language permits these lines regardless of editor.

## Changes

- **Grammar** (\`beancount.pest\`): new \`org_mode_heading\` rule (parallel to \`comment_line\`), added to the \`entry\` choice. Headings at the top level are consumed and discarded.
- **Adapter** (\`mod.rs\`): heading preserved as \`Entry::Comment\` so the source line survives the AST round-trip; resolution discards it like any other comment.
- **Sample fixture**: a small \`* Personal / ** 2024 Journal\` section near the top so the parity fixture exercises the new surface and bean-check + our parser stay in lockstep.
- **Module-level docs**: org-mode headings move from the \"NOT YET SUPPORTED\" carve-out list to the \"accepted and silently dropped\" line.

## Tests

- \`org_mode_heading_grammar_rule\` -- the rule matches \`*\`, \`**\`, \`***\` headings
- \`org_mode_outline_journal_parses_and_resolves\` -- a mixed outline+open+transaction journal parses and resolves with the correct entry counts at both AST and HIR layers

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo test --workspace\` (36 beancount tests; all green)
- [x] \`cargo build --target wasm32-unknown-unknown -p doppio --lib\`
- [x] \`bean-check tests/fixtures/sample.beancount\` (still clean with the new headings)

## Why no issue first

Trivial parser affordance -- a few lines of grammar + adapter -- and it's a Beancount language feature, not editor-specific. Filed directly as a PR rather than as an issue first.