### PR TITLE
feat(beancount): interpret string escape sequences (#187)

### DIFF
--- a/crates/doppio/src/grammars/beancount/beancount.pest
+++ b/crates/doppio/src/grammars/beancount/beancount.pest
@@ -261,10 +261,15 @@ date = ${ year ~ "-" ~ monthdate ~ "-" ~ monthdate }
 year = @{ ASCII_DIGIT{4} }
 monthdate = @{ ASCII_DIGIT{2} }
 
-// String literal: simple double-quoted form. Escape sequences are not
-// modelled (see header note).
+// String literal: double-quoted form with backslash escape sequences.
+// The grammar accepts any byte after a backslash so the inner text
+// matches even malformed escapes; the AST adapter is responsible for
+// interpreting the recognised sequences (\\, \", \n, \t, \r) and
+// passing through unknown escapes verbatim with the leading backslash
+// preserved.
 string = ${ "\"" ~ string_inner ~ "\"" }
-string_inner = @{ (!"\"" ~ ANY)* }
+string_inner = @{ (escape_seq | (!"\"" ~ !"\\" ~ ANY))* }
+escape_seq = @{ "\\" ~ ANY }
 
 // Account: colon-separated segments. Beancount accepts segments
 // starting with an uppercase letter or digit; we accept either case

--- a/crates/doppio/src/grammars/beancount/mod.rs
+++ b/crates/doppio/src/grammars/beancount/mod.rs
@@ -40,9 +40,15 @@
 //!   held commodity distinction is collapsed.
 //! - `pad` is preserved as an [`Entry::Pad`] marker but the elaborator does
 //!   not yet act on it; the algorithm is the subject of #147.
-//! - String escape sequences inside quoted strings are not interpreted.
 //! - Org-mode outline headings (`*`, `**`, `***`, ... at column 0) are
 //!   accepted and silently dropped, matching Beancount itself.
+//!
+//! ## String escape sequences
+//!
+//! Recognised inside double-quoted strings: `\\`, `\"`, `\n`, `\t`,
+//! `\r`. Unrecognised escapes (e.g. `\q`) pass through verbatim with
+//! the leading backslash preserved, rather than erroring. An escaped
+//! quote inside a string literal does not terminate the string.
 //!
 //! ## Lexically-scoped tag and metadata directives
 //!
@@ -235,14 +241,49 @@ fn parse_flag(s: &str) -> TransactionState {
     }
 }
 
-/// Extract the inner text of a `string` pair (strip surrounding quotes).
+/// Extract and decode the inner text of a `string` pair: strip the
+/// surrounding quotes and interpret recognised backslash escape
+/// sequences.
+///
+/// Recognised: `\\`, `\"`, `\n`, `\t`, `\r`. Unrecognised escapes
+/// (e.g. `\q`) pass through verbatim with the leading backslash
+/// preserved -- this matches Python's "be lenient on unknown escapes
+/// in string literals" stance and avoids losing source bytes.
 fn string_inner(pair: Pair<Rule>) -> String {
     // string = ${ "\"" ~ string_inner ~ "\"" }
     let inner_pair = pair
         .into_inner()
         .next()
         .expect("string must contain string_inner");
-    inner_pair.as_str().to_string()
+    decode_string_escapes(inner_pair.as_str())
+}
+
+fn decode_string_escapes(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut chars = raw.chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('\\') => out.push('\\'),
+            Some('"') => out.push('"'),
+            Some('n') => out.push('\n'),
+            Some('t') => out.push('\t'),
+            Some('r') => out.push('\r'),
+            // Unknown escape: keep the backslash and the following
+            // character verbatim. This is intentionally lenient.
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
+            // Trailing lone backslash (only possible if the grammar
+            // somehow let one through; preserve it).
+            None => out.push('\\'),
+        }
+    }
+    out
 }
 
 // ---
@@ -816,6 +857,34 @@ mod tests {
     }
 
     #[test]
