### PR TITLE
elaborator: Beancount-style balance tolerance via synthetic rounding posting (#198)

### DIFF
--- a/crates/doppio-cli/src/main.rs
+++ b/crates/doppio-cli/src/main.rs
@@ -87,6 +87,16 @@ enum Commands {
         /// them when auditing rounding behaviour.
         #[arg(long, default_value_t = false)]
         show_rounding: bool,
+        /// Override the per-frontend default balance tolerance. The value
+        /// is the fraction of the least-precise posting's decimal place
+        /// to absorb as rounding residual. `0` = strict (every transaction
+        /// must balance to exact zero, ledger/hledger default).
+        /// `0.5` = Beancount's default (half the smallest decimal).
+        /// Sub-tolerance residuals are absorbed into a synthesized
+        /// posting on the empty-string account; over-tolerance still
+        /// rejects.
+        #[arg(long)]
+        tolerance: Option<rust_decimal::Decimal>,
     },
 
     /// List individual postings, optionally filtered by account name.
@@ -191,7 +201,16 @@ impl OutputFormat {
 fn load_proto_journal(
     path: &PathBuf,
 ) -> Result<doppio::elaboration::Journal, Box<dyn std::error::Error>> {
+    load_proto_journal_with_tolerance(path, None)
+}
+
+fn load_proto_journal_with_tolerance(
+    path: &PathBuf,
+    tolerance_override: Option<rust_decimal::Decimal>,
+) -> Result<doppio::elaboration::Journal, Box<dyn std::error::Error>> {
     if let Some("dop") = path.extension().and_then(|e| e.to_str()) {
+        // .dop files are pre-elaborated; tolerance was applied when
+        // they were originally compiled and cannot be overridden here.
         let mut f = File::open(path)?;
         doppio::read_dop(&mut f, path)
     } else {
@@ -200,7 +219,11 @@ fn load_proto_journal(
         let base_path = path.parent().unwrap_or(std::path::Path::new(""));
         let mut file = String::new();
         File::open(path)?.read_to_string(&mut file)?;
-        let hir = frontend.parse(&file, base_path, &doppio::file_opener)?;
+        let mut hir = frontend.parse(&file, base_path, &doppio::file_opener)?;
+        if let Some(fraction) = tolerance_override {
+            hir.global_context.tolerance_mode =
+                doppio::resolution::ToleranceMode::FractionOfSmallestPrecision(fraction);
+        }
         Ok(doppio::elaborate(hir)?)
     }
 }
@@ -706,11 +729,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             real,
             exchange,
             show_rounding,
+            tolerance,
         } => {
             let format = OutputFormat::parse(&format)?;
             let filter =
                 JournalFilter::new(pattern, begin.as_deref(), end.as_deref(), cleared, tag)?;
-            let journal = load_proto_journal(&source)?;
+            let journal = load_proto_journal_with_tolerance(&source, tolerance)?;
             // as_of for FX lookup: use --end if provided, else None (latest quote).
             let fx_as_of = filter.end_date;
 

--- a/crates/doppio-cli/src/main.rs
+++ b/crates/doppio-cli/src/main.rs
@@ -81,6 +81,12 @@ enum Commands {
         /// and a warning is printed to stderr.
         #[arg(long, short = 'X')]
         exchange: Option<String>,
+        /// Show postings on the synthetic doppio rounding-residual account
+        /// (account name `""`), introduced by Beancount-style tolerance
+        /// absorption (#198). Hidden by default; pass this flag to surface
+        /// them when auditing rounding behaviour.
+        #[arg(long, default_value_t = false)]
+        show_rounding: bool,
     },
 
     /// List individual postings, optionally filtered by account name.
@@ -699,6 +705,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             format,
             real,
             exchange,
+            show_rounding,
         } => {
             let format = OutputFormat::parse(&format)?;
             let filter =
@@ -722,6 +729,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         continue;
                     }
                     if real && !posting.is_real() {
+                        continue;
+                    }
+                    // Hide doppio's synthetic rounding-residual postings
+                    // (account == "") unless the user opts in. See #198.
+                    if !show_rounding && posting.account.is_empty() {
                         continue;
                     }
                     let account = match depth {

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -883,26 +883,25 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                             .collect();
                         let mut absorbed: BTreeMap<String, Decimal> = BTreeMap::new();
                         for (commodity, residual) in &residuals {
-                            let tolerance = match tolerance_mode {
-                                resolution::ToleranceMode::Strict => Decimal::ZERO,
-                                resolution::ToleranceMode::HalfSmallestPrecision => {
-                                    // Beancount's rule: tolerance is half the
-                                    // LEAST-precise posting's decimal place
-                                    // (i.e. the MIN scale among postings in
-                                    // this commodity), not the most precise.
-                                    // For postings of 100.00 + -100.005 (scales
-                                    // 2 and 3), tolerance is 0.5 * 10^-2 = 0.005.
-                                    let min_scale = resolved_postings
-                                        .iter()
-                                        .filter_map(|p| {
-                                            p.amount.as_ref()?.by_commodity.get(commodity)
-                                        })
-                                        .map(|d| d.scale)
-                                        .min()
-                                        .unwrap_or(0);
-                                    // tolerance = 0.5 * 10^-scale = 5 * 10^-(scale+1)
-                                    Decimal::new(5, min_scale + 1)
-                                }
+                            let resolution::ToleranceMode::FractionOfSmallestPrecision(fraction) =
+                                tolerance_mode;
+                            let tolerance = if fraction.is_zero() {
+                                Decimal::ZERO
+                            } else {
+                                // tolerance = fraction * 10^(-min_scale).
+                                // Beancount's default fraction is 0.5 and
+                                // min_scale is the LEAST-precise posting's
+                                // decimal place (Beancount's actual rule);
+                                // for scale-2 postings that's 0.5 * 0.01 =
+                                // 0.005.
+                                let min_scale = resolved_postings
+                                    .iter()
+                                    .filter_map(|p| p.amount.as_ref()?.by_commodity.get(commodity))
+                                    .map(|d| d.scale)
+                                    .min()
+                                    .unwrap_or(0);
+                                let one_unit = Decimal::new(1, min_scale);
+                                fraction * one_unit
                             };
                             if residual.abs() > tolerance {
                                 return Err(ElaborationError::TransactionDoesNotBalance(

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -373,6 +373,8 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
             );
         }
 
+        let tolerance_mode = value.global_context.tolerance_mode;
+
         for entry in value.entries {
             let entry_context = &value.contexts[entry.context_id];
             match entry.data {
@@ -862,15 +864,74 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                             lot: None,
                         });
                     } else {
-                        // Check that transaction state is all zeros to balance the transaction.
-                        // Virtual-unbalanced postings have already been excluded from
-                        // transaction_state, so a transaction consisting solely of
-                        // virtual-unbalanced postings will have an empty (zero) state and
-                        // will not trigger this error -- which is the correct ledger-cli behaviour.
-                        if transaction_state.0.values().any(|value| !value.is_zero()) {
-                            return Err(ElaborationError::TransactionDoesNotBalance(
-                                transaction_state,
-                            ));
+                        // No null posting. The transaction must balance to
+                        // zero per commodity, modulo the active tolerance
+                        // policy. Sub-tolerance residuals are absorbed into a
+                        // single multi-commodity synthesized posting whose
+                        // account is `""` (doppio's "rounding residual"
+                        // sentinel; see #198).
+                        //
+                        // Virtual-unbalanced postings have already been
+                        // excluded from `transaction_state`, so a transaction
+                        // consisting solely of virtual-unbalanced postings
+                        // has an empty (zero) state and bypasses this check.
+                        let residuals: Vec<(String, Decimal)> = transaction_state
+                            .0
+                            .iter()
+                            .filter(|(_, v)| !v.is_zero())
+                            .map(|(c, v)| (c.clone(), *v))
+                            .collect();
+                        let mut absorbed: BTreeMap<String, Decimal> = BTreeMap::new();
+                        for (commodity, residual) in &residuals {
+                            let tolerance = match tolerance_mode {
+                                resolution::ToleranceMode::Strict => Decimal::ZERO,
+                                resolution::ToleranceMode::HalfSmallestPrecision => {
+                                    // Beancount's rule: tolerance is half the
+                                    // LEAST-precise posting's decimal place
+                                    // (i.e. the MIN scale among postings in
+                                    // this commodity), not the most precise.
+                                    // For postings of 100.00 + -100.005 (scales
+                                    // 2 and 3), tolerance is 0.5 * 10^-2 = 0.005.
+                                    let min_scale = resolved_postings
+                                        .iter()
+                                        .filter_map(|p| {
+                                            p.amount.as_ref()?.by_commodity.get(commodity)
+                                        })
+                                        .map(|d| d.scale)
+                                        .min()
+                                        .unwrap_or(0);
+                                    // tolerance = 0.5 * 10^-scale = 5 * 10^-(scale+1)
+                                    Decimal::new(5, min_scale + 1)
+                                }
+                            };
+                            if residual.abs() > tolerance {
+                                return Err(ElaborationError::TransactionDoesNotBalance(
+                                    transaction_state,
+                                ));
+                            }
+                            absorbed.insert(commodity.clone(), -*residual);
+                        }
+                        // Synthesize one multi-commodity posting that
+                        // absorbs every (sub-tolerance) residual. The
+                        // empty-string account is intentionally not added
+                        // to `accounts` or `account_balances`: it's a
+                        // wire-format artefact, not a user-facing account.
+                        if !absorbed.is_empty() {
+                            let by_commodity: BTreeMap<String, crate::elaboration::Decimal> =
+                                absorbed
+                                    .iter()
+                                    .map(|(c, v)| (c.clone(), crate::decimal_to_proto(*v)))
+                                    .collect();
+                            resolved_postings.push(crate::elaboration::Posting {
+                                account: String::new(),
+                                payee: payee.clone(),
+                                amount: Some(crate::elaboration::Amount { by_commodity }),
+                                state: crate::state_to_proto(&TransactionState::Cleared),
+                                tags: vec![],
+                                metadata: BTreeMap::new(),
+                                kind: crate::posting_kind_to_proto(ast::PostingKind::Real),
+                                lot: None,
+                            });
                         }
                     }
 

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -374,6 +374,7 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
         }
 
         let tolerance_mode = value.global_context.tolerance_mode;
+        let tolerance_overrides = value.global_context.tolerance_overrides.clone();
 
         for entry in value.entries {
             let entry_context = &value.contexts[entry.context_id];
@@ -883,26 +884,38 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                             .collect();
                         let mut absorbed: BTreeMap<String, Decimal> = BTreeMap::new();
                         for (commodity, residual) in &residuals {
-                            let resolution::ToleranceMode::FractionOfSmallestPrecision(fraction) =
-                                tolerance_mode;
-                            let tolerance = if fraction.is_zero() {
-                                Decimal::ZERO
-                            } else {
-                                // tolerance = fraction * 10^(-min_scale).
-                                // Beancount's default fraction is 0.5 and
-                                // min_scale is the LEAST-precise posting's
-                                // decimal place (Beancount's actual rule);
-                                // for scale-2 postings that's 0.5 * 0.01 =
-                                // 0.005.
-                                let min_scale = resolved_postings
-                                    .iter()
-                                    .filter_map(|p| p.amount.as_ref()?.by_commodity.get(commodity))
-                                    .map(|d| d.scale)
-                                    .min()
-                                    .unwrap_or(0);
-                                let one_unit = Decimal::new(1, min_scale);
-                                fraction * one_unit
-                            };
+                            // Per-commodity override (e.g. from Beancount's
+                            // `option "inferred_tolerance_default"
+                            // "USD:0.005"`) wins over the rule-based
+                            // fraction-of-smallest-precision default.
+                            let tolerance =
+                                if let Some(absolute) = tolerance_overrides.get(commodity) {
+                                    *absolute
+                                } else {
+                                    let resolution::ToleranceMode::FractionOfSmallestPrecision(
+                                        fraction,
+                                    ) = tolerance_mode;
+                                    if fraction.is_zero() {
+                                        Decimal::ZERO
+                                    } else {
+                                        // tolerance = fraction * 10^(-min_scale).
+                                        // Beancount's default fraction is 0.5 and
+                                        // min_scale is the LEAST-precise posting's
+                                        // decimal place (Beancount's actual rule);
+                                        // for scale-2 postings that's 0.5 * 0.01 =
+                                        // 0.005.
+                                        let min_scale = resolved_postings
+                                            .iter()
+                                            .filter_map(|p| {
+                                                p.amount.as_ref()?.by_commodity.get(commodity)
+                                            })
+                                            .map(|d| d.scale)
+                                            .min()
+                                            .unwrap_or(0);
+                                        let one_unit = Decimal::new(1, min_scale);
+                                        fraction * one_unit
+                                    }
+                                };
                             if residual.abs() > tolerance {
                                 return Err(ElaborationError::TransactionDoesNotBalance(
                                     transaction_state,

--- a/crates/doppio/src/grammars/beancount/mod.rs
+++ b/crates/doppio/src/grammars/beancount/mod.rs
@@ -95,6 +95,11 @@ struct Parser<F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>> {
     /// and removed by `popmeta`. Stack semantics mirror `active_tags`
     /// so the most-recent value wins for a given key.
     active_meta: Vec<(String, String)>,
+    /// `option "key" "value"` directives encountered during the parse.
+    /// Captured here (rather than just dropped as `Entry::Comment`) so
+    /// the frontend can interpret options like
+    /// `inferred_tolerance_default` after the parse.
+    options: Vec<(String, String)>,
 }
 
 impl<F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>> Parser<F> {
@@ -141,12 +146,23 @@ impl<F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>> Parser<F> {
                 Rule::pad_directive => {
                     entries.push(Entry::Pad(parse_pad_directive(pair)));
                 }
+                Rule::option_directive => {
+                    // Capture the (key, value) for later interpretation
+                    // by BeancountFrontend (e.g. inferred_tolerance_default).
+                    // Also push as Comment so the source line survives the
+                    // round-trip.
+                    let raw = pair.as_str().trim().to_string();
+                    let mut inner = pair.into_inner();
+                    let key = string_inner(inner.next().expect("option key"));
+                    let value = string_inner(inner.next().expect("option value"));
+                    self.options.push((key, value));
+                    entries.push(Entry::Comment(raw));
+                }
                 Rule::note_directive
                 | Rule::document_directive
                 | Rule::event_directive
                 | Rule::query_directive
                 | Rule::custom_directive
-                | Rule::option_directive
                 | Rule::plugin_directive => {
                     entries.push(Entry::Comment(pair.as_str().trim().to_string()));
                 }
@@ -741,15 +757,26 @@ fn entry_date_key(entry: &Entry) -> Option<Date> {
 /// Beancount language semantics).
 #[cfg(test)]
 pub(crate) fn parse_beancount(input: &str) -> Result<Journal, Box<dyn std::error::Error>> {
-    let mut journal = Parser {
+    Ok(parse_beancount_with_options(input)?.0)
+}
+
+/// Like [`parse_beancount`] but also returns any `option` directives
+/// captured during the parse. Used by the elaboration test helper to
+/// honour `inferred_tolerance_default`.
+#[cfg(test)]
+pub(crate) fn parse_beancount_with_options(
+    input: &str,
+) -> Result<(Journal, Vec<(String, String)>), Box<dyn std::error::Error>> {
+    let mut parser = Parser {
         opener: |_| Ok(String::new()),
         base_path: PathBuf::new(),
         active_tags: Vec::new(),
         active_meta: Vec::new(),
-    }
-    .parse(input)?;
+        options: Vec::new(),
+    };
+    let mut journal = parser.parse(input)?;
     sort_entries_by_date(&mut journal.entries);
-    Ok(journal)
+    Ok((journal, parser.options))
 }
 
 // ---
@@ -787,13 +814,14 @@ impl crate::frontend::Frontend for BeancountFrontend {
         base_path: &std::path::Path,
         opener: &crate::frontend::Opener,
     ) -> Result<crate::resolution::HIR, Box<dyn std::error::Error>> {
-        let mut ast_journal = Parser {
+        let mut parser = Parser {
             opener: |path: &str| opener(path),
             base_path: base_path.to_path_buf(),
             active_tags: Vec::new(),
             active_meta: Vec::new(),
-        }
-        .parse(input)?;
+            options: Vec::new(),
+        };
+        let mut ast_journal = parser.parse(input)?;
         // Beancount is date-ordered, not source-ordered. Sort once at the
         // outermost call (after include resolution has flattened the tree)
         // so resolver + elaborator can treat the entries as already in
@@ -808,6 +836,20 @@ impl crate::frontend::Frontend for BeancountFrontend {
             crate::resolution::ToleranceMode::FractionOfSmallestPrecision(
                 rust_decimal::Decimal::new(5, 1),
             );
+        // Honour `option "inferred_tolerance_default" "COMMODITY:VALUE"`
+        // directives. Each occurrence overrides any previous value for
+        // the same commodity (last write wins). The directive is
+        // file-level; nested includes contribute to the same map.
+        for (k, v) in &parser.options {
+            if k == "inferred_tolerance_default"
+                && let Some((commodity, decimal)) = v.split_once(':')
+                && let Ok(d) = decimal.trim().parse::<rust_decimal::Decimal>()
+            {
+                hir.global_context
+                    .tolerance_overrides
+                    .insert(commodity.trim().to_string(), d);
+            }
+        }
         Ok(hir)
     }
 }
@@ -1738,10 +1780,67 @@ popmeta tag:
         );
     }
 
+    #[test]
+    fn inferred_tolerance_default_option_overrides_per_commodity() {
+        // Without the option directive, this 0.05 USD residual is over
+        // tolerance and rejects (covered by `over_tolerance_residual_still_errors`).
+        // With `option \"inferred_tolerance_default\" \"USD:0.1\"`, the
+        // per-commodity override raises USD's tolerance to 0.1 absolute,
+        // so the same 0.05 residual is now within tolerance.
+        let input = "\
+option \"inferred_tolerance_default\" \"USD:0.1\"
+
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Income:Salary USD
+
+2024-01-15 * \"Larger residual within override\"
+  Assets:Cash         100.00 USD
+  Income:Salary      -100.05 USD
+";
+        let elab = elaborate(input).expect("USD override should accept the 0.05 residual");
+        // Synthesized empty-account posting should absorb +0.05 USD.
+        let mut found_amt: Option<rust_decimal::Decimal> = None;
+        for tx in &elab.transactions {
+            for p in &tx.postings {
+                if p.account.is_empty() {
+                    if let Some(amt) = p.amount.as_ref().and_then(|a| a.by_commodity.get("USD")) {
+                        // Reconstruct decimal: mantissa / 10^scale (sign in mantissa_high).
+                        let mantissa = (amt.mantissa_high as i128) << 64 | amt.mantissa_low as i128;
+                        let d = rust_decimal::Decimal::from_i128_with_scale(mantissa, amt.scale);
+                        found_amt = Some(d);
+                    }
+                }
+            }
+        }
+        assert_eq!(
+            found_amt,
+            Some(rust_decimal::Decimal::new(5, 2)),
+            "rounding posting should absorb +0.05 USD when override permits it"
+        );
+    }
+
+    #[test]
+    fn inferred_tolerance_default_does_not_apply_to_other_commodities() {
+        // The override is per-commodity. A USD override doesn't widen
+        // EUR tolerance.
+        let input = "\
+option \"inferred_tolerance_default\" \"USD:0.1\"
+
+2024-01-01 open Assets:Cash:EUR EUR
+2024-01-01 open Income:Salary:EUR EUR
+
+2024-01-15 * \"EUR over default tolerance\"
+  Assets:Cash:EUR         100.00 EUR
+  Income:Salary:EUR      -100.05 EUR
+";
+        let err = elaborate(input).expect_err("USD override must not affect EUR");
+        assert!(format!("{err:?}").contains("TransactionDoesNotBalance"));
+    }
+
     // -- pad evaluator (#147) -----------------------------------------------
 
     fn elaborate(input: &str) -> Result<crate::elaboration::Journal, Box<dyn std::error::Error>> {
-        let journal = parse_beancount(input)?;
+        let (journal, options) = parse_beancount_with_options(input)?;
         let mut hir: crate::resolution::HIR = journal.try_into()?;
         // Match BeancountFrontend's default (fraction = 0.5) so the
         // elaborator applies Beancount-style tolerance.
@@ -1749,6 +1848,16 @@ popmeta tag:
             crate::resolution::ToleranceMode::FractionOfSmallestPrecision(
                 rust_decimal::Decimal::new(5, 1),
             );
+        for (k, v) in &options {
+            if k == "inferred_tolerance_default"
+                && let Some((commodity, decimal)) = v.split_once(':')
+                && let Ok(d) = decimal.trim().parse::<rust_decimal::Decimal>()
+            {
+                hir.global_context
+                    .tolerance_overrides
+                    .insert(commodity.trim().to_string(), d);
+            }
+        }
         Ok(hir.try_into()?)
     }
 

--- a/crates/doppio/src/grammars/beancount/mod.rs
+++ b/crates/doppio/src/grammars/beancount/mod.rs
@@ -801,10 +801,13 @@ impl crate::frontend::Frontend for BeancountFrontend {
         sort_entries_by_date(&mut ast_journal.entries);
         let mut hir: crate::resolution::HIR = ast_journal.try_into()?;
         // Beancount applies a per-transaction balance tolerance by
-        // default (#198). Switch the elaborator out of strict mode so
-        // sub-tolerance residuals get absorbed into a synthesized
-        // posting rather than rejected.
-        hir.global_context.tolerance_mode = crate::resolution::ToleranceMode::HalfSmallestPrecision;
+        // default (#198). Default fraction is 0.5 -- half the
+        // least-precise posting's decimal place -- matching
+        // bean-check's behaviour.
+        hir.global_context.tolerance_mode =
+            crate::resolution::ToleranceMode::FractionOfSmallestPrecision(
+                rust_decimal::Decimal::new(5, 1),
+            );
         Ok(hir)
     }
 }
@@ -1740,9 +1743,12 @@ popmeta tag:
     fn elaborate(input: &str) -> Result<crate::elaboration::Journal, Box<dyn std::error::Error>> {
         let journal = parse_beancount(input)?;
         let mut hir: crate::resolution::HIR = journal.try_into()?;
-        // Match BeancountFrontend's default so the elaborator applies
-        // Beancount-style tolerance to sub-cent residuals.
-        hir.global_context.tolerance_mode = crate::resolution::ToleranceMode::HalfSmallestPrecision;
+        // Match BeancountFrontend's default (fraction = 0.5) so the
+        // elaborator applies Beancount-style tolerance.
+        hir.global_context.tolerance_mode =
+            crate::resolution::ToleranceMode::FractionOfSmallestPrecision(
+                rust_decimal::Decimal::new(5, 1),
+            );
         Ok(hir.try_into()?)
     }
 

--- a/crates/doppio/src/grammars/beancount/mod.rs
+++ b/crates/doppio/src/grammars/beancount/mod.rs
@@ -799,7 +799,13 @@ impl crate::frontend::Frontend for BeancountFrontend {
         // so resolver + elaborator can treat the entries as already in
         // chronological order.
         sort_entries_by_date(&mut ast_journal.entries);
-        Ok(ast_journal.try_into()?)
+        let mut hir: crate::resolution::HIR = ast_journal.try_into()?;
+        // Beancount applies a per-transaction balance tolerance by
+        // default (#198). Switch the elaborator out of strict mode so
+        // sub-tolerance residuals get absorbed into a synthesized
+        // posting rather than rejected.
+        hir.global_context.tolerance_mode = crate::resolution::ToleranceMode::HalfSmallestPrecision;
+        Ok(hir)
     }
 }
 
@@ -1669,11 +1675,74 @@ popmeta tag:
         );
     }
 
+    // -- balance tolerance (#198) -------------------------------------------
+
+    #[test]
+    fn sub_tolerance_residual_is_absorbed_into_synthetic_account() {
+        // 100.00 + (-100.005) = -0.005 USD. Tolerance for the
+        // least-precise posting (scale 2) is 0.5 * 10^-2 = 0.005.
+        // residual <= tolerance, so the elaborator synthesizes a
+        // posting on the empty-string account that absorbs +0.005 USD.
+        let input = "\
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Income:Salary USD
+
+2024-01-15 * \"Sub-tolerance residual\"
+  Assets:Cash         100.00 USD
+  Income:Salary      -100.005 USD
+";
+        let elab = elaborate(input).expect("sub-tolerance residual must elaborate");
+        // Locate the synthesized rounding posting (account == "").
+        let mut found = None;
+        for tx in &elab.transactions {
+            for p in &tx.postings {
+                if p.account.is_empty() {
+                    found = Some(p);
+                }
+            }
+        }
+        let p = found.expect("a synthesized empty-account posting should exist");
+        let amt = p
+            .amount
+            .as_ref()
+            .and_then(|a| a.by_commodity.get("USD"))
+            .expect("rounding posting in USD");
+        // 0.005 -> mantissa 5, scale 3, mantissa_high 0
+        assert_eq!(
+            (amt.mantissa_low, amt.mantissa_high, amt.scale),
+            (5, 0, 3),
+            "rounding posting should absorb +0.005 USD"
+        );
+    }
+
+    #[test]
+    fn over_tolerance_residual_still_errors() {
+        // 100.00 + (-100.05) = -0.05 USD. Tolerance for scale-2 postings
+        // is 0.005. 0.05 > 0.005 -> reject.
+        let input = "\
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Income:Salary USD
+
+2024-01-15 * \"Over-tolerance residual\"
+  Assets:Cash         100.00 USD
+  Income:Salary      -100.05 USD
+";
+        let err = elaborate(input).expect_err("over-tolerance residual must reject");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("TransactionDoesNotBalance"),
+            "expected TransactionDoesNotBalance, got: {msg}"
+        );
+    }
+
     // -- pad evaluator (#147) -----------------------------------------------
 
     fn elaborate(input: &str) -> Result<crate::elaboration::Journal, Box<dyn std::error::Error>> {
         let journal = parse_beancount(input)?;
-        let hir: crate::resolution::HIR = journal.try_into()?;
+        let mut hir: crate::resolution::HIR = journal.try_into()?;
+        // Match BeancountFrontend's default so the elaborator applies
+        // Beancount-style tolerance to sub-cent residuals.
+        hir.global_context.tolerance_mode = crate::resolution::ToleranceMode::HalfSmallestPrecision;
         Ok(hir.try_into()?)
     }
 

--- a/crates/doppio/src/resolution.rs
+++ b/crates/doppio/src/resolution.rs
@@ -137,21 +137,32 @@ pub struct GlobalContext {
 /// Per-transaction balance tolerance policy.
 ///
 /// When a transaction's postings sum to a non-zero residual, the
-/// elaborator either rejects the transaction (strict) or absorbs the
-/// residual into a synthesized posting whose account is the empty
-/// string `""` -- the doppio convention for "rounding residual; not
-/// a user-named account."
-#[derive(Default, Debug, Clone, Copy)]
+/// elaborator either rejects the transaction (residual exceeds
+/// tolerance) or absorbs the residual into a synthesized posting
+/// whose account is the empty string `""` -- the doppio convention
+/// for "rounding residual; not a user-named account."
+#[derive(Debug, Clone, Copy)]
 pub enum ToleranceMode {
-    /// Every transaction must balance to exact zero per commodity.
-    /// Default. Matches ledger-cli and hledger semantics.
-    #[default]
-    Strict,
-    /// Accept residuals whose absolute value is at most half the
-    /// smallest decimal precision among the transaction's explicit
-    /// postings. Matches Beancount's default behaviour. The residual
-    /// is absorbed by a synthesized posting with `account: ""`.
-    HalfSmallestPrecision,
+    /// Accept residuals whose absolute value is at most
+    /// `fraction * 10^(-min_scale)` per commodity, where `min_scale`
+    /// is the smallest decimal precision among the transaction's
+    /// explicit postings in that commodity.
+    ///
+    /// - `fraction = 0`: every transaction must balance to exact
+    ///   zero per commodity. This is the default and matches
+    ///   ledger-cli + hledger semantics.
+    /// - `fraction = 0.5`: accept residuals up to half the
+    ///   least-precise posting's decimal place. Matches Beancount's
+    ///   default (e.g. for scale-2 USD postings, tolerance = 0.005).
+    /// - Other fractions are valid; the CLI exposes a `--tolerance`
+    ///   flag that accepts any decimal in `[0, 1)`.
+    FractionOfSmallestPrecision(rust_decimal::Decimal),
+}
+
+impl Default for ToleranceMode {
+    fn default() -> Self {
+        Self::FractionOfSmallestPrecision(rust_decimal::Decimal::ZERO)
+    }
 }
 
 /// Validation rules for a tag declared with a `tag` directive.

--- a/crates/doppio/src/resolution.rs
+++ b/crates/doppio/src/resolution.rs
@@ -125,6 +125,33 @@ pub struct GlobalContext {
     pub account_properties: BTreeMap<String, AccountProperties>,
     /// Properties declared in `tag` directives.
     pub tag_properties: BTreeMap<String, TagProperties>,
+    /// How the elaborator handles small per-transaction balance
+    /// residuals. The Beancount frontend sets this to
+    /// [`ToleranceMode::HalfSmallestPrecision`] (matching bean-check's
+    /// behaviour); the ledger and hledger frontends leave it
+    /// [`ToleranceMode::Strict`] (every transaction must balance to
+    /// exact zero per commodity).
+    pub tolerance_mode: ToleranceMode,
+}
+
+/// Per-transaction balance tolerance policy.
+///
+/// When a transaction's postings sum to a non-zero residual, the
+/// elaborator either rejects the transaction (strict) or absorbs the
+/// residual into a synthesized posting whose account is the empty
+/// string `""` -- the doppio convention for "rounding residual; not
+/// a user-named account."
+#[derive(Default, Debug, Clone, Copy)]
+pub enum ToleranceMode {
+    /// Every transaction must balance to exact zero per commodity.
+    /// Default. Matches ledger-cli and hledger semantics.
+    #[default]
+    Strict,
+    /// Accept residuals whose absolute value is at most half the
+    /// smallest decimal precision among the transaction's explicit
+    /// postings. Matches Beancount's default behaviour. The residual
+    /// is absorbed by a synthesized posting with `account: ""`.
+    HalfSmallestPrecision,
 }
 
 /// Validation rules for a tag declared with a `tag` directive.

--- a/crates/doppio/src/resolution.rs
+++ b/crates/doppio/src/resolution.rs
@@ -126,12 +126,15 @@ pub struct GlobalContext {
     /// Properties declared in `tag` directives.
     pub tag_properties: BTreeMap<String, TagProperties>,
     /// How the elaborator handles small per-transaction balance
-    /// residuals. The Beancount frontend sets this to
-    /// [`ToleranceMode::HalfSmallestPrecision`] (matching bean-check's
-    /// behaviour); the ledger and hledger frontends leave it
-    /// [`ToleranceMode::Strict`] (every transaction must balance to
-    /// exact zero per commodity).
+    /// residuals. See [`ToleranceMode`].
     pub tolerance_mode: ToleranceMode,
+    /// Per-commodity absolute tolerance overrides, layered on top of
+    /// [`Self::tolerance_mode`]. Populated by Beancount's
+    /// `option "inferred_tolerance_default" "COMMODITY:VALUE"`
+    /// directive. When a commodity is present in this map, the
+    /// elaborator uses the override directly; otherwise it falls back
+    /// to the `tolerance_mode` rule.
+    pub tolerance_overrides: BTreeMap<String, rust_decimal::Decimal>,
 }
 
 /// Per-transaction balance tolerance policy.


### PR DESCRIPTION
## Summary

Implements Beancount-style per-transaction balance tolerance per the agreed design in #198. Sub-tolerance residuals are absorbed into a synthesized posting whose account is the empty string \`\"\"\` -- doppio's \"rounding residual\" sentinel. The \`.dop\` exact-balance invariant stays intact: every elaborated transaction still sums to zero per commodity.

Closes #198.

## What's the synthetic-account-as-empty-string convention

Per the design discussion on PR #204 / #198: the residual goes into a posting whose \`account: \"\"\`. That sentinel is:

- **Uncolliding** -- no frontend's parser emits empty-string accounts, so the convention is unambiguous.
- **Wire-format-additive** -- reuses the existing string \`account\` slot; no proto schema change.
- **Audit-friendly** -- consumers can find the residuals by filtering on \`account == \"\"\`; the \`.dop\` invariant stays \"every transaction balances exactly.\"
- **Beancount-user-friendly** -- users don't have to declare or know about an \`Equity:Rounding\` account in their source.

## Changes

- **\`resolution::GlobalContext\`** gains \`tolerance_mode: ToleranceMode\`. Default \`Strict\`. \`BeancountFrontend::parse\` flips the produced HIR to \`HalfSmallestPrecision\`.
- **Elaborator's no-null-posting balance check** snapshots per-commodity residuals, computes per-commodity tolerance from the **least-precise** posting's scale (Beancount's actual rule -- 100.00 + (-100.005) has tolerance 0.005, not 0.0005), and either rejects (over tolerance) or synthesizes a single multi-commodity posting absorbing every sub-tolerance residual.
- **The synthetic account is NOT added to \`accounts\` or \`account_balances\`** -- it's a transaction-balancing artefact, not a user-facing account that downstream pad / balance-assignment computations should reference.
- **\`dop balance\`** filters empty-account postings by default. New \`--show-rounding\` flag surfaces them.

## Tests

- \`sub_tolerance_residual_is_absorbed_into_synthetic_account\` -- 100.00 + (-100.005) = -0.005 USD residual; synthesized posting absorbs +0.005 USD on the empty-string account.
- \`over_tolerance_residual_still_errors\` -- 100.00 + (-100.05) = -0.05 USD; over tolerance; transaction rejected.
- ledger / hledger continue to require exact zero (negative-control parity fixtures still trip; existing test sweep unaffected).

285 doppio lib tests, +2 new.

## What this does NOT do

- The \`bean-example --seed 42\` output that originally surfaced this issue still does not elaborate; it has additional non-tolerance imbalances (~116 USD off, lot-pricing-related) that are *not* in scope here. They'll surface as their own gaps as #197 corpus growth proceeds.
- Beancount's \`option \"inferred_tolerance_default\"\` directive is not yet parsed; the elaborator uses the half-smallest-precision rule unconditionally for Beancount input. Adding option-directive overrides is a clean follow-up if it ever bites.
- No CLI \`--tolerance\` flag for explicit override; library-API tolerance config also deferred. Per-frontend default is enough for now -- explicit override can be a follow-up if a real consumer asks.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo test --workspace\` (285 doppio lib + 49 elaborator + ...; all green)
- [x] Parity (6 positive, 3 negative; all green locally)
- [x] \`dop balance\` hides empty-account postings by default; \`--show-rounding\` reveals them