### PR TITLE
hledger: `comment` / `end comment` block-comment syntax (#205)

### DIFF
--- a/crates/doppio/src/grammars/hledger/hledger.pest
+++ b/crates/doppio/src/grammars/hledger/hledger.pest
@@ -22,7 +22,6 @@
 //   - Automated posting arithmetic bodies (`= query\n    account  *1.1`):
 //     the auto_rule rule captures the shape but the posting amounts inside
 //     automated rules that use `*N` will fail to parse.  See TODO(#103).
-//   - `comment` / `end comment` block comment syntax.
 //   - Full hledger date inference from a preceding `Y year` directive.
 //   - Directive-attached tags (metadata on the same line as a directive).
 // ============================================================
@@ -40,6 +39,7 @@ entry = _{
     | commodity_directive
     | default_directive
     | include_directive
+    | block_comment
     | comment_line
 }
 
@@ -187,6 +187,24 @@ ws = _{ " " | "\t" }
 note = ${ ";" ~ note_str }
 note_str = ${ (!NEWLINE ~ ANY)* }
 comment_line = @{ (";" | "#") ~ (!NEWLINE ~ ANY)* }
+
+// `comment` ... `end comment` block-comment form. hledger ignores
+// every line in between; we capture the inner text verbatim and
+// pass it through as Entry::Comment so resolution discards it like
+// any other comment. The opening `comment` must appear on its own
+// line; an unclosed block (no matching `end comment`) is implicitly
+// terminated by EOF, matching hledger's behaviour.
+//
+// The body lookahead requires `end comment` to be followed by
+// NEWLINE or EOI so that a literal `end comment` *substring* inside
+// the body's prose (e.g. inside backticks) does not prematurely
+// terminate the block.
+block_comment = ${
+    "comment" ~ NEWLINE ~
+    block_comment_body ~
+    (("end comment" ~ (NEWLINE | EOI)) | EOI)
+}
+block_comment_body = @{ (!("end comment" ~ (NEWLINE | EOI)) ~ ANY)* }
 
 // --- Historical prices ---
 

--- a/crates/doppio/src/grammars/hledger/mod.rs
+++ b/crates/doppio/src/grammars/hledger/mod.rs
@@ -16,8 +16,15 @@
 //!   the `auto_rule` grammar rule captures the shape of an automated posting
 //!   rule but postings whose amounts use `*N` will produce a parse error.
 //!   See TODO(#103).
-//! - `comment` / `end comment` block comments are not yet supported.
 //! - Full date inference from a `Y year` directive is not implemented.
+//!
+//! ## Block comments
+//!
+//! `comment` ... `end comment` block comments are accepted; the
+//! contents are preserved verbatim as `Entry::Comment` and resolution
+//! discards them. An unclosed `comment` block (no matching
+//! `end comment`) is implicitly terminated at EOF, matching hledger's
+//! own behaviour.
 //!
 //! ## Lot-cost forms
 //!
@@ -69,6 +76,12 @@ impl<F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>> Parser<F> {
                     entries.push(Entry::Transaction(parse_transaction(pair)?));
                 }
                 Rule::comment_line => {
+                    entries.push(Entry::Comment(pair.as_str().to_string()));
+                }
+                Rule::block_comment => {
+                    // Preserve the full source text (including the
+                    // `comment` / `end comment` markers) so the round-trip
+                    // representation is faithful; resolution discards.
                     entries.push(Entry::Comment(pair.as_str().to_string()));
                 }
                 Rule::historical_price => {
@@ -1272,6 +1285,58 @@ P 2024-02-15 AAPL $182.50
     }
 
     #[test]
+    #[test]
+    fn block_comment_closed_and_unclosed() {
+        // Closed `comment` ... `end comment` block in the middle of a journal.
+        let closed = "\
+2024-01-01 * Salary
+    Assets:Bank      $100
+    Income:Salary
+
+comment
+this is ignored
+    Assets:Fake     $999
+end comment
+
+2024-01-02 * Coffee
+    Expenses:Food    $5
+    Assets:Bank
+";
+        let journal = parse_hledger(closed).expect("parse closed block-comment");
+        let txs: Vec<_> = journal
+            .entries
+            .iter()
+            .filter(|e| matches!(e, Entry::Transaction(_)))
+            .collect();
+        assert_eq!(
+            txs.len(),
+            2,
+            "block comment must not consume the second txn"
+        );
+
+        // Unclosed block at EOF: hledger treats it as comment-to-EOF.
+        let unclosed = "\
+2024-01-01 * Salary
+    Assets:Bank      $100
+    Income:Salary
+
+comment
+trailing notes about the journal
+nothing after this matters
+";
+        let journal = parse_hledger(unclosed).expect("parse unclosed block-comment");
+        let txs: Vec<_> = journal
+            .entries
+            .iter()
+            .filter(|e| matches!(e, Entry::Transaction(_)))
+            .collect();
+        assert_eq!(
+            txs.len(),
+            1,
+            "the single transaction before the unclosed block must parse"
+        );
+    }
+
     #[test]
     fn assertion_op_recognises_star_qualifier() {
         // The grammar accepts `=`, `==`, `=*`, `==*`. The `*` qualifier

--- a/scripts/parity_check.py
+++ b/scripts/parity_check.py
@@ -223,8 +223,9 @@ POSITIVE: list[Case] = [
     # Upstream-sourced corpus under tests/parity/. Each fixture's
     # leading comment block records source URL + commit SHA + license
     # per the convention documented in tests/parity/README.md.
-    Case("hledger:ascii",    REPO / "tests/parity/hledger-ascii.journal", hledger_balances),
-    Case("hledger:zerostar", REPO / "tests/parity/hledger-zerostar.journal", hledger_balances),
+    Case("hledger:ascii",         REPO / "tests/parity/hledger-ascii.journal", hledger_balances),
+    Case("hledger:zerostar",      REPO / "tests/parity/hledger-zerostar.journal", hledger_balances),
+    Case("hledger:block-comment", REPO / "tests/parity/hledger-block-comment.journal", hledger_balances),
 ]
 
 NEGATIVE: list[Case] = [

--- a/tests/parity/hledger-block-comment.journal
+++ b/tests/parity/hledger-block-comment.journal
@@ -1,0 +1,27 @@
+; Hand-crafted fixture exercising hledger's `comment` / `end comment`
+; block-comment syntax (#205). Both a closed block (mid-file) and an
+; unclosed block (at EOF, hledger treats as comment-to-EOF) are
+; covered. Real upstream files (e.g. hledger's own multicurrency.journal)
+; use both forms.
+
+2024-01-01 * Salary
+    Assets:Bank      1000.00 USD
+    Income:Salary   -1000.00 USD
+
+comment
+This is a block comment in the middle of the journal. hledger
+ignores every line between `comment` and `end comment`. The text
+inside can look like a journal entry without affecting parsing:
+    Assets:Fake    9999.99 USD
+    Income:Phantom -9999.99 USD
+end comment
+
+2024-01-15 * Groceries
+    Expenses:Food    50.00 USD
+    Assets:Bank     -50.00 USD
+
+comment
+Trailing comment block with no `end comment`; hledger treats it
+as a comment-to-EOF. Anything below this line is ignored.
+    More fake content
+    Even more fake content


### PR DESCRIPTION
## Summary

hledger supports a multi-line block-comment form -- \`comment\` on its own line opens a region, \`end comment\` closes it. An unclosed block at EOF is implicitly terminated. Real hledger journals use this routinely for prose docs and to disable chunks during debugging. Our hledger frontend has documented the gap since the frontend landed; tracked as #205.

Closes #205.

## Changes

- **Grammar**: \`block_comment\` rule with a body that captures verbatim text. The end-marker lookahead requires \`end comment\` to be followed by \`NEWLINE\` or \`EOI\` so that the literal substring \"end comment\" in prose (e.g. inside backticks) does not prematurely terminate the block.
- **Adapter**: passes block_comment through as \`Entry::Comment\` (preserves the source line; resolution discards).
- New parity fixture \`tests/parity/hledger-block-comment.journal\` exercises both forms (closed mid-file and unclosed at EOF). Hand-crafted; hledger and doppio agree on balances.

## Why hand-crafted, not vendored

I tried vendoring hledger's upstream \`multicurrency.journal\` first. It surfaced one more gap (#207 -- \`==*\` should aggregate across the account subtree, not just the named account). Filed as a follow-up; multicurrency.journal stays unvendored until #207 lands.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo test --workspace\` (283 doppio lib tests; +1 new)
- [x] Parity (6 positive incl. new \`hledger:block-comment\`, 3 negative; all green locally)
- [x] Module-level docs updated: \"comment / end comment block comments\" moves from the carve-out list to a positive-listing section