### PR TITLE
feat: cross-frontend total-cost lot basis (#193)

### DIFF
--- a/crates/doppio/src/ast.rs
+++ b/crates/doppio/src/ast.rs
@@ -762,8 +762,15 @@ pub enum LotPricing {
 /// an [`AmountDetails::Amount`] only when at least one annotation was found.
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct LotAnnotation {
-    /// Per-unit cost basis.  `None` if no `{cost}` annotation was present.
+    /// Per-unit cost basis (or, when [`Self::cost_is_total`] is `true`,
+    /// the *total* lot cost). `None` if no `{cost}` / `{{total}}`
+    /// annotation was present.
     pub cost: Option<ValueExpr>,
+    /// `true` when the cost was expressed as a total via the
+    /// `{{total}}` double-brace form. The elaborator divides
+    /// [`Self::cost`] by the posting's unit count before using it as
+    /// per-unit basis. Defaults to `false` (per-unit).
+    pub cost_is_total: bool,
     /// Acquisition date.  `None` if no `[date]` annotation was present.
     pub date: Option<chrono::NaiveDate>,
     /// Free-form note.  `None` if no `((note))` annotation was present.

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -154,6 +154,10 @@ pub enum ElaborationError {
         /// A rendered form of the failing expression (for diagnostics).
         expression: String,
     },
+    /// A `{{total}}` lot annotation was attached to a posting whose
+    /// unit count is zero, so per-unit basis cannot be derived. This is
+    /// a malformed input, not a doppio bug.
+    TotalCostWithZeroUnits,
 }
 
 /// Error produced when evaluating a value expression (e.g., an amount or
@@ -331,6 +335,12 @@ impl Display for ElaborationError {
                 write!(
                     f,
                     "tag assertion failed for {tag_name}: \"{tag_value}\": assert {expression}"
+                )
+            }
+            ElaborationError::TotalCostWithZeroUnits => {
+                write!(
+                    f,
+                    "`{{{{total}}}}` lot cost cannot be applied to a posting with zero units"
                 )
             }
         }
@@ -565,14 +575,28 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                                                 .expect("epoch is valid");
                                             let proto_date =
                                                 ann.date.map(|d| (d - epoch).num_days() as i32);
+                                            let cost_is_total = ann.cost_is_total;
                                             let (proto_cost, cost_pair) =
                                                 if let Some(cost_expr) = ann.cost {
-                                                    let (cv, cc) =
+                                                    let (mut cv, cc) =
                                                         evaluator::eval_and_normalize_amount(
                                                             cost_expr,
                                                             entry_context,
                                                             &state,
                                                         )?;
+                                                    // `{{total}}` form: convert total -> per-unit
+                                                    // by dividing by the posting's absolute unit
+                                                    // count. The proto stores the canonical
+                                                    // per-unit form; the source-syntax
+                                                    // distinction is intentionally erased here.
+                                                    if cost_is_total {
+                                                        if value.is_zero() {
+                                                            return Err(
+                                                        ElaborationError::TotalCostWithZeroUnits,
+                                                    );
+                                                        }
+                                                        cv /= value.abs();
+                                                    }
                                                     let proto_amount = crate::elaboration::Amount {
                                                         by_commodity: BTreeMap::from([(
                                                             cc.clone(),

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -155,8 +155,8 @@ pub enum ElaborationError {
         expression: String,
     },
     /// A `{{total}}` lot annotation was attached to a posting whose
-    /// unit count is zero, so per-unit basis cannot be derived. This is
-    /// a malformed input, not a doppio bug.
+    /// unit count is zero, so per-unit basis cannot be derived from
+    /// the total.
     TotalCostWithZeroUnits,
 }
 

--- a/crates/doppio/src/grammars/beancount/mod.rs
+++ b/crates/doppio/src/grammars/beancount/mod.rs
@@ -37,10 +37,10 @@
 //!   date (ISO), or quoted label. The wildcard `{*}` form is accepted but
 //!   the wildcard is silently dropped, and the cost commodity vs held
 //!   commodity distinction is collapsed.
-//! - The total-cost `{{total}}` form is rejected at parse time with a
-//!   clear error (matching the hledger frontend's existing stance).
-//!   Real total-cost lot basis support is tracked cross-frontend in
-//!   #193; when that lands, this rejection goes away.
+//! - The total-cost `{{total}}` form is supported: the adapter records
+//!   `cost_is_total = true` on the lot annotation and the elaborator
+//!   divides by the posting's unit count to derive per-unit basis.
+//!   The proto wire format always carries the canonical per-unit form.
 //! - `pad` is preserved as an [`Entry::Pad`] marker but the elaborator does
 //!   not yet act on it; the algorithm is the subject of #147.
 //! - Org-mode outline headings (`*`, `**`, `***`, ... at column 0) are
@@ -422,20 +422,12 @@ fn parse_amount_logic(pair: Pair<Rule>) -> Result<AmountDetails, Box<dyn std::er
         match p.as_rule() {
             Rule::value_expr => value = Some(parse_expr(p)),
             Rule::lot_annotation => {
-                // Reject the `{{total}}` double-brace form. The grammar
-                // matches it before `{cost}` so the raw token text starts
-                // with `{{`. Treating it as per-unit cost here would
-                // produce a wrong basis (e.g. `10 AAPL {{$1500}}` would
-                // yield $15,000 instead of $1,500); explicit error is
-                // safer than silent miscomputation. Real total-cost
-                // support is tracked in #193 (cross-frontend); when that
-                // lands this rejection goes away.
+                // The `{{total}}` form: the grammar matches it before
+                // `{cost}` so the raw token text starts with `{{`. The
+                // elaborator divides by the posting's unit count when
+                // applying the cost (see #193).
                 if p.as_str().starts_with("{{") {
-                    return Err(
-                        "Beancount `{{total}}` lot syntax is not yet implemented (#193); \
-                         use `{cost}` for per-unit cost or `@@ total` for transient total cost"
-                            .into(),
-                    );
+                    lot_annotation.cost_is_total = true;
                 }
                 has_lot_annotation = true;
                 merge_lot_annotation_into(p, &mut lot_annotation);
@@ -1179,23 +1171,43 @@ mod tests {
     }
 
     #[test]
-    fn double_brace_total_cost_lot_is_rejected() {
-        // `10 AAPL {{$1825 USD}}` means the entire lot was acquired for
-        // a total of 1825 USD (per-unit basis 182.50). Treating it as
-        // per-unit cost (the current best-effort code path) would
-        // silently produce a 10x-wrong basis. Until cross-frontend
-        // support lands (#193), parse must error -- explicit failure
-        // is far better than silent miscomputation.
-        let input = "\
-2024-02-15 * \"Apple lot purchase via total-cost\"
-  Assets:Brokerage   10 AAPL {{1825.00 USD}}
-  Assets:Bank:Checking       -1825.00 USD
+    fn double_brace_total_cost_lot_elaborates_to_per_unit() {
+        // `{{1825 USD}}` declares the *total* lot cost; the elaborator
+        // divides by 10 (the unit count) to derive a per-unit basis of
+        // 182.50, which is what flows through the rest of the pipeline.
+        // The transaction balances at $1825 cash either way.
+        let total_form = "\
+2024-01-01 open Assets:Brokerage USD
+2024-01-01 open Assets:Bank:Checking USD
+
+2024-02-15 * \"Apple lot purchase (total-cost form)\"
+  Assets:Brokerage    10 AAPL {{1825.00 USD}}
+  Assets:Bank:Checking      -1825.00 USD
 ";
-        let err = parse_beancount(input).expect_err("`{{total}}` must be rejected");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("{{total}}") && msg.contains("#193"),
-            "error should explain the gap and reference #193, got: {msg}"
+        let per_unit_form = "\
+2024-01-01 open Assets:Brokerage USD
+2024-01-01 open Assets:Bank:Checking USD
+
+2024-02-15 * \"Apple lot purchase (per-unit form)\"
+  Assets:Brokerage    10 AAPL {182.50 USD}
+  Assets:Bank:Checking      -1825.00 USD
+";
+        let total_elab = elaborate(total_form).expect("`{{total}}` should elaborate");
+        let per_unit_elab = elaborate(per_unit_form).expect("`{cost}` should elaborate");
+
+        // Both forms should produce identical elaborated lot cost on the
+        // brokerage posting (the canonical per-unit form).
+        let total_lot = total_elab.transactions[0].postings[0]
+            .lot
+            .as_ref()
+            .expect("lot present (total form)");
+        let per_unit_lot = per_unit_elab.transactions[0].postings[0]
+            .lot
+            .as_ref()
+            .expect("lot present (per-unit form)");
+        assert_eq!(
+            total_lot, per_unit_lot,
+            "total and per-unit forms should produce identical elaborated lots"
         );
     }
 

--- a/crates/doppio/src/grammars/hledger/mod.rs
+++ b/crates/doppio/src/grammars/hledger/mod.rs
@@ -18,6 +18,14 @@
 //!   See TODO(#103).
 //! - `comment` / `end comment` block comments are not yet supported.
 //! - Full date inference from a `Y year` directive is not implemented.
+//!
+//! ## Lot-cost forms
+//!
+//! Both per-unit `{cost}` and total `{{total}}` forms are supported.
+//! The adapter records the brace count on
+//! [`ast::LotAnnotation::cost_is_total`]; the elaborator divides by
+//! the posting's unit count when applying a total-cost lot, so the
+//! canonical per-unit basis flows through the rest of the pipeline.
 
 use crate::ast::*;
 use pest::Parser as _;
@@ -266,7 +274,7 @@ fn parse_amount_logic(pair: Pair<Rule>) -> Result<AmountDetails, Box<dyn std::er
                             }
                             Rule::lot_annotation => {
                                 has_lot_annotation = true;
-                                parse_lot_annotation_into(child, &mut lot_annotation)?;
+                                parse_lot_annotation_into(child, &mut lot_annotation);
                             }
                             _ => unreachable!(),
                         }
@@ -310,29 +318,19 @@ fn parse_amount_logic(pair: Pair<Rule>) -> Result<AmountDetails, Box<dyn std::er
 /// [`LotAnnotation`] struct.  Duplicate annotations of the same kind take the
 /// last value (matching ledger-cli behaviour).
 ///
-/// # Errors
-///
-/// Returns an error if a `{{total}}` double-brace lot cost is encountered.
-/// The double-brace form is syntactically accepted by the grammar but its
-/// per-lot total-cost semantics are not yet implemented.  Treating it silently
-/// as a per-unit cost would produce wrong balances (e.g. `10 AAPL {{$1500}}`
-/// would yield a cash contribution of $15 000 instead of $1 500).  Use
-/// `{cost}` for per-unit cost or `@@ total` for transient total cost instead.
-fn parse_lot_annotation_into(
-    pair: Pair<Rule>,
-    acc: &mut LotAnnotation,
-) -> Result<(), Box<dyn std::error::Error>> {
+/// The `{{total}}` double-brace form is recognised and recorded by setting
+/// [`LotAnnotation::cost_is_total`]; the elaborator divides the captured
+/// total by the posting's unit count to derive per-unit basis.
+fn parse_lot_annotation_into(pair: Pair<Rule>, acc: &mut LotAnnotation) {
     let child = pair.into_inner().next().unwrap();
     match child.as_rule() {
         Rule::lot_cost => {
-            // Reject the `{{expr}}` double-brace form. The grammar matches it
-            // before `{expr}` so the raw token text starts with "{{".
+            // The `{{total}}` form: the grammar matches it before
+            // `{cost}` so the raw token text starts with `{{`. The
+            // elaborator divides by the posting's unit count when
+            // applying the cost.
             if child.as_str().starts_with("{{") {
-                return Err(
-                    "double-brace `{{total}}` lot syntax is not yet implemented; \
-                     use `{cost}` for per-unit cost or `@@ total` for transient total cost"
-                        .into(),
-                );
+                acc.cost_is_total = true;
             }
             let expr_pair = child.into_inner().next().unwrap();
             acc.cost = Some(parse_expr(expr_pair));
@@ -350,7 +348,6 @@ fn parse_lot_annotation_into(
         }
         _ => unreachable!(),
     }
-    Ok(())
 }
 
 fn parse_historical_price(pair: Pair<Rule>) -> HistoricalPrice {
@@ -1252,17 +1249,23 @@ P 2024-02-15 AAPL $182.50
     }
 
     #[test]
-    fn test_lot_annotation_double_brace_rejected() {
+    fn test_lot_annotation_double_brace_total_form() {
+        // `{{$1500}}` declares the total lot cost. The adapter records
+        // `cost_is_total = true` and stores the inner expression
+        // verbatim; the elaborator (covered by integration tests in the
+        // doppio crate) divides by the unit count to derive per-unit
+        // basis. Here we only assert the AST shape.
         let input = "2024-03-01 Buy\n    assets:brokerage   10 AAPL {{$1500}}\n    assets:cash\n";
-        let result = parse_hledger(input);
-        assert!(
-            result.is_err(),
-            "double-brace `{{total}}` should be rejected at parse time"
-        );
-        let msg = result.unwrap_err().to_string();
-        assert!(
-            msg.contains("double-brace"),
-            "error message should mention double-brace, got: {msg}"
-        );
+        let journal = parse_hledger(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!("expected transaction")
+        };
+        let details = tx.postings[0].amount.as_ref().expect("amount present");
+        let AmountDetails::Amount { lot_annotation, .. } = details else {
+            panic!("expected Amount details")
+        };
+        let ann = lot_annotation.as_ref().expect("lot annotation present");
+        assert!(ann.cost_is_total, "double-brace form sets cost_is_total");
+        assert!(ann.cost.is_some(), "cost expression captured");
     }
 }


### PR DESCRIPTION
## Summary

Closes the `{{total}}` lot annotation gap in both the hledger and Beancount frontends. Until this PR, the form was either rejected at parse time (hledger; Beancount as of #194 stopgap) or silently miscomputed (earlier Beancount). Now both frontends accept it and the elaborator derives the canonical per-unit basis by dividing the captured total by the posting's unit count.

Closes #193 and the `{{total}}` sub-gap of #185.

## Why no proto change

`{{total}}` vs `{cost}` is a parse-time fact about how the source expressed the basis. Once we know the total and the unit count, the elaborator computes the same per-unit basis either way. The proto wire format already carries the per-unit form; it never needed a flag.

This is smaller scope than the original #193 issue body suggested (~100 lines instead of ~150) — that estimate has been corrected on the issue.

## Changes

- **AST** (`LotAnnotation`): new `cost_is_total: bool` (parse-time fact, defaults to false). Internal-only; no public API change.
- **Adapters**: hledger and Beancount both detect the `{{...}}` brace count and set the bool. Both parse-time rejections are removed.
- **Elaborator**: when `cost_is_total` is true, divide the cost by the absolute unit count before storing the per-unit form in the proto Lot. New `ElaborationError::TotalCostWithZeroUnits` for the malformed `{{total}}` + 0-unit posting case.

## Tests

- **Beancount** (`double_brace_total_cost_lot_elaborates_to_per_unit`): a `{{total}}` posting and an equivalent `{cost}` posting produce **identical elaborated lots** end-to-end. Replaces the previous rejection test.
- **hledger** (`test_lot_annotation_double_brace_total_form`): the AST shape correctly captures `cost_is_total = true` for `{{total}}`. Replaces the previous rejection test.
- All existing per-unit-cost tests continue to pass — confirms the per-unit code path is undisturbed.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace` (278 doppio lib + ...; all green)
- [x] `cargo build --target wasm32-unknown-unknown -p doppio --lib`
- [x] `bean-check tests/fixtures/sample.beancount` (still clean)