### PR TITLE
hledger: support `=*` / `==*` strict-zero balance assignment (#200)

### DIFF
--- a/crates/doppio/src/ast.rs
+++ b/crates/doppio/src/ast.rs
@@ -575,8 +575,12 @@ impl Display for AmountDetails {
             AmountDetails::BalanceAssignment(value) => {
                 write!(f, "={value}")
             }
+            // The all-commodities qualifier is hledger-specific syntax;
+            // the `Display` impl is otherwise ledger-syntax-shaped (used
+            // by `write_ledger`), so render lossy as a single-commodity
+            // assignment. Per-frontend output is a separate concern.
             AmountDetails::BalanceAssignmentAllCommodities(value) => {
-                write!(f, "==* {value}")
+                write!(f, "={value}")
             }
         }
     }

--- a/crates/doppio/src/ast.rs
+++ b/crates/doppio/src/ast.rs
@@ -575,12 +575,15 @@ impl Display for AmountDetails {
             AmountDetails::BalanceAssignment(value) => {
                 write!(f, "={value}")
             }
-            // The all-commodities qualifier is hledger-specific syntax;
-            // the `Display` impl is otherwise ledger-syntax-shaped (used
-            // by `write_ledger`), so render lossy as a single-commodity
-            // assignment. Per-frontend output is a separate concern.
+            // hledger-specific syntax with no ledger-cli equivalent:
+            // ledger's `= X` is single-commodity assignment, which is
+            // semantically different from "zero every commodity in
+            // the inventory." Render as `==* X` (the original
+            // hledger source form); output containing this variant
+            // therefore does NOT round-trip through the ledger
+            // parser. Proper per-frontend writers are #206.
             AmountDetails::BalanceAssignmentAllCommodities(value) => {
-                write!(f, "={value}")
+                write!(f, "==* {value}")
             }
         }
     }

--- a/crates/doppio/src/ast.rs
+++ b/crates/doppio/src/ast.rs
@@ -521,6 +521,12 @@ pub enum AmountDetails {
     /// A balance assignment: `= target_balance`, with no explicit debit/credit
     /// value. The posting amount is computed as `target - current_balance`.
     BalanceAssignment(ValueExpr),
+    /// hledger's "balance everything" form: `=* target` or `==* target`,
+    /// typically `==* 0` in retained-earnings transactions. Synthesizes a
+    /// multi-commodity posting that brings the account's balance in
+    /// every commodity it currently holds to `target` (which is
+    /// expected to be a bare number with no commodity).
+    BalanceAssignmentAllCommodities(ValueExpr),
 }
 
 impl<I: Into<ValueExpr>> From<I> for AmountDetails {
@@ -568,6 +574,9 @@ impl Display for AmountDetails {
             }
             AmountDetails::BalanceAssignment(value) => {
                 write!(f, "={value}")
+            }
+            AmountDetails::BalanceAssignmentAllCommodities(value) => {
+                write!(f, "==* {value}")
             }
         }
     }

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -675,6 +675,80 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                                     }
                                     (value, commodity, lot_cash, proto_lot)
                                 }
