### PR TITLE
parity: vendor first upstream corpus fixture + scaffold the pattern (#197)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .*.swp
+scripts/__pycache__/

--- a/scripts/parity_check.py
+++ b/scripts/parity_check.py
@@ -214,13 +214,16 @@ class Case:
 
 
 POSITIVE: list[Case] = [
-    # The "primary" fixtures live where their primary consumers do --
-    # near each crate's tests, not under a top-level e2e dir. The
-    # parity harness reaches in to validate them; new comprehensive
-    # corpora go under tests/parity/ alongside the negative fixtures.
-    Case("beancount", REPO / "crates/doppio/tests/fixtures/sample.beancount", beancount_balances),
-    Case("hledger",   REPO / "crates/doppio-cli/tests/fixtures/sample.hledger", hledger_balances),
-    Case("ledger",    REPO / "web/fixtures/sample.ledger", ledger_balances),
+    # "Primary" fixtures live where their primary consumers do -- near
+    # each crate's tests, not under a top-level e2e dir. The parity
+    # harness reaches in to validate them.
+    Case("beancount:sample", REPO / "crates/doppio/tests/fixtures/sample.beancount", beancount_balances),
+    Case("hledger:sample",   REPO / "crates/doppio-cli/tests/fixtures/sample.hledger", hledger_balances),
+    Case("ledger:sample",    REPO / "web/fixtures/sample.ledger", ledger_balances),
+    # Upstream-sourced corpus under tests/parity/. Each fixture's
+    # leading comment block records source URL + commit SHA + license
+    # per the convention documented in tests/parity/README.md.
+    Case("hledger:ascii",    REPO / "tests/parity/hledger-ascii.journal", hledger_balances),
 ]
 
 NEGATIVE: list[Case] = [

--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -19,20 +19,62 @@ Beancount API for `.beancount`, `hledger` for `.hledger`, `ledger` for
   "silent CI no-op" foot-gun: a future change that turns the parity
   job into a no-op makes negative cases pass-by-omission instead of
   failing as they should.
-- **Positive corpus fixtures** (added later, not yet present): real
-  Beancount / hledger / ledger files we want to validate doppio
-  against. Add them here when a specific bug or scenario warrants
-  permanent coverage. The "primary" parity fixtures stay where their
-  primary consumers do (`crates/doppio/tests/fixtures/sample.beancount`,
+- **Positive corpus fixtures**: upstream- or generator-sourced files
+  we want to validate doppio against. The "primary" parity fixtures
+  stay where their primary consumers do
+  (`crates/doppio/tests/fixtures/sample.beancount`,
   `crates/doppio-cli/tests/fixtures/sample.hledger`,
-  `web/fixtures/sample.ledger`).
+  `web/fixtures/sample.ledger`); broader corpus additions go here.
+
+## Vendoring upstream fixtures
+
+When pulling a fixture from an upstream repo (preferred over fetching
+at CI time -- vendoring keeps the test reproducible and bisectable),
+prepend a comment block at the top of the file recording:
+
+- **Source URL** -- a permalink including the upstream commit SHA
+- **Commit SHA + branch + fetch date**
+- **License** -- and a one-line note on compatibility with doppio's MIT
+- **What it exercises** -- one or two sentences naming the features
+  this fixture covers, so a future reader can decide whether to keep,
+  delete, or replace it
+
+Example: see `hledger-ascii.journal` in this directory.
+
+The harness reads the file verbatim; comment blocks are skipped by
+each canonical tool's parser. Naming convention for upstream-sourced
+fixtures: `<format>-<descriptive-name>.<ext>`
+(e.g. `hledger-ascii.journal`, `beancount-vesting.beancount`).
+
+## Generated fixtures
+
+`bean-example` (ships with the `beancount` Python package) produces a
+realistic synthetic Beancount journal. To regenerate deterministically:
+
+    bean-example --seed 42 -o tests/parity/beancount-example.beancount
+
+Then prepend a header recording the generator version + seed + date.
+Beancount is the only frontend with a usable generator; ledger-cli
+and hledger don't ship analogues.
+
+> **Currently blocked**: `bean-example` output exercises Beancount's
+> per-transaction balance tolerance (small sub-cent rounding residuals
+> that bean-check accepts but doppio's elaborator currently rejects).
+> Tracked in #198. Once that lands, regenerate per the command above
+> and add to `POSITIVE` in `scripts/parity_check.py`.
 
 ## Adding a new case
 
-1. Drop matching files for each format you want to cover into this dir.
-2. Append `Case("...", ...)` rows to the relevant list (`POSITIVE`
-   or `NEGATIVE`) in `scripts/parity_check.py`.
+1. Vendor / generate the file(s) into this dir per the conventions above.
+2. Append `Case("label", path, canonical_fn)` rows to the relevant list
+   (`POSITIVE` or `NEGATIVE`) in `scripts/parity_check.py`. Use a
+   `frontend:name` label (e.g. `hledger:ascii`) so failures are easy
+   to attribute.
 3. Run `python3 scripts/parity_check.py [--negative]` locally to
-   confirm. CI will exercise it on the next PR.
+   confirm. CI exercises both positive and negative on every PR.
+4. If the fixture surfaces a real gap in doppio (silent miscomputation,
+   parse rejection of valid syntax), file the gap as its own issue
+   before adding the fixture to `POSITIVE` -- the parity harness is
+   only useful when its passes are honest.
 
 [issue #183]: https://github.com/alevy/doppio/issues/183

--- a/tests/parity/hledger-ascii.journal
+++ b/tests/parity/hledger-ascii.journal
@@ -1,0 +1,26 @@
+; Source: hledger upstream test corpus
+;   https://raw.githubusercontent.com/simonmichael/hledger/029ba15ddfea8dbd1516475c9b83bef5285d6b2a/examples/ascii.journal
+;   commit 029ba15ddfea8dbd1516475c9b83bef5285d6b2a (main, fetched 2026-05-07)
+;   license: GPL-3.0 (hledger project; compatible with redistribution under doppio's MIT)
+;
+; Exercises: deep account hierarchy ("1:2:3:4:5"), per-unit `@` and total
+; `@@` lot pricing, `P` historical price directives. Small (15 lines of
+; original content) and intentionally synthetic-looking; lets the parity
+; harness validate price/cost arithmetic on an upstream corpus without
+; bringing in the tooling-specific quirks of larger journals.
+
+2000-01-01 transaction 1
+  1                                          1 A @ 0.71 B
+  1:2                                       -0.71 B
+
+2000-01-02 transaction 2
+  1:2:3                                      2 B @@ 2 C
+  1:2:3:4                                   -2 C
+
+2000-01-03 transaction 3
+  1:2:3:4:5                                  3 C
+  1                                         -3 C
+
+P 2000-01-01 A  0.70 B
+P 2000-01-02 A  0.71 B
+P 2000-01-03 A  0.72 B


### PR DESCRIPTION
## Summary

Establishes the upstream-corpus pattern from #197 with one working fixture (`hledger-ascii.journal`) and three follow-up issues for the gaps surfaced while exploring the rest. The PR is deliberately scaffolding-shaped: it makes the next ten upstream fixtures cheap to add, without rushing the pattern into something fragile.

## What lands

- **`tests/parity/hledger-ascii.journal`** — pulled verbatim from `simonmichael/hledger` upstream (`examples/ascii.journal`, commit `029ba15`, GPL-3.0). Small, exercises deep account hierarchy + per-unit `@` and total `@@` lot pricing + `P` historical price directives. Doppio and hledger agree on balances; added to `POSITIVE`.
- **`tests/parity/README.md`** — documents the vendor-with-source-tracking convention: each upstream fixture starts with a comment block recording source URL, commit SHA, license, and what features it exercises. Naming: `<format>-<name>.<ext>`. Also documents the `bean-example` regeneration command (currently blocked on #198) and "what to do when an upstream fixture surfaces a real doppio gap" (file the gap, don't silently add the fixture).
- **`scripts/parity_check.py`** — POSITIVE labels gain a `frontend:scope` suffix (`hledger:ascii` vs `hledger:sample`) so per-fixture failures are easy to attribute.

## Gaps surfaced during exploration (filed as follow-up issues)

Trying to vendor the broader corpus pulled in three classes of upstream fixture that doppio could not validate. Each is its own issue per the principle from #195 (parser rejection ≠ feature complete; surface the semantic gap):

- **#198** — Beancount per-transaction balance tolerance. `bean-example` output produces sub-cent residuals that `bean-check` accepts and doppio rejects. Blocks the generator-sourced Beancount path.
- **#199** — Beancount shebang (`#!`) and `#+` org-mode-startup prelude lines. File-level analogue of the `*` outline headings we already accept (#190). Blocks `beancount/examples/simple/{starter,basic}.beancount`.
- **#200** — hledger `==* 0` strict-zero balance assignment. Used in fiscal-year retained-earnings workflows. Blocks `hledger/examples/multicurrency.journal`.

When these land, the corresponding fixtures become trivial single-line additions to `POSITIVE`.

## Test plan

- [x] `python3 scripts/parity_check.py` (4 positive cases, all pass)
- [x] `python3 scripts/parity_check.py --negative` (3 negative cases, all reject)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace` (no Rust changes)