+    fn string_with_escape_sequences() {
+        // Escaped quote inside the literal must not terminate the string.
+        parse_one(Rule::string, "\"hello \\\" world\"");
+        // Common escapes the grammar must accept.
+        parse_one(Rule::string, "\"line1\\nline2\"");
+        parse_one(Rule::string, "\"col1\\tcol2\"");
+        parse_one(Rule::string, "\"path C:\\\\Users\\\\me\"");
+    }
+
+    #[test]
+    fn decode_string_escapes_recognises_known_sequences() {
+        assert_eq!(decode_string_escapes("hello"), "hello");
+        assert_eq!(decode_string_escapes(r"line1\nline2"), "line1\nline2");
+        assert_eq!(decode_string_escapes(r"col1\tcol2"), "col1\tcol2");
+        assert_eq!(decode_string_escapes(r"x\rclear"), "x\rclear");
+        assert_eq!(decode_string_escapes(r#"say \"hi\""#), r#"say "hi""#);
+        assert_eq!(decode_string_escapes(r"a\\b"), r"a\b");
+    }
+
+    #[test]
+    fn decode_string_escapes_passes_unknown_through() {
+        // \q is not a recognised escape; the backslash + char survive.
+        assert_eq!(decode_string_escapes(r"a\qb"), r"a\qb");
+        // Trailing lone backslash also survives.
+        assert_eq!(decode_string_escapes(r"a\"), r"a\");
+    }
+
+    #[test]
     fn flag_recognises_star_bang_txn() {
         parse_one(Rule::flag, "*");
         parse_one(Rule::flag, "!");
@@ -1221,6 +1290,35 @@ mod tests {
             .filter(|e| matches!(e.data, crate::resolution::Entry::Transaction(_)))
             .count();
         assert_eq!(resolved_txn_count, 1);
+    }
+
+    #[test]
+    fn transaction_string_with_embedded_escapes() {
+        // The narration contains an escaped quote and an explicit newline
+        // sequence. Both must (a) parse without terminating the string
+        // early, and (b) be decoded into their actual characters in the
+        // resulting Transaction.description.
+        let input = "\
+2024-01-01 open Expenses:Food
+2024-01-01 open Assets:Cash USD
+
+2024-03-10 * \"order #42 \\\"weekly\\\" delivery\\nnote: replace tomatoes\"
+  Expenses:Food      12.34 USD
+  Assets:Cash       -12.34 USD
+";
+        let journal = parse_beancount(input).expect("parse");
+        let Entry::Transaction(tx) = journal
+            .entries
+            .iter()
+            .find(|e| matches!(e, Entry::Transaction(_)))
+            .expect("transaction present")
+        else {
+            unreachable!()
+        };
+        assert_eq!(
+            tx.description, "order #42 \"weekly\" delivery\nnote: replace tomatoes",
+            "string escapes should be decoded into actual characters"
+        );
     }
 
     // -- pushtag/poptag, pushmeta/popmeta (#188 / #189) ---------------------

--- a/crates/doppio/tests/fixtures/sample.beancount
+++ b/crates/doppio/tests/fixtures/sample.beancount
@@ -65,6 +65,12 @@ include "secondary.beancount"
   Assets:Cash:EUR              500.00 EUR @ 1.07 USD
   Assets:Bank:Checking        -535.00 USD
 
+;; --- String literal with escape sequences ---
+
+2024-04-01 * "Quote in narration: he said \"go\" then left"
+  Expenses:Food                   25.00 USD
+  Liabilities:CreditCard         -25.00 USD
+
 ;; --- Lexically-scoped tags + metadata (pushtag/pushmeta) ---
 
 pushtag #household


### PR DESCRIPTION
## Summary

Quoted Beancount string literals now decode the standard escape sequences (\`\\\\\`, \`\\\"\`, \`\\n\`, \`\\t\`, \`\\r\`). An escaped quote inside a literal no longer terminates the string. Unrecognised escapes pass through verbatim with the leading backslash preserved (Python-style leniency), so source bytes are never lost.

Closes #187 once merged.

## Changes

- **Grammar** (\`beancount.pest\`): \`string_inner\` now recognises \`escape_seq = \\\\ ANY\` as a distinct token alternative, so an embedded \`\\\"\` does not end the literal. The grammar accepts any byte after a backslash; the adapter decides what is meaningful.
- **Adapter** (\`mod.rs\`): a new \`decode_string_escapes\` helper interprets recognised sequences. \`string_inner(pair)\` now returns the decoded text rather than the raw inner-text-with-backslashes.
- **Module docs**: replace the carve-out \"string escape sequences are not interpreted\" with a positive-listing \"## String escape sequences\" section enumerating what is recognised and how unknown escapes behave.
- **Sample fixture**: a small \`\"... he said \\\"go\\\" then left\"\` transaction so bean-check + our parser stay in lockstep on the escape surface.

## Tests

- \`string_with_escape_sequences\` -- grammar accepts \`\\\"\`, \`\\n\`, \`\\t\`, and Windows-path-like backslash forms
- \`decode_string_escapes_recognises_known_sequences\` -- direct unit test on the helper for \`\\\\\`, \`\\\"\`, \`\\n\`, \`\\t\`, \`\\r\`
- \`decode_string_escapes_passes_unknown_through\` -- \`\\q\` survives as \`\\q\`; trailing lone backslash survives
- \`transaction_string_with_embedded_escapes\` -- end-to-end: a transaction narration containing escaped quote + \`\\n\` decodes correctly into \`Transaction.description\`

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo test --workspace\` (47 beancount tests + ...; all green)
- [x] \`cargo build --target wasm32-unknown-unknown -p doppio --lib\`
- [x] \`bean-check tests/fixtures/sample.beancount\` (still clean with the new section)