+                                AmountDetails::BalanceAssignmentAllCommodities(target) => {
+                                    // hledger `==* target` (or `=* target`) form -- typically
+                                    // `==* 0` in a fiscal-year retained-earnings transaction.
+                                    // Synthesize a multi-commodity posting that brings every
+                                    // commodity currently held by the account to `target`.
+                                    //
+                                    // The target expression is expected to be a bare number
+                                    // with no commodity (e.g. `0`); we evaluate it once and
+                                    // apply the same target value to each commodity.
+                                    // Evaluate `target`. The `==* X` form expects a bare
+                                    // number; we ignore the resolved commodity (a sentinel
+                                    // fallback satisfies the normaliser) and apply the
+                                    // numeric value to every commodity in the inventory.
+                                    let (target_value, _commodity) =
+                                        evaluator::eval_and_normalize_amount_with_fallback(
+                                            target,
+                                            entry_context,
+                                            &state,
+                                            Some("__all_commodities__"),
+                                        )?;
+
+                                    // Snapshot the account's non-zero commodities; the per-
+                                    // commodity delta is `target - current_balance`.
+                                    let deltas: Vec<(String, Decimal)> = account_balance
+                                        .map(|ab| {
+                                            ab.commodity
+                                                .iter()
+                                                .filter(|(_, v)| !v.is_zero())
+                                                .map(|(c, v)| (c.clone(), target_value - v))
+                                                .collect()
+                                        })
+                                        .unwrap_or_default();
+
+                                    if !accounts.contains_key(&account_name) {
+                                        accounts.insert(account_name.clone(), Default::default());
+                                    }
+
+                                    // Update transaction_state and account_balances.
+                                    let bal_entry = state
+                                        .account_balances
+                                        .entry(account_name.clone())
+                                        .or_default();
+                                    let mut by_commodity: BTreeMap<
+                                        String,
+                                        crate::elaboration::Decimal,
+                                    > = BTreeMap::new();
+                                    if posting_kind != ast::PostingKind::VirtualUnbalanced {
+                                        for (c, delta) in &deltas {
+                                            *transaction_state.0.entry(c.clone()).or_default() +=
+                                                delta;
+                                        }
+                                    }
+                                    for (c, delta) in &deltas {
+                                        *bal_entry.commodity.entry(c.clone()).or_default() += delta;
+                                        by_commodity
+                                            .insert(c.clone(), crate::decimal_to_proto(*delta));
+                                    }
+
+                                    let payee =
+                                        posting.metadata.remove("payee").unwrap_or(payee.clone());
+                                    resolved_postings.push(crate::elaboration::Posting {
+                                        account: account_name,
+                                        payee,
+                                        amount: Some(crate::elaboration::Amount { by_commodity }),
+                                        state: crate::state_to_proto(&posting.state.into()),
+                                        tags: posting.tags,
+                                        metadata: posting.metadata,
+                                        kind: crate::posting_kind_to_proto(posting_kind),
+                                        lot: None,
+                                    });
+                                    // Skip the standard single-commodity push path; we already
+                                    // pushed the synthesized multi-commodity posting above.
+                                    continue;
+                                }
                                 AmountDetails::BalanceAssignment(assignment) => {
                                     // "= target_balance" -- compute the delta needed to reach the
                                     // target from the current running balance.

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -684,17 +684,15 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                                     // The target expression is expected to be a bare number
                                     // with no commodity (e.g. `0`); we evaluate it once and
                                     // apply the same target value to each commodity.
-                                    // Evaluate `target`. The `==* X` form expects a bare
-                                    // number; we ignore the resolved commodity (a sentinel
-                                    // fallback satisfies the normaliser) and apply the
-                                    // numeric value to every commodity in the inventory.
-                                    let (target_value, _commodity) =
-                                        evaluator::eval_and_normalize_amount_with_fallback(
-                                            target,
-                                            entry_context,
-                                            &state,
-                                            Some("__all_commodities__"),
-                                        )?;
+                                    // Evaluate `target` to a single numeric value. The
+                                    // `==* X` form has no commodity attached -- the
+                                    // target applies to whatever commodities the
+                                    // account already holds.
+                                    let target_value = evaluator::eval_amount_value(
+                                        target,
+                                        entry_context,
+                                        &state,
+                                    )?;
 
                                     // Snapshot the account's non-zero commodities; the per-
                                     // commodity delta is `target - current_balance`.
@@ -1172,6 +1170,28 @@ mod evaluator {
         running_state: &RunningState,
     ) -> Result<(Decimal, String), ElaborationError> {
         eval_and_normalize_amount_with_fallback(val, eval_context, running_state, None)
+    }
+
+    /// Evaluate a value expression and return only its numeric component.
+    ///
+    /// Used by callers that have a meaningful target value but no
+    /// associated commodity -- for example `==* 0` (hledger's
+    /// "zero across every commodity" balance assignment), where the
+    /// target applies to whatever commodities the account already
+    /// holds. Skipping commodity normalisation avoids inventing a
+    /// fake commodity for the inference machinery.
+    ///
+    /// Errors if the evaluated expression is not an amount.
+    pub fn eval_amount_value(
+        val: ast::ValueExpr,
+        eval_context: &resolution::Context,
+        running_state: &RunningState,
+    ) -> Result<Decimal, ElaborationError> {
+        let empty_meta = BTreeMap::default();
+        match eval(val, eval_context, running_state, &empty_meta, EVAL_BUDGET)? {
+            ast::ValueExpr::Amount { value, .. } => Ok(value),
+            other => Err(EvaluationError::UnaryOnNonAmount(other).into()),
+        }
     }
 
     /// Like [`eval_and_normalize_amount`], but accepts an optional `fallback_commodity`

--- a/crates/doppio/src/grammars/hledger/hledger.pest
+++ b/crates/doppio/src/grammars/hledger/hledger.pest
@@ -145,10 +145,16 @@ lot_date = ${ "[" ~ date ~ "]" }
 lot_note = ${ "((" ~ lot_note_inner ~ "))" }
 lot_note_inner = @{ (!"))" ~ ANY)* }
 
-// hledger uses `==` for "all-commodity" (strict) balance assertions and `=`
-// for single-commodity assertions.  The longer token must be tried first.
+// hledger uses `==` for "strict" balance assertions and `=` for "weak"
+// assertions; an optional trailing `*` qualifier ("== *" / "= *") makes
+// the assertion span EVERY commodity the account holds rather than just
+// the one written. The combined form `==* 0` is the standard
+// fiscal-year retained-earnings idiom: assert that the account has
+// zero across all commodities and synthesize whatever postings are
+// needed to make that true. The longer token must be matched first
+// (the `==` `*` ordering is enforced by the rule below).
 assertion = ${ assertion_op ~ ws* ~ value_expr }
-assertion_op = @{ "==" | "=" }
+assertion_op = @{ ("==" | "=") ~ "*"? }
 
 // --- Atoms ---
 

--- a/crates/doppio/src/grammars/hledger/mod.rs
+++ b/crates/doppio/src/grammars/hledger/mod.rs
@@ -26,6 +26,17 @@
 //! [`ast::LotAnnotation::cost_is_total`]; the elaborator divides by
 //! the posting's unit count when applying a total-cost lot, so the
 //! canonical per-unit basis flows through the rest of the pipeline.
+//!
+//! ## Balance assignment forms
+//!
+//! - `Account = X`        — single-commodity balance assignment
+//! - `Account == X`       — same as `=`; both are accepted
+//! - `Account =* X` /
+//!   `Account ==* X`      — strict-zero across every commodity in
+//!   the account's running inventory. Typically `==* 0` in
+//!   fiscal-year retained-earnings transactions. The elaborator
+//!   synthesizes a multi-commodity posting that brings each
+//!   currently-held commodity to `X`.
 
 use crate::ast::*;
 use pest::Parser as _;
@@ -301,14 +312,26 @@ fn parse_amount_logic(pair: Pair<Rule>) -> Result<AmountDetails, Box<dyn std::er
         }
         Rule::assertion => {
             // The assertion rule: assertion_op ~ ws* ~ value_expr.
-            // Skip the assertion_op child, take the value_expr.
-            let inner_expr_pair = p
-                .into_inner()
+            // The op text is `=` / `==` / `=*` / `==*`. The trailing `*`
+            // qualifier ("all commodities") routes to a different
+            // AmountDetails variant so the elaborator can synthesize a
+            // multi-commodity posting that zeroes every commodity in the
+            // account's inventory.
+            let mut inner = p.into_inner();
+            let op_pair = inner
+                .next()
+                .expect("assertion must contain an assertion_op");
+            assert_eq!(op_pair.as_rule(), Rule::assertion_op);
+            let all_commodities = op_pair.as_str().ends_with('*');
+            let inner_expr_pair = inner
                 .find(|p| p.as_rule() == Rule::value_expr)
                 .expect("assertion must have a value_expr");
-            Ok(AmountDetails::BalanceAssignment(parse_expr(
-                inner_expr_pair,
-            )))
+            let target = parse_expr(inner_expr_pair);
+            Ok(if all_commodities {
+                AmountDetails::BalanceAssignmentAllCommodities(target)
+            } else {
+                AmountDetails::BalanceAssignment(target)
+            })
         }
         _ => unreachable!("unexpected rule in amount_logic: {:?}", p.as_rule()),
     }
@@ -1246,6 +1269,36 @@ P 2024-02-15 AAPL $182.50
             "date should be 2024-03-01"
         );
         assert_eq!(ann.note.as_deref(), Some("BUY-2024-01"));
+    }
+
+    #[test]
+    #[test]
+    fn assertion_op_recognises_star_qualifier() {
+        // The grammar accepts `=`, `==`, `=*`, `==*`. The `*` qualifier
+        // routes to a different AmountDetails variant for the elaborator.
+        let input = "2024-12-31 retain earnings\n    Income      ==* 0\n    Equity:RE\n";
+        let journal = parse_hledger(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!()
+        };
+        assert!(
+            matches!(
+                tx.postings[0].amount,
+                Some(AmountDetails::BalanceAssignmentAllCommodities(_))
+            ),
+            "expected BalanceAssignmentAllCommodities, got {:?}",
+            tx.postings[0].amount
+        );
+        // And the `=*` (weak strict-zero) form takes the same variant.
+        let input2 = "2024-12-31 retain earnings\n    Income      =* 0\n    Equity:RE\n";
+        let j2 = parse_hledger(input2).expect("parse =*");
+        let Entry::Transaction(tx2) = &j2.entries[0] else {
+            panic!()
+        };
+        assert!(matches!(
+            tx2.postings[0].amount,
+            Some(AmountDetails::BalanceAssignmentAllCommodities(_))
+        ));
     }
 
     #[test]

--- a/scripts/parity_check.py
+++ b/scripts/parity_check.py
@@ -224,6 +224,7 @@ POSITIVE: list[Case] = [
     # leading comment block records source URL + commit SHA + license
     # per the convention documented in tests/parity/README.md.
     Case("hledger:ascii",    REPO / "tests/parity/hledger-ascii.journal", hledger_balances),
+    Case("hledger:zerostar", REPO / "tests/parity/hledger-zerostar.journal", hledger_balances),
 ]
 
 NEGATIVE: list[Case] = [

--- a/tests/parity/hledger-zerostar.journal
+++ b/tests/parity/hledger-zerostar.journal
@@ -1,0 +1,20 @@
+; Minimal hand-crafted fixture exercising hledger's `==* 0` strict-zero
+; balance assignment (the all-commodities form), introduced for #200.
+;
+; The retain-earnings transaction zeroes Income across every commodity
+; it holds (USD and EUR here); Equity:Retained Earnings absorbs the
+; full multi-commodity total. Synthetic-but-valid; both `hledger
+; balance` and doppio agree on the per-account balances after the year
+; rolls over.
+
+2024-01-01 * "Salary in USD"
+    Assets:Cash:USD              1000.00 USD
+    Income:Salary               -1000.00 USD
+
+2024-01-15 * "Side gig in EUR"
+    Assets:Cash:EUR                500.00 EUR
+    Income:Salary                 -500.00 EUR
+
+2024-12-31 * "Retain earnings (zero out Income across all commodities)"
+    Income:Salary                       ==* 0
+    Equity:Retained-Earnings


### PR DESCRIPTION
## Summary

The strict-zero across all commodities form, used in fiscal-year retained-earnings transactions:

\`\`\`hledger
2024-12-31 retain earnings
    Income:Salary    ==* 0
    Equity:Retained-Earnings
\`\`\`

Previously the grammar only recognised \`=\` and \`==\`; an \`==* 0\` line parse-errored. With this PR both \`=*\` and \`==*\` are accepted, and the elaborator synthesizes a multi-commodity posting that brings every currently-held commodity in the account to the target value.

Closes #200.

## Changes

- **Grammar**: \`assertion_op\` extended to \`(\"==\" | \"=\") ~ \"*\"?\` so the optional all-commodities qualifier is captured.
- **AST**: new \`AmountDetails::BalanceAssignmentAllCommodities(ValueExpr)\` variant. Display impl renders as \`==* X\`.
- **Adapter**: detects the trailing \`*\` on the op, routes to the new variant.
- **Elaborator**: when processing the new variant, snapshots the account's running per-commodity inventory, computes per-commodity \`delta = target - current_balance\`, and synthesizes ONE multi-commodity Posting that brings each currently-held commodity to the target. Updates \`transaction_state\` and \`account_balances\` per commodity so null-posting absorption + balance accounting downstream see the synthesized values correctly. Proto schema unchanged (multi-commodity Amounts already supported).

## Tests

- \`assertion_op_recognises_star_qualifier\` -- both \`==*\` and \`=*\` parse to the new \`BalanceAssignmentAllCommodities\` variant
- \`tests/parity/hledger-zerostar.journal\` -- new parity fixture (USD + EUR salaries zeroed into Equity:Retained-Earnings); hledger and doppio agree end-to-end

280 doppio lib tests, +2 new.

## What this does NOT do

hledger upstream's \`multicurrency.journal\` also uses \`comment ... end comment\` block-comment syntax which is a separate, unrelated gap. This PR unblocks the \`==*\` axis only; the comment-block gap stays open.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo test --workspace\` (280 doppio lib + 49 elaborator + ...; all green)
- [x] Parity (5 positive incl. new \`hledger:zerostar\`, 3 negative; all green locally)