### PR TITLE
beancount: balance applies at start-of-date + vendor bean-example (#212)

### DIFF
--- a/crates/doppio/src/grammars/beancount/mod.rs
+++ b/crates/doppio/src/grammars/beancount/mod.rs
@@ -722,18 +722,39 @@ fn clean_decimal(s: &str) -> Decimal {
 // ---
 // Date-order normalisation
 // ---
-/// Beancount evaluates entries in **date order**, not source order, which
-/// matters for `pad` + `balance` (a pad must see all transactions on its
-/// target account between its date and the next assertion's date before
-/// computing the gap to fill).
-///
-/// We stable-sort the AST entries here so the resolver and elaborator can
+/// Beancount evaluates entries in **date order**, not source order. We
+/// stable-sort the AST entries here so the resolver and elaborator can
 /// stay source-order-agnostic. Undated entries (directives, comments)
-/// keep their original relative position and sort before any dated entry
-/// because directives are setup that should apply before the journal's
-/// time-evolving state begins.
+/// keep their original relative position and sort before any dated
+/// entry.
+///
+/// Within the same date, Beancount applies a fixed ordering that
+/// matters for the pad/balance interaction (#147) and for balance
+/// assertions that should fire BEFORE any same-date transaction
+/// touching the asserted account (#212):
+///
+/// 1. **Pad** -- registers a "pending pad" for the next balance.
+/// 2. **Balance** -- assertion fires at the *beginning* of the date,
+///    consuming any pending pad. Per Beancount's documentation:
+///    "The balance directive applies for the *beginning* of the date."
+/// 3. **Transactions / HistoricalPrice / other dated** -- happen
+///    during the date, in source order (stable sort tiebreak).
 fn sort_entries_by_date(entries: &mut [Entry]) {
-    entries.sort_by_key(entry_date_key);
+    entries.sort_by_key(entry_sort_key);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum SameDayOrder {
+    /// Pad registers a pending fill before any same-date balance.
+    Pad,
+    /// Balance asserts at the start of the date, after pad.
+    Balance,
+    /// Transactions, prices, etc. -- "during" the date.
+    During,
+}
+
+fn entry_sort_key(entry: &Entry) -> (Option<Date>, SameDayOrder) {
+    (entry_date_key(entry), entry_sub_order(entry))
 }
 
 fn entry_date_key(entry: &Entry) -> Option<Date> {
@@ -743,6 +764,14 @@ fn entry_date_key(entry: &Entry) -> Option<Date> {
         Entry::HistoricalPrice(hp) => Some(hp.date.clone()),
         Entry::Pad(p) => Some(p.date.clone()),
         Entry::Directive(_) | Entry::Comment(_) => None,
+    }
+}
+
+fn entry_sub_order(entry: &Entry) -> SameDayOrder {
+    match entry {
+        Entry::Pad(_) => SameDayOrder::Pad,
+        Entry::Assertion(_) => SameDayOrder::Balance,
+        _ => SameDayOrder::During,
     }
 }
 

--- a/scripts/parity_check.py
+++ b/scripts/parity_check.py
@@ -43,7 +43,14 @@ Tuple3 = tuple[str, str, Decimal]
 
 def beancount_balances(fixture: Path) -> set[Tuple3]:
     """Use the Beancount Python API directly. Cleaner than parsing
-    `bean-report` text and survives the 2.x → 3.x transition."""
+    `bean-report` text and survives the 2.x → 3.x transition.
+
+    Aggregates per-lot positions into a single (account, commodity,
+    total) tuple so the comparison matches doppio's aggregate balance
+    view. Beancount tracks lots individually (so an account holding
+    three ITOT purchases at different costs has three position rows
+    for the same currency); doppio reports the aggregate. Per-lot
+    inventory comparison is its own concern (#185)."""
     from beancount.loader import load_file
     from beancount.core.realization import realize, iter_children
 
@@ -51,13 +58,15 @@ def beancount_balances(fixture: Path) -> set[Tuple3]:
     if errors:
         raise RuntimeError(f"beancount errors loading {fixture}: {errors}")
     real_root = realize(entries)
-    out: set[Tuple3] = set()
+    aggregated: dict[tuple[str, str], Decimal] = {}
     for ra in iter_children(real_root):
         for pos in ra.balance.get_positions():
             amt = pos.units.number
-            if amt is not None and amt != 0:
-                out.add((ra.account, pos.units.currency, Decimal(str(amt))))
-    return out
+            if amt is None:
+                continue
+            key = (ra.account, pos.units.currency)
+            aggregated[key] = aggregated.get(key, Decimal(0)) + Decimal(str(amt))
+    return {(acct, comm, total) for (acct, comm), total in aggregated.items() if total != 0}
 
 
 def hledger_balances(fixture: Path) -> set[Tuple3]:
@@ -226,6 +235,7 @@ POSITIVE: list[Case] = [
     Case("hledger:ascii",         REPO / "tests/parity/hledger-ascii.journal", hledger_balances),
     Case("hledger:zerostar",      REPO / "tests/parity/hledger-zerostar.journal", hledger_balances),
     Case("hledger:block-comment", REPO / "tests/parity/hledger-block-comment.journal", hledger_balances),
+    Case("beancount:example",     REPO / "tests/parity/bean-example.beancount", beancount_balances),
 ]
 
 NEGATIVE: list[Case] = [

--- a/tests/parity/bean-example.beancount
+++ b/tests/parity/bean-example.beancount
@@ -1,0 +1,5726 @@
+; Source: bean-example (Beancount 3.x synthetic-journal generator).
+;   Generation command: bean-example --seed 42 -o tests/parity/bean-example.beancount
+;   beancount package: 3.2.0 (matched by .github/workflows/ci.yml)
+;   license: GPL-2.0 (Beancount project; compatible with redistribution
+;            under doppio's MIT for vendored test data)
+;
+; Exercises a realistic multi-year personal-finance journal: payroll,
+; 401k contributions in IRAUSD tracker, brokerage buys/sells with cost
+; basis, currency conversions, fiscal-year balance assertions, etc.
+;
+; To regenerate (e.g. after a beancount version bump): re-run the
+; command above. Output is deterministic for the seed + version pin.
+
+;; -*- mode: org; mode: beancount; -*-
+;; Birth: 1980-05-12
+;; Dates: 2024-01-01 - 2026-05-06
+;; THIS FILE HAS BEEN AUTO-GENERATED.
+* Options
+
+option "title" "Example Beancount file"
+option "operating_currency" "USD"
+
+
+
+
+* Commodities
+
+
+1792-01-01 commodity USD
+  name: "US Dollar"
+  export: "CASH"
+
+1900-01-01 commodity VMMXX
+  export: "MUTF:VMMXX (MONEY:USD)"
+
+1980-05-12 commodity VACHR
+  name: "Employer Vacation Hours"
+  export: "IGNORE"
+
+1980-05-12 commodity IRAUSD
+  name: "US 401k and IRA Contributions"
+  export: "IGNORE"
+
+1995-09-18 commodity VBMPX
+  name: "Vanguard Total Bond Market Index Fund Institutional Plus Shares"
+  export: "MUTF:VBMPX"
+  price: "USD:google/MUTF:VBMPX"
+
+2004-01-20 commodity ITOT
+  name: "iShares Core S&P Total U.S. Stock Market ETF"
+  export: "NYSEARCA:ITOT"
+  price: "USD:google/NYSEARCA:ITOT"
+
+2004-01-26 commodity VHT
+  name: "Vanguard Health Care ETF"
+  export: "NYSEARCA:VHT"
+  price: "USD:google/NYSEARCA:VHT"
+
+2004-11-01 commodity GLD
+  name: "SPDR Gold Trust (ETF)"
+  export: "NYSEARCA:GLD"
+  price: "USD:google/NYSEARCA:GLD"
+
+2007-07-20 commodity VEA
+  name: "Vanguard FTSE Developed Markets ETF"
+  export: "NYSEARCA:VEA"
+  price: "USD:google/NYSEARCA:VEA"
+
+2009-05-01 commodity RGAGX
+  name: "American Funds The Growth Fund of America Class R-6"
+  export: "MUTF:RGAGX"
+  price: "USD:google/MUTF:RGAGX"
+
+
+
+* Equity Accounts
+
+1980-05-12 open Equity:Opening-Balances
+1980-05-12 open Liabilities:AccountsPayable
+
+
+
+* Banking
+
+2024-01-01 open Assets:US:BofA
+  institution: "Bank of America"
+  address: "123 America Street, LargeTown, USA"
+  phone: "+1.012.345.6789"
+2024-01-01 open Assets:US:BofA:Checking                        USD
+  account: "00234-48574897"
+
+2024-01-01 * "Opening Balance for checking account"
+  Assets:US:BofA:Checking                         3976.78 USD
+  Equity:Opening-Balances                        -3976.78 USD
+
+2024-01-02 balance Assets:US:BofA:Checking        3976.78 USD
+
+2024-01-03 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2024-01-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2024-01-09 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2024-01-18 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -63.85 USD
+  Expenses:Home:Phone                               63.85 USD
+
+2024-01-22 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -80.08 USD
+  Expenses:Home:Internet                            80.08 USD
+
+2024-01-30 balance Assets:US:BofA:Checking        3833.87 USD
+
+2024-02-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2024-02-04 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2024-02-08 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2024-02-18 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -73.75 USD
+  Expenses:Home:Phone                               73.75 USD
+
+2024-02-21 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -80.09 USD
+  Expenses:Home:Internet                            80.09 USD
+
+2024-02-27 balance Assets:US:BofA:Checking        3334.24 USD
+
+2024-03-03 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2024-03-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2024-03-09 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2024-03-18 balance Assets:US:BofA:Checking        2695.75 USD
+
+2024-03-18 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -58.74 USD
+  Expenses:Home:Phone                               58.74 USD
+
+2024-03-22 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -80.13 USD
+  Expenses:Home:Internet                            80.13 USD
+
+2024-04-03 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2024-04-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2024-04-09 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2024-04-17 balance Assets:US:BofA:Checking        2191.38 USD
+
+2024-04-19 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -53.37 USD
+  Expenses:Home:Phone                               53.37 USD
+
+2024-04-23 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -80.05 USD
+  Expenses:Home:Internet                            80.05 USD
+
+2024-05-03 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2024-05-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2024-05-09 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2024-05-12 balance Assets:US:BofA:Checking        1703.35 USD
+
+2024-05-18 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -54.30 USD
+  Expenses:Home:Phone                               54.30 USD
+
+2024-05-21 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -80.03 USD
+  Expenses:Home:Internet                            80.03 USD
+
+2024-06-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2024-06-06 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2024-06-07 balance Assets:US:BofA:Checking        1866.22 USD
+
+2024-06-09 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2024-06-19 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -69.57 USD
+  Expenses:Home:Phone                               69.57 USD
+
+2024-06-23 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -79.97 USD
+  Expenses:Home:Internet                            79.97 USD
+
+2024-06-29 balance Assets:US:BofA:Checking        2400.00 USD
+
+2024-07-03 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2024-07-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2024-07-08 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2024-07-18 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -66.08 USD
+  Expenses:Home:Phone                               66.08 USD
+
+2024-07-22 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -80.00 USD
+  Expenses:Home:Internet                            80.00 USD
+
+2024-07-25 balance Assets:US:BofA:Checking        1746.16 USD
+
+2024-08-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2024-08-06 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2024-08-08 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2024-08-19 balance Assets:US:BofA:Checking        3154.97 USD
+
+2024-08-19 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -67.27 USD
+  Expenses:Home:Phone                               67.27 USD
+
+2024-08-21 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -79.85 USD
+  Expenses:Home:Internet                            79.85 USD
+
+2024-09-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2024-09-05 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2024-09-08 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2024-09-13 * "Transfering accumulated savings to other account"
+  Assets:US:BofA:Checking                           -3500 USD
+  Assets:US:ETrade:Cash                              3500 USD
+
+2024-09-14 balance Assets:US:BofA:Checking        1405.48 USD
+
+2024-09-20 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -67.91 USD
+  Expenses:Home:Phone                               67.91 USD
+
+2024-09-21 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -80.10 USD
+  Expenses:Home:Internet                            80.10 USD
+
+2024-10-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2024-10-05 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2024-10-08 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2024-10-09 balance Assets:US:BofA:Checking         561.25 USD
+
+2024-10-19 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -45.63 USD
+  Expenses:Home:Phone                               45.63 USD
+
+2024-10-23 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -79.89 USD
+  Expenses:Home:Internet                            79.89 USD
+
+2024-10-29 balance Assets:US:BofA:Checking        5536.93 USD
+
+2024-11-03 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2024-11-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2024-11-08 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2024-11-08 * "Transfering accumulated savings to other account"
+  Assets:US:BofA:Checking                           -4500 USD
+  Assets:US:ETrade:Cash                              4500 USD
+
+2024-11-18 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -46.02 USD
+  Expenses:Home:Phone                               46.02 USD
+
+2024-11-22 balance Assets:US:BofA:Checking        3090.26 USD
+
+2024-11-23 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -80.02 USD
+  Expenses:Home:Internet                            80.02 USD
+
+2024-12-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2024-12-06 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2024-12-08 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2024-12-17 balance Assets:US:BofA:Checking        2428.28 USD
+
+2024-12-19 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -38.28 USD
+  Expenses:Home:Phone                               38.28 USD
+
+2024-12-22 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -79.82 USD
+  Expenses:Home:Internet                            79.82 USD
+
+2025-01-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2025-01-05 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2025-01-08 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2025-01-11 balance Assets:US:BofA:Checking        3432.87 USD
+
+2025-01-19 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -54.79 USD
+  Expenses:Home:Phone                               54.79 USD
+
+2025-01-21 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -79.95 USD
+  Expenses:Home:Internet                            79.95 USD
+
+2025-02-03 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2025-02-04 balance Assets:US:BofA:Checking        3599.33 USD
+
+2025-02-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2025-02-08 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2025-02-20 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -70.80 USD
+  Expenses:Home:Phone                               70.80 USD
+
+2025-02-23 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -79.95 USD
+  Expenses:Home:Internet                            79.95 USD
+
+2025-03-03 balance Assets:US:BofA:Checking        5083.74 USD
+
+2025-03-03 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2025-03-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2025-03-09 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2025-03-18 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -62.53 USD
+  Expenses:Home:Phone                               62.53 USD
+
+2025-03-21 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -80.01 USD
+  Expenses:Home:Internet                            80.01 USD
+
+2025-03-31 balance Assets:US:BofA:Checking        4101.21 USD
+
+2025-04-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2025-04-05 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2025-04-08 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2025-04-19 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -57.72 USD
+  Expenses:Home:Phone                               57.72 USD
+
+2025-04-21 balance Assets:US:BofA:Checking        2015.12 USD
+
+2025-04-23 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -79.93 USD
+  Expenses:Home:Internet                            79.93 USD
+
+2025-05-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2025-05-05 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2025-05-08 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2025-05-14 balance Assets:US:BofA:Checking        1654.13 USD
+
+2025-05-20 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -65.06 USD
+  Expenses:Home:Phone                               65.06 USD
+
+2025-05-22 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -79.97 USD
+  Expenses:Home:Internet                            79.97 USD
+
+2025-06-03 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2025-06-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2025-06-08 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2025-06-10 balance Assets:US:BofA:Checking        1158.70 USD
+
+2025-06-19 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -55.75 USD
+  Expenses:Home:Phone                               55.75 USD
+
+2025-06-23 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -80.09 USD
+  Expenses:Home:Internet                            80.09 USD
+
+2025-07-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2025-07-04 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2025-07-06 balance Assets:US:BofA:Checking        1320.06 USD
+
+2025-07-08 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2025-07-18 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -65.39 USD
+  Expenses:Home:Phone                               65.39 USD
+
+2025-07-23 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -80.01 USD
+  Expenses:Home:Internet                            80.01 USD
+
+2025-08-02 balance Assets:US:BofA:Checking        3748.92 USD
+
+2025-08-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2025-08-04 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2025-08-08 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2025-08-19 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -64.25 USD
+  Expenses:Home:Phone                               64.25 USD
+
+2025-08-23 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -79.90 USD
+  Expenses:Home:Internet                            79.90 USD
+
+2025-08-26 balance Assets:US:BofA:Checking        3166.47 USD
+
+2025-09-03 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2025-09-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2025-09-09 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2025-09-12 * "Transfering accumulated savings to other account"
+  Assets:US:BofA:Checking                           -4000 USD
+  Assets:US:ETrade:Cash                              4000 USD
+
+2025-09-17 balance Assets:US:BofA:Checking        1301.16 USD
+
+2025-09-20 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -55.98 USD
+  Expenses:Home:Phone                               55.98 USD
+
+2025-09-21 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -80.05 USD
+  Expenses:Home:Internet                            80.05 USD
+
+2025-10-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2025-10-04 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2025-10-08 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2025-10-13 balance Assets:US:BofA:Checking        3137.16 USD
+
+2025-10-19 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -64.56 USD
+  Expenses:Home:Phone                               64.56 USD
+
+2025-10-22 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -80.06 USD
+  Expenses:Home:Internet                            80.06 USD
+
+2025-11-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2025-11-05 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2025-11-07 * "Transfering accumulated savings to other account"
+  Assets:US:BofA:Checking                           -4500 USD
+  Assets:US:ETrade:Cash                              4500 USD
+
+2025-11-08 balance Assets:US:BofA:Checking         381.15 USD
+
+2025-11-09 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2025-11-20 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -77.97 USD
+  Expenses:Home:Phone                               77.97 USD
+
+2025-11-21 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -80.22 USD
+  Expenses:Home:Internet                            80.22 USD
+
+2025-11-30 balance Assets:US:BofA:Checking        2708.56 USD
+
+2025-12-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2025-12-06 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2025-12-08 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2025-12-19 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -50.31 USD
+  Expenses:Home:Phone                               50.31 USD
+
+2025-12-23 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -79.98 USD
+  Expenses:Home:Internet                            79.98 USD
+
+2025-12-29 balance Assets:US:BofA:Checking        4787.64 USD
+
+2026-01-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2026-01-05 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2026-01-08 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2026-01-19 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -53.59 USD
+  Expenses:Home:Phone                               53.59 USD
+
+2026-01-21 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -79.88 USD
+  Expenses:Home:Internet                            79.88 USD
+
+2026-01-27 balance Assets:US:BofA:Checking        4365.71 USD
+
+2026-02-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2026-02-06 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2026-02-09 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2026-02-17 balance Assets:US:BofA:Checking        3923.44 USD
+
+2026-02-20 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -62.70 USD
+  Expenses:Home:Phone                               62.70 USD
+
+2026-02-22 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -79.88 USD
+  Expenses:Home:Internet                            79.88 USD
+
+2026-03-03 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2026-03-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2026-03-08 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2026-03-11 balance Assets:US:BofA:Checking        2662.46 USD
+
+2026-03-19 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -58.74 USD
+  Expenses:Home:Phone                               58.74 USD
+
+2026-03-21 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -80.03 USD
+  Expenses:Home:Internet                            80.03 USD
+
+2026-04-03 balance Assets:US:BofA:Checking        3710.52 USD
+
+2026-04-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+2026-04-04 * "RiverBank Properties" "Paying the rent"
+  Assets:US:BofA:Checking                        -2400.00 USD
+  Expenses:Home:Rent                              2400.00 USD
+
+2026-04-08 * "EDISON POWER" ""
+  Assets:US:BofA:Checking                          -65.00 USD
+  Expenses:Home:Electricity                         65.00 USD
+
+2026-04-19 * "Verizon Wireless" ""
+  Assets:US:BofA:Checking                          -71.87 USD
+  Expenses:Home:Phone                               71.87 USD
+
+2026-04-23 * "Wine-Tarner Cable" ""
+  Assets:US:BofA:Checking                          -79.97 USD
+  Expenses:Home:Internet                            79.97 USD
+
+2026-04-24 * "Transfering accumulated savings to other account"
+  Assets:US:BofA:Checking                           -3500 USD
+  Assets:US:ETrade:Cash                              3500 USD
+
+2026-04-27 balance Assets:US:BofA:Checking         290.88 USD
+
+2026-05-04 * "BANK FEES" "Monthly bank fee"
+  Assets:US:BofA:Checking                           -4.00 USD
+  Expenses:Financial:Fees                            4.00 USD
+
+
+
+* Credit-Cards
+
+1980-05-12 open Liabilities:US:Chase:Slate                      USD
+
+2024-01-06 * "Kin Soy" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -40.47 USD
+  Expenses:Food:Restaurant                          40.47 USD
+
+2024-01-08 * "Kin Soy" "Eating out "
+  Liabilities:US:Chase:Slate                       -38.52 USD
+  Expenses:Food:Restaurant                          38.52 USD
+
+2024-01-10 * "Farmer Fresh" "Buying groceries"
+  Liabilities:US:Chase:Slate                      -126.64 USD
+  Expenses:Food:Groceries                          126.64 USD
+
+2024-01-11 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       231.18 USD
+  Assets:US:BofA:Checking                         -231.18 USD
+
+2024-01-13 * "Jewel of Morroco" "Eating out "
+  Liabilities:US:Chase:Slate                       -25.55 USD
+  Expenses:Food:Restaurant                          25.55 USD
+
+2024-01-17 * "Cafe Modagor" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -17.88 USD
+  Expenses:Food:Restaurant                          17.88 USD
+
+2024-01-19 * "Cafe Modagor" "Eating out "
+  Liabilities:US:Chase:Slate                       -30.40 USD
+  Expenses:Food:Restaurant                          30.40 USD
+
+2024-01-21 * "China Garden" "Eating out "
+  Liabilities:US:Chase:Slate                       -56.37 USD
+  Expenses:Food:Restaurant                          56.37 USD
+
+2024-01-26 * "Goba Goba" "Eating out "
+  Liabilities:US:Chase:Slate                       -17.36 USD
+  Expenses:Food:Restaurant                          17.36 USD
+
+2024-01-28 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2024-01-30 * "Uncle Boons" "Eating out "
+  Liabilities:US:Chase:Slate                       -24.02 USD
+  Expenses:Food:Restaurant                          24.02 USD
+
+2024-01-30 * "Farmer Fresh" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -86.62 USD
+  Expenses:Food:Groceries                           86.62 USD
+
+2024-01-31 balance Liabilities:US:Chase:Slate     -352.65 USD
+
+2024-02-01 * "Kin Soy" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -25.31 USD
+  Expenses:Food:Restaurant                          25.31 USD
+
+2024-02-04 * "Goba Goba" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -22.84 USD
+  Expenses:Food:Restaurant                          22.84 USD
+
+2024-02-05 * "Onion Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -98.13 USD
+  Expenses:Food:Groceries                           98.13 USD
+
+2024-02-08 * "Jewel of Morroco" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -47.50 USD
+  Expenses:Food:Restaurant                          47.50 USD
+
+2024-02-11 * "Jewel of Morroco" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -31.56 USD
+  Expenses:Food:Restaurant                          31.56 USD
+
+2024-02-11 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       577.99 USD
+  Assets:US:BofA:Checking                         -577.99 USD
+
+2024-02-13 * "Good Moods Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                      -113.93 USD
+  Expenses:Food:Groceries                          113.93 USD
+
+2024-02-16 * "Rose Flower" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -55.99 USD
+  Expenses:Food:Restaurant                          55.99 USD
+
+2024-02-19 * "Kin Soy" "Eating out "
+  Liabilities:US:Chase:Slate                       -51.63 USD
+  Expenses:Food:Restaurant                          51.63 USD
+
+2024-02-19 * "Farmer Fresh" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -86.68 USD
+  Expenses:Food:Groceries                           86.68 USD
+
+2024-02-21 * "China Garden" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -22.07 USD
+  Expenses:Food:Restaurant                          22.07 USD
+
+2024-02-23 * "Cafe Modagor" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -60.03 USD
+  Expenses:Food:Restaurant                          60.03 USD
+
+2024-02-25 * "Jewel of Morroco" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -40.98 USD
+  Expenses:Food:Restaurant                          40.98 USD
+
+2024-02-27 * "Uncle Boons" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -28.61 USD
+  Expenses:Food:Restaurant                          28.61 USD
+
+2024-02-27 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2024-02-28 balance Liabilities:US:Chase:Slate     -579.92 USD
+
+2024-03-01 * "Rose Flower" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -46.57 USD
+  Expenses:Food:Restaurant                          46.57 USD
+
+2024-03-03 * "Rose Flower" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -48.36 USD
+  Expenses:Food:Restaurant                          48.36 USD
+
+2024-03-05 * "Kin Soy" "Eating out "
+  Liabilities:US:Chase:Slate                       -22.75 USD
+  Expenses:Food:Restaurant                          22.75 USD
+
+2024-03-05 * "Onion Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                      -115.59 USD
+  Expenses:Food:Groceries                          115.59 USD
+
+2024-03-08 * "Cafe Modagor" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -37.50 USD
+  Expenses:Food:Restaurant                          37.50 USD
+
+2024-03-11 * "Jewel of Morroco" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -20.00 USD
+  Expenses:Food:Restaurant                          20.00 USD
+
+2024-03-11 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       870.69 USD
+  Assets:US:BofA:Checking                         -870.69 USD
+
+2024-03-12 * "Cafe Modagor" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -43.79 USD
+  Expenses:Food:Restaurant                          43.79 USD
+
+2024-03-17 * "Jewel of Morroco" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -31.47 USD
+  Expenses:Food:Restaurant                          31.47 USD
+
+2024-03-18 * "Chichipotle" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -30.19 USD
+  Expenses:Food:Restaurant                          30.19 USD
+
+2024-03-18 * "Good Moods Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -48.80 USD
+  Expenses:Food:Groceries                           48.80 USD
+
+2024-03-20 balance Liabilities:US:Chase:Slate     -154.25 USD
+
+2024-03-22 * "Goba Goba" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -65.52 USD
+  Expenses:Food:Restaurant                          65.52 USD
+
+2024-03-25 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2024-03-27 * "Chichipotle" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -47.72 USD
+  Expenses:Food:Restaurant                          47.72 USD
+
+2024-04-01 * "Uncle Boons" "Eating out "
+  Liabilities:US:Chase:Slate                       -10.12 USD
+  Expenses:Food:Restaurant                          10.12 USD
+
+2024-04-03 * "China Garden" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -44.98 USD
+  Expenses:Food:Restaurant                          44.98 USD
+
+2024-04-06 * "Good Moods Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -71.99 USD
+  Expenses:Food:Groceries                           71.99 USD
+
+2024-04-07 * "China Garden" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -40.43 USD
+  Expenses:Food:Restaurant                          40.43 USD
+
+2024-04-10 * "Rose Flower" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -20.53 USD
+  Expenses:Food:Restaurant                          20.53 USD
+
+2024-04-11 * "Kin Soy" "Eating out "
+  Liabilities:US:Chase:Slate                       -22.16 USD
+  Expenses:Food:Restaurant                          22.16 USD
+
+2024-04-11 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       597.70 USD
+  Assets:US:BofA:Checking                         -597.70 USD
+
+2024-04-13 balance Liabilities:US:Chase:Slate           0 USD
+
+2024-04-15 * "Kin Soy" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -28.92 USD
+  Expenses:Food:Restaurant                          28.92 USD
+
+2024-04-17 * "China Garden" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -21.74 USD
+  Expenses:Food:Restaurant                          21.74 USD
+
+2024-04-22 * "Uncle Boons" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -20.19 USD
+  Expenses:Food:Restaurant                          20.19 USD
+
+2024-04-22 * "Farmer Fresh" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -93.78 USD
+  Expenses:Food:Groceries                           93.78 USD
+
+2024-04-24 * "Goba Goba" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -21.64 USD
+  Expenses:Food:Restaurant                          21.64 USD
+
+2024-04-24 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2024-04-26 * "Uncle Boons" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -37.74 USD
+  Expenses:Food:Restaurant                          37.74 USD
+
+2024-04-28 * "Rose Flower" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -24.03 USD
+  Expenses:Food:Restaurant                          24.03 USD
+
+2024-05-01 * "Rose Flower" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -44.22 USD
+  Expenses:Food:Restaurant                          44.22 USD
+
+2024-05-03 balance Liabilities:US:Chase:Slate     -412.26 USD
+
+2024-05-03 * "Farmer Fresh" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -81.18 USD
+  Expenses:Food:Groceries                           81.18 USD
+
+2024-05-05 * "Uncle Boons" "Eating out "
+  Liabilities:US:Chase:Slate                       -29.33 USD
+  Expenses:Food:Restaurant                          29.33 USD
+
+2024-05-06 * "Rose Flower" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -43.60 USD
+  Expenses:Food:Restaurant                          43.60 USD
+
+2024-05-08 * "Jewel of Morroco" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -20.44 USD
+  Expenses:Food:Restaurant                          20.44 USD
+
+2024-05-08 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       586.81 USD
+  Assets:US:BofA:Checking                         -586.81 USD
+
+2024-05-13 * "Jewel of Morroco" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -12.08 USD
+  Expenses:Food:Restaurant                          12.08 USD
+
+2024-05-18 * "Kin Soy" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -37.22 USD
+  Expenses:Food:Restaurant                          37.22 USD
+
+2024-05-21 * "Cafe Modagor" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -34.25 USD
+  Expenses:Food:Restaurant                          34.25 USD
+
+2024-05-22 * "Uncle Boons" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -24.44 USD
+  Expenses:Food:Restaurant                          24.44 USD
+
+2024-05-22 * "Onion Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -71.20 USD
+  Expenses:Food:Groceries                           71.20 USD
+
+2024-05-24 * "Cafe Modagor" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -24.43 USD
+  Expenses:Food:Restaurant                          24.43 USD
+
+2024-05-25 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2024-05-27 * "Jewel of Morroco" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -51.17 USD
+  Expenses:Food:Restaurant                          51.17 USD
+
+2024-05-27 * "Good Moods Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                      -125.02 USD
+  Expenses:Food:Groceries                          125.02 USD
+
+2024-05-29 balance Liabilities:US:Chase:Slate     -499.81 USD
+
+2024-06-01 * "Goba Goba" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -23.96 USD
+  Expenses:Food:Restaurant                          23.96 USD
+
+2024-06-02 * "Uncle Boons" "Eating out "
+  Liabilities:US:Chase:Slate                       -21.45 USD
+  Expenses:Food:Restaurant                          21.45 USD
+
+2024-06-03 * "Uncle Boons" "Eating out "
+  Liabilities:US:Chase:Slate                       -29.08 USD
+  Expenses:Food:Restaurant                          29.08 USD
+
+2024-06-07 * "Rose Flower" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -27.98 USD
+  Expenses:Food:Restaurant                          27.98 USD
+
+2024-06-07 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       602.28 USD
+  Assets:US:BofA:Checking                         -602.28 USD
+
+2024-06-08 * "Farmer Fresh" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -81.30 USD
+  Expenses:Food:Groceries                           81.30 USD
+
+2024-06-09 * "Rose Flower" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -86.84 USD
+  Expenses:Food:Restaurant                          86.84 USD
+
+2024-06-13 * "Goba Goba" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -30.72 USD
+  Expenses:Food:Restaurant                          30.72 USD
+
+2024-06-17 * "China Garden" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -55.52 USD
+  Expenses:Food:Restaurant                          55.52 USD
+
+2024-06-18 * "Uncle Boons" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -43.49 USD
+  Expenses:Food:Restaurant                          43.49 USD
+
+2024-06-23 * "Rose Flower" "Eating out "
+  Liabilities:US:Chase:Slate                       -24.69 USD
+  Expenses:Food:Restaurant                          24.69 USD
+
+2024-06-25 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2024-06-27 balance Liabilities:US:Chase:Slate     -442.56 USD
+
+2024-06-27 * "Chichipotle" "Eating out "
+  Liabilities:US:Chase:Slate                       -15.76 USD
+  Expenses:Food:Restaurant                          15.76 USD
+
+2024-06-27 * "Good Moods Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -65.31 USD
+  Expenses:Food:Groceries                           65.31 USD
+
+2024-06-28 * "Chichipotle" "Eating out "
+  Liabilities:US:Chase:Slate                       -18.99 USD
+  Expenses:Food:Restaurant                          18.99 USD
+
+2024-06-29 * "Rose Flower" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -61.47 USD
+  Expenses:Food:Restaurant                          61.47 USD
+
+2024-06-30 * "Uncle Boons" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -33.87 USD
+  Expenses:Food:Restaurant                          33.87 USD
+
+2024-07-04 * "Goba Goba" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -31.79 USD
+  Expenses:Food:Restaurant                          31.79 USD
+
+2024-07-07 * "Rose Flower" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -17.75 USD
+  Expenses:Food:Restaurant                          17.75 USD
+
+2024-07-10 * "Goba Goba" "Eating out "
+  Liabilities:US:Chase:Slate                       -52.46 USD
+  Expenses:Food:Restaurant                          52.46 USD
+
+2024-07-10 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       739.96 USD
+  Assets:US:BofA:Checking                         -739.96 USD
+
+2024-07-15 * "Jewel of Morroco" "Eating out "
+  Liabilities:US:Chase:Slate                       -29.51 USD
+  Expenses:Food:Restaurant                          29.51 USD
+
+2024-07-15 * "Farmer Fresh" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -66.89 USD
+  Expenses:Food:Groceries                           66.89 USD
+
+2024-07-18 * "Rose Flower" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -22.35 USD
+  Expenses:Food:Restaurant                          22.35 USD
+
+2024-07-20 balance Liabilities:US:Chase:Slate     -118.75 USD
+
+2024-07-22 * "Goba Goba" "Eating out "
+  Liabilities:US:Chase:Slate                       -63.95 USD
+  Expenses:Food:Restaurant                          63.95 USD
+
+2024-07-22 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2024-07-23 * "Cafe Modagor" "Eating out "
+  Liabilities:US:Chase:Slate                       -26.35 USD
+  Expenses:Food:Restaurant                          26.35 USD
+
+2024-07-24 * "Goba Goba" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -39.00 USD
+  Expenses:Food:Restaurant                          39.00 USD
+
+2024-07-28 * "Jewel of Morroco" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -39.16 USD
+  Expenses:Food:Restaurant                          39.16 USD
+
+2024-07-31 * "Rose Flower" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -26.55 USD
+  Expenses:Food:Restaurant                          26.55 USD
+
+2024-08-02 * "Cafe Modagor" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -95.11 USD
+  Expenses:Food:Restaurant                          95.11 USD
+
+2024-08-02 * "Corner Deli" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -67.53 USD
+  Expenses:Food:Groceries                           67.53 USD
+
+2024-08-03 * "Chichipotle" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -55.30 USD
+  Expenses:Food:Restaurant                          55.30 USD
+
+2024-08-06 * "Jewel of Morroco" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -40.15 USD
+  Expenses:Food:Restaurant                          40.15 USD
+
+2024-08-08 * "Goba Goba" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -31.54 USD
+  Expenses:Food:Restaurant                          31.54 USD
+
+2024-08-08 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       723.39 USD
+  Assets:US:BofA:Checking                         -723.39 USD
+
+2024-08-09 * "Chichipotle" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -33.94 USD
+  Expenses:Food:Restaurant                          33.94 USD
+
+2024-08-09 * "Good Moods Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -95.17 USD
+  Expenses:Food:Groceries                           95.17 USD
+
+2024-08-11 * "Rose Flower" "Eating out "
+  Liabilities:US:Chase:Slate                       -28.93 USD
+  Expenses:Food:Restaurant                          28.93 USD
+
+2024-08-14 * "China Garden" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -34.74 USD
+  Expenses:Food:Restaurant                          34.74 USD
+
+2024-08-16 balance Liabilities:US:Chase:Slate     -192.78 USD
+
+2024-08-18 * "Kin Soy" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -38.28 USD
+  Expenses:Food:Restaurant                          38.28 USD
+
+2024-08-20 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2024-08-22 * "Uncle Boons" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -19.28 USD
+  Expenses:Food:Restaurant                          19.28 USD
+
+2024-08-23 * "Chichipotle" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -20.90 USD
+  Expenses:Food:Restaurant                          20.90 USD
+
+2024-08-25 * "Kin Soy" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -33.66 USD
+  Expenses:Food:Restaurant                          33.66 USD
+
+2024-08-25 * "Farmer Fresh" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -69.24 USD
+  Expenses:Food:Groceries                           69.24 USD
+
+2024-08-27 * "Rose Flower" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -75.54 USD
+  Expenses:Food:Restaurant                          75.54 USD
+
+2024-08-31 * "Cafe Modagor" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -18.00 USD
+  Expenses:Food:Restaurant                          18.00 USD
+
+2024-09-03 * "China Garden" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -36.97 USD
+  Expenses:Food:Restaurant                          36.97 USD
+
+2024-09-05 * "Uncle Boons" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -11.44 USD
+  Expenses:Food:Restaurant                          11.44 USD
+
+2024-09-06 * "Jewel of Morroco" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -29.29 USD
+  Expenses:Food:Restaurant                          29.29 USD
+
+2024-09-07 * "Jewel of Morroco" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -31.43 USD
+  Expenses:Food:Restaurant                          31.43 USD
+
+2024-09-08 * "China Garden" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -37.76 USD
+  Expenses:Food:Restaurant                          37.76 USD
+
+2024-09-08 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       734.57 USD
+  Assets:US:BofA:Checking                         -734.57 USD
+
+2024-09-09 * "Jewel of Morroco" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -35.77 USD
+  Expenses:Food:Restaurant                          35.77 USD
+
+2024-09-09 * "Onion Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -89.51 USD
+  Expenses:Food:Groceries                           89.51 USD
+
+2024-09-10 balance Liabilities:US:Chase:Slate     -125.28 USD
+
+2024-09-11 * "Chichipotle" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -20.13 USD
+  Expenses:Food:Restaurant                          20.13 USD
+
+2024-09-16 * "Jewel of Morroco" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -24.12 USD
+  Expenses:Food:Restaurant                          24.12 USD
+
+2024-09-20 * "Rose Flower" "Eating out after work"
+  Liabilities:US:Chase:Slate                      -112.30 USD
+  Expenses:Food:Restaurant                         112.30 USD
+
+2024-09-21 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2024-09-22 * "Cafe Modagor" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -13.53 USD
+  Expenses:Food:Restaurant                          13.53 USD
+
+2024-09-25 * "Corner Deli" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -70.75 USD
+  Expenses:Food:Groceries                           70.75 USD
+
+2024-09-27 * "Jewel of Morroco" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -65.88 USD
+  Expenses:Food:Restaurant                          65.88 USD
+
+2024-09-29 * "Rose Flower" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -38.45 USD
+  Expenses:Food:Restaurant                          38.45 USD
+
+2024-10-01 balance Liabilities:US:Chase:Slate     -590.44 USD
+
+2024-10-02 * "Kin Soy" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -24.46 USD
+  Expenses:Food:Restaurant                          24.46 USD
+
+2024-10-02 * "Corner Deli" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -89.55 USD
+  Expenses:Food:Groceries                           89.55 USD
+
+2024-10-07 * "China Garden" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -23.14 USD
+  Expenses:Food:Restaurant                          23.14 USD
+
+2024-10-08 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       777.82 USD
+  Assets:US:BofA:Checking                         -777.82 USD
+
+2024-10-10 * "Farmer Fresh" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -50.23 USD
+  Expenses:Food:Groceries                           50.23 USD
+
+2024-10-12 * "Goba Goba" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -22.58 USD
+  Expenses:Food:Restaurant                          22.58 USD
+
+2024-10-13 * "China Garden" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -20.13 USD
+  Expenses:Food:Restaurant                          20.13 USD
+
+2024-10-15 * "Cafe Modagor" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -24.89 USD
+  Expenses:Food:Restaurant                          24.89 USD
+
+2024-10-19 * "Cafe Modagor" "Eating out "
+  Liabilities:US:Chase:Slate                       -28.35 USD
+  Expenses:Food:Restaurant                          28.35 USD
+
+2024-10-23 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2024-10-24 * "Uncle Boons" "Eating out "
+  Liabilities:US:Chase:Slate                       -18.14 USD
+  Expenses:Food:Restaurant                          18.14 USD
+
+2024-10-25 * "Jewel of Morroco" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -16.69 USD
+  Expenses:Food:Restaurant                          16.69 USD
+
+2024-10-26 balance Liabilities:US:Chase:Slate     -250.78 USD
+
+2024-10-28 * "Good Moods Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -88.60 USD
+  Expenses:Food:Groceries                           88.60 USD
+
+2024-10-29 * "China Garden" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -39.12 USD
+  Expenses:Food:Restaurant                          39.12 USD
+
+2024-10-30 * "China Garden" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -15.02 USD
+  Expenses:Food:Restaurant                          15.02 USD
+
+2024-11-04 * "Jewel of Morroco" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -31.19 USD
+  Expenses:Food:Restaurant                          31.19 USD
+
+2024-11-05 * "Kin Soy" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -60.59 USD
+  Expenses:Food:Restaurant                          60.59 USD
+
+2024-11-08 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       532.85 USD
+  Assets:US:BofA:Checking                         -532.85 USD
+
+2024-11-09 * "Jewel of Morroco" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -47.55 USD
+  Expenses:Food:Restaurant                          47.55 USD
+
+2024-11-10 * "China Garden" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -24.82 USD
+  Expenses:Food:Restaurant                          24.82 USD
+
+2024-11-14 * "Rose Flower" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -72.50 USD
+  Expenses:Food:Restaurant                          72.50 USD
+
+2024-11-15 balance Liabilities:US:Chase:Slate      -97.32 USD
+
+2024-11-15 * "Rose Flower" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -18.36 USD
+  Expenses:Food:Restaurant                          18.36 USD
+
+2024-11-17 * "Good Moods Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -97.61 USD
+  Expenses:Food:Groceries                           97.61 USD
+
+2024-11-20 * "Kin Soy" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -25.94 USD
+  Expenses:Food:Restaurant                          25.94 USD
+
+2024-11-24 * "China Garden" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -24.19 USD
+  Expenses:Food:Restaurant                          24.19 USD
+
+2024-11-24 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2024-11-27 * "Rose Flower" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -39.20 USD
+  Expenses:Food:Restaurant                          39.20 USD
+
+2024-11-27 * "Farmer Fresh" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -79.57 USD
+  Expenses:Food:Groceries                           79.57 USD
+
+2024-11-28 * "China Garden" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -14.20 USD
+  Expenses:Food:Restaurant                          14.20 USD
+
+2024-11-29 * "Cafe Modagor" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -23.16 USD
+  Expenses:Food:Restaurant                          23.16 USD
+
+2024-11-30 * "Jewel of Morroco" "Eating out "
+  Liabilities:US:Chase:Slate                       -16.39 USD
+  Expenses:Food:Restaurant                          16.39 USD
+
+2024-12-03 * "Cafe Modagor" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -21.22 USD
+  Expenses:Food:Restaurant                          21.22 USD
+
+2024-12-03 * "Farmer Fresh" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -79.31 USD
+  Expenses:Food:Groceries                           79.31 USD
+
+2024-12-05 * "Uncle Boons" "Eating out "
+  Liabilities:US:Chase:Slate                       -16.08 USD
+  Expenses:Food:Restaurant                          16.08 USD
+
+2024-12-08 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       702.02 USD
+  Assets:US:BofA:Checking                         -702.02 USD
+
+2024-12-09 * "Kin Soy" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -29.47 USD
+  Expenses:Food:Restaurant                          29.47 USD
+
+2024-12-12 * "Chichipotle" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -28.03 USD
+  Expenses:Food:Restaurant                          28.03 USD
+
+2024-12-13 * "Rose Flower" "Eating out "
+  Liabilities:US:Chase:Slate                       -38.85 USD
+  Expenses:Food:Restaurant                          38.85 USD
+
+2024-12-14 balance Liabilities:US:Chase:Slate      -66.88 USD
+
+2024-12-17 * "China Garden" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -20.85 USD
+  Expenses:Food:Restaurant                          20.85 USD
+
+2024-12-21 * "Jewel of Morroco" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -54.32 USD
+  Expenses:Food:Restaurant                          54.32 USD
+
+2024-12-21 * "Farmer Fresh" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -92.23 USD
+  Expenses:Food:Groceries                           92.23 USD
+
+2024-12-24 * "Chichipotle" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -16.24 USD
+  Expenses:Food:Restaurant                          16.24 USD
+
+2024-12-25 * "Jewel of Morroco" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -28.56 USD
+  Expenses:Food:Restaurant                          28.56 USD
+
+2024-12-26 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2024-12-29 * "Cafe Modagor" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -12.48 USD
+  Expenses:Food:Restaurant                          12.48 USD
+
+2024-12-31 * "Good Moods Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -94.44 USD
+  Expenses:Food:Groceries                           94.44 USD
+
+2025-01-01 * "Goba Goba" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -33.78 USD
+  Expenses:Food:Restaurant                          33.78 USD
+
+2025-01-03 * "Cafe Modagor" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -22.95 USD
+  Expenses:Food:Restaurant                          22.95 USD
+
+2025-01-07 * "Chichipotle" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -28.32 USD
+  Expenses:Food:Restaurant                          28.32 USD
+
+2025-01-07 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       591.05 USD
+  Assets:US:BofA:Checking                         -591.05 USD
+
+2025-01-10 * "Rose Flower" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -28.32 USD
+  Expenses:Food:Restaurant                          28.32 USD
+
+2025-01-13 balance Liabilities:US:Chase:Slate      -28.32 USD
+
+2025-01-14 * "Farmer Fresh" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -60.75 USD
+  Expenses:Food:Groceries                           60.75 USD
+
+2025-01-15 * "Rose Flower" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -17.30 USD
+  Expenses:Food:Restaurant                          17.30 USD
+
+2025-01-18 * "Jewel of Morroco" "Eating out "
+  Liabilities:US:Chase:Slate                       -57.00 USD
+  Expenses:Food:Restaurant                          57.00 USD
+
+2025-01-22 * "Corner Deli" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -83.66 USD
+  Expenses:Food:Groceries                           83.66 USD
+
+2025-01-23 * "Chichipotle" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -35.97 USD
+  Expenses:Food:Restaurant                          35.97 USD
+
+2025-01-23 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2025-01-26 * "Chichipotle" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -34.73 USD
+  Expenses:Food:Restaurant                          34.73 USD
+
+2025-01-28 * "Farmer Fresh" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -98.64 USD
+  Expenses:Food:Groceries                           98.64 USD
+
+2025-01-29 * "Chichipotle" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -33.35 USD
+  Expenses:Food:Restaurant                          33.35 USD
+
+2025-02-01 * "China Garden" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -26.52 USD
+  Expenses:Food:Restaurant                          26.52 USD
+
+2025-02-04 * "Goba Goba" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -35.68 USD
+  Expenses:Food:Restaurant                          35.68 USD
+
+2025-02-05 balance Liabilities:US:Chase:Slate     -631.92 USD
+
+2025-02-05 * "Uncle Boons" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -32.08 USD
+  Expenses:Food:Restaurant                          32.08 USD
+
+2025-02-05 * "Corner Deli" "Buying groceries"
+  Liabilities:US:Chase:Slate                      -108.71 USD
+  Expenses:Food:Groceries                          108.71 USD
+
+2025-02-07 * "Jewel of Morroco" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -87.14 USD
+  Expenses:Food:Restaurant                          87.14 USD
+
+2025-02-09 * "Cafe Modagor" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -59.92 USD
+  Expenses:Food:Restaurant                          59.92 USD
+
+2025-02-10 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       997.04 USD
+  Assets:US:BofA:Checking                         -997.04 USD
+
+2025-02-11 * "Farmer Fresh" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -77.27 USD
+  Expenses:Food:Groceries                           77.27 USD
+
+2025-02-13 event "location" "Los Angeles"
+
+2025-02-14 * "Mr. Marcel" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -39.89 USD
+  Expenses:Food:Restaurant                          39.89 USD
+
+2025-02-14 * "Banana Leaf" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -27.47 USD
+  Expenses:Food:Restaurant                          27.47 USD
+
+2025-02-14 * "Dupar's" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -31.35 USD
+  Expenses:Food:Restaurant                          31.35 USD
+
+2025-02-14 * "Chipotle" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -13.96 USD
+  Expenses:Food:Restaurant                          13.96 USD
+
+2025-02-14 * "E.B.'s Beer and Wine" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -12.03 USD
+  Expenses:Food:Alcohol                             12.03 USD
+
+2025-02-15 * "Banana Leaf" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -19.08 USD
+  Expenses:Food:Restaurant                          19.08 USD
+
+2025-02-15 * "Pampas Grill" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -26.05 USD
+  Expenses:Food:Restaurant                          26.05 USD
+
+2025-02-15 * "Chipotle" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -16.05 USD
+  Expenses:Food:Restaurant                          16.05 USD
+
+2025-02-16 * "Pampas Grill" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -24.61 USD
+  Expenses:Food:Restaurant                          24.61 USD
+
+2025-02-16 * "Chipotle" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -19.12 USD
+  Expenses:Food:Restaurant                          19.12 USD
+
+2025-02-16 * "Starbucks" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                        -6.59 USD
+  Expenses:Food:Coffee                               6.59 USD
+
+2025-02-17 * "Mr. Marcel" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -41.63 USD
+  Expenses:Food:Restaurant                          41.63 USD
+
+2025-02-17 * "Dupar's" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -25.30 USD
+  Expenses:Food:Restaurant                          25.30 USD
+
+2025-02-17 * "E.B.'s Beer and Wine" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -11.38 USD
+  Expenses:Food:Alcohol                             11.38 USD
+
+2025-02-18 * "Dupar's" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -28.42 USD
+  Expenses:Food:Restaurant                          28.42 USD
+
+2025-02-18 * "Pampas Grill" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -28.37 USD
+  Expenses:Food:Restaurant                          28.37 USD
+
+2025-02-19 * "Starbucks" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                        -6.21 USD
+  Expenses:Food:Coffee                               6.21 USD
+
+2025-02-19 * "E.B.'s Beer and Wine" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                        -7.18 USD
+  Expenses:Food:Alcohol                              7.18 USD
+
+2025-02-20 * "Dupar's" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -32.08 USD
+  Expenses:Food:Restaurant                          32.08 USD
+
+2025-02-20 * "Pampas Grill" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -24.58 USD
+  Expenses:Food:Restaurant                          24.58 USD
+
+2025-02-20 * "Chipotle" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -14.24 USD
+  Expenses:Food:Restaurant                          14.24 USD
+
+2025-02-21 * "Banana Leaf" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -27.53 USD
+  Expenses:Food:Restaurant                          27.53 USD
+
+2025-02-21 * "Chipotle" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -17.20 USD
+  Expenses:Food:Restaurant                          17.20 USD
+
+2025-02-22 * "Banana Leaf" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -18.61 USD
+  Expenses:Food:Restaurant                          18.61 USD
+
+2025-02-22 * "Dupar's" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -30.85 USD
+  Expenses:Food:Restaurant                          30.85 USD
+
+2025-02-22 * "Pampas Grill" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -27.07 USD
+  Expenses:Food:Restaurant                          27.07 USD
+
+2025-02-22 * "Chipotle" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -15.09 USD
+  Expenses:Food:Restaurant                          15.09 USD
+
+2025-02-22 * "E.B.'s Beer and Wine" "" #trip-los-angeles-2025
+  Liabilities:US:Chase:Slate                       -11.98 USD
+  Expenses:Food:Alcohol                             11.98 USD
+
+2025-02-22 * "Consume vacation days"
+  Assets:US:Hooli:Vacation                            -72 VACHR
+  Expenses:Vacation                                    72 VACHR
+
+2025-02-22 event "location" "New Metropolis"
+
+2025-02-23 * "Goba Goba" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -19.87 USD
+  Expenses:Food:Restaurant                          19.87 USD
+
+2025-02-27 * "Chichipotle" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -18.21 USD
+  Expenses:Food:Restaurant                          18.21 USD
+
+2025-03-03 * "Kin Soy" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -23.52 USD
+  Expenses:Food:Restaurant                          23.52 USD
+
+2025-03-06 balance Liabilities:US:Chase:Slate     -665.52 USD
+
+2025-03-07 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       117.70 USD
+  Assets:US:BofA:Checking                         -117.70 USD
+
+2025-03-08 * "Jewel of Morroco" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -56.10 USD
+  Expenses:Food:Restaurant                          56.10 USD
+
+2025-03-09 * "Good Moods Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -67.18 USD
+  Expenses:Food:Groceries                           67.18 USD
+
+2025-03-10 * "Chichipotle" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -21.45 USD
+  Expenses:Food:Restaurant                          21.45 USD
+
+2025-03-15 * "Goba Goba" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -30.38 USD
+  Expenses:Food:Restaurant                          30.38 USD
+
+2025-03-15 * "Good Moods Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -85.58 USD
+  Expenses:Food:Groceries                           85.58 USD
+
+2025-03-18 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2025-03-19 * "Chichipotle" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -13.32 USD
+  Expenses:Food:Restaurant                          13.32 USD
+
+2025-03-20 * "Kin Soy" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -27.20 USD
+  Expenses:Food:Restaurant                          27.20 USD
+
+2025-03-21 * "China Garden" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -27.43 USD
+  Expenses:Food:Restaurant                          27.43 USD
+
+2025-03-23 * "Chichipotle" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -26.78 USD
+  Expenses:Food:Restaurant                          26.78 USD
+
+2025-03-24 * "Kin Soy" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -34.21 USD
+  Expenses:Food:Restaurant                          34.21 USD
+
+2025-03-25 * "Chichipotle" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -17.44 USD
+  Expenses:Food:Restaurant                          17.44 USD
+
+2025-03-26 * "Rose Flower" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -47.91 USD
+  Expenses:Food:Restaurant                          47.91 USD
+
+2025-03-28 * "Cafe Modagor" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -23.64 USD
+  Expenses:Food:Restaurant                          23.64 USD
+
+2025-03-29 * "Rose Flower" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -59.92 USD
+  Expenses:Food:Restaurant                          59.92 USD
+
+2025-03-30 * "Corner Deli" "Buying groceries"
+  Liabilities:US:Chase:Slate                      -108.51 USD
+  Expenses:Food:Groceries                          108.51 USD
+
+2025-04-02 * "Uncle Boons" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -17.87 USD
+  Expenses:Food:Restaurant                          17.87 USD
+
+2025-04-03 balance Liabilities:US:Chase:Slate    -1332.74 USD
+
+2025-04-05 * "Cafe Modagor" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -40.75 USD
+  Expenses:Food:Restaurant                          40.75 USD
+
+2025-04-07 * "Goba Goba" "Eating out "
+  Liabilities:US:Chase:Slate                       -14.93 USD
+  Expenses:Food:Restaurant                          14.93 USD
+
+2025-04-07 * "Good Moods Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -76.69 USD
+  Expenses:Food:Groceries                           76.69 USD
+
+2025-04-10 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       909.97 USD
+  Assets:US:BofA:Checking                         -909.97 USD
+
+2025-04-11 * "Chichipotle" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -48.78 USD
+  Expenses:Food:Restaurant                          48.78 USD
+
+2025-04-14 * "China Garden" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -11.11 USD
+  Expenses:Food:Restaurant                          11.11 USD
+
+2025-04-16 * "Farmer Fresh" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -54.14 USD
+  Expenses:Food:Groceries                           54.14 USD
+
+2025-04-19 * "Uncle Boons" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -20.44 USD
+  Expenses:Food:Restaurant                          20.44 USD
+
+2025-04-19 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2025-04-21 * "China Garden" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -10.20 USD
+  Expenses:Food:Restaurant                          10.20 USD
+
+2025-04-22 * "Chichipotle" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -43.42 USD
+  Expenses:Food:Restaurant                          43.42 USD
+
+2025-04-25 * "China Garden" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -57.70 USD
+  Expenses:Food:Restaurant                          57.70 USD
+
+2025-04-26 balance Liabilities:US:Chase:Slate     -920.93 USD
+
+2025-04-26 * "Goba Goba" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -35.61 USD
+  Expenses:Food:Restaurant                          35.61 USD
+
+2025-04-29 * "Uncle Boons" "Eating out "
+  Liabilities:US:Chase:Slate                       -19.88 USD
+  Expenses:Food:Restaurant                          19.88 USD
+
+2025-05-04 * "China Garden" "Eating out "
+  Liabilities:US:Chase:Slate                       -35.98 USD
+  Expenses:Food:Restaurant                          35.98 USD
+
+2025-05-05 * "Rose Flower" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -34.56 USD
+  Expenses:Food:Restaurant                          34.56 USD
+
+2025-05-06 * "Farmer Fresh" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -51.62 USD
+  Expenses:Food:Groceries                           51.62 USD
+
+2025-05-08 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       513.26 USD
+  Assets:US:BofA:Checking                         -513.26 USD
+
+2025-05-09 * "Rose Flower" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -18.60 USD
+  Expenses:Food:Restaurant                          18.60 USD
+
+2025-05-14 * "Cafe Modagor" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -37.40 USD
+  Expenses:Food:Restaurant                          37.40 USD
+
+2025-05-17 * "Cafe Modagor" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -28.38 USD
+  Expenses:Food:Restaurant                          28.38 USD
+
+2025-05-17 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2025-05-20 balance Liabilities:US:Chase:Slate     -789.70 USD
+
+2025-05-22 * "Kin Soy" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -26.21 USD
+  Expenses:Food:Restaurant                          26.21 USD
+
+2025-05-23 * "Cafe Modagor" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -41.61 USD
+  Expenses:Food:Restaurant                          41.61 USD
+
+2025-05-23 * "Onion Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -75.42 USD
+  Expenses:Food:Groceries                           75.42 USD
+
+2025-05-26 * "Uncle Boons" "Eating out "
+  Liabilities:US:Chase:Slate                       -35.94 USD
+  Expenses:Food:Restaurant                          35.94 USD
+
+2025-05-28 * "Cafe Modagor" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -21.58 USD
+  Expenses:Food:Restaurant                          21.58 USD
+
+2025-05-31 * "Uncle Boons" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -41.48 USD
+  Expenses:Food:Restaurant                          41.48 USD
+
+2025-06-02 * "Kin Soy" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -45.47 USD
+  Expenses:Food:Restaurant                          45.47 USD
+
+2025-06-04 * "Goba Goba" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -31.84 USD
+  Expenses:Food:Restaurant                          31.84 USD
+
+2025-06-05 * "Cafe Modagor" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -41.35 USD
+  Expenses:Food:Restaurant                          41.35 USD
+
+2025-06-08 * "China Garden" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -35.92 USD
+  Expenses:Food:Restaurant                          35.92 USD
+
+2025-06-08 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       582.60 USD
+  Assets:US:BofA:Checking                         -582.60 USD
+
+2025-06-09 * "Farmer Fresh" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -80.78 USD
+  Expenses:Food:Groceries                           80.78 USD
+
+2025-06-12 balance Liabilities:US:Chase:Slate     -684.70 USD
+
+2025-06-13 * "Jewel of Morroco" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -33.79 USD
+  Expenses:Food:Restaurant                          33.79 USD
+
+2025-06-14 * "China Garden" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -30.55 USD
+  Expenses:Food:Restaurant                          30.55 USD
+
+2025-06-17 * "Cafe Modagor" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -57.29 USD
+  Expenses:Food:Restaurant                          57.29 USD
+
+2025-06-18 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2025-06-19 * "Uncle Boons" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -36.98 USD
+  Expenses:Food:Restaurant                          36.98 USD
+
+2025-06-24 * "Goba Goba" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -38.15 USD
+  Expenses:Food:Restaurant                          38.15 USD
+
+2025-06-29 * "Rose Flower" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -44.25 USD
+  Expenses:Food:Restaurant                          44.25 USD
+
+2025-06-29 * "Farmer Fresh" "Buying groceries"
+  Liabilities:US:Chase:Slate                      -126.93 USD
+  Expenses:Food:Groceries                          126.93 USD
+
+2025-06-30 * "Jewel of Morroco" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -34.96 USD
+  Expenses:Food:Restaurant                          34.96 USD
+
+2025-07-02 balance Liabilities:US:Chase:Slate    -1207.60 USD
+
+2025-07-04 * "Uncle Boons" "Eating out "
+  Liabilities:US:Chase:Slate                       -54.41 USD
+  Expenses:Food:Restaurant                          54.41 USD
+
+2025-07-06 * "Chichipotle" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -58.79 USD
+  Expenses:Food:Restaurant                          58.79 USD
+
+2025-07-07 * "Kin Soy" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -19.97 USD
+  Expenses:Food:Restaurant                          19.97 USD
+
+2025-07-11 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       761.94 USD
+  Assets:US:BofA:Checking                         -761.94 USD
+
+2025-07-12 * "Cafe Modagor" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -25.09 USD
+  Expenses:Food:Restaurant                          25.09 USD
+
+2025-07-14 * "Goba Goba" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -29.06 USD
+  Expenses:Food:Restaurant                          29.06 USD
+
+2025-07-15 * "Jewel of Morroco" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -23.67 USD
+  Expenses:Food:Restaurant                          23.67 USD
+
+2025-07-15 * "Corner Deli" "Buying groceries"
+  Liabilities:US:Chase:Slate                      -106.85 USD
+  Expenses:Food:Groceries                          106.85 USD
+
+2025-07-15 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2025-07-17 * "Chichipotle" "Eating out "
+  Liabilities:US:Chase:Slate                       -36.27 USD
+  Expenses:Food:Restaurant                          36.27 USD
+
+2025-07-21 * "Jewel of Morroco" "Eating out "
+  Liabilities:US:Chase:Slate                       -50.69 USD
+  Expenses:Food:Restaurant                          50.69 USD
+
+2025-07-23 balance Liabilities:US:Chase:Slate     -970.46 USD
+
+2025-07-23 * "Uncle Boons" "Eating out "
+  Liabilities:US:Chase:Slate                       -22.09 USD
+  Expenses:Food:Restaurant                          22.09 USD
+
+2025-07-28 * "Uncle Boons" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -64.74 USD
+  Expenses:Food:Restaurant                          64.74 USD
+
+2025-07-29 * "Jewel of Morroco" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -19.93 USD
+  Expenses:Food:Restaurant                          19.93 USD
+
+2025-07-30 event "location" "New York"
+
+2025-07-31 * "Cafe Select" "" #trip-new-york-2025
+  Liabilities:US:Chase:Slate                       -35.25 USD
+  Expenses:Food:Restaurant                          35.25 USD
+
+2025-07-31 * "Takahachi" "" #trip-new-york-2025
+  Liabilities:US:Chase:Slate                       -47.92 USD
+  Expenses:Food:Restaurant                          47.92 USD
+
+2025-08-01 * "Takahachi" "" #trip-new-york-2025
+  Liabilities:US:Chase:Slate                       -49.46 USD
+  Expenses:Food:Restaurant                          49.46 USD
+
+2025-08-02 * "Laut" "" #trip-new-york-2025
+  Liabilities:US:Chase:Slate                       -30.85 USD
+  Expenses:Food:Restaurant                          30.85 USD
+
+2025-08-03 * "Uncle Boons" "" #trip-new-york-2025
+  Liabilities:US:Chase:Slate                       -33.33 USD
+  Expenses:Food:Restaurant                          33.33 USD
+
+2025-08-04 * "Cafe Select" "" #trip-new-york-2025
+  Liabilities:US:Chase:Slate                       -22.14 USD
+  Expenses:Food:Restaurant                          22.14 USD
+
+2025-08-04 * "Gimme! Coffee" "" #trip-new-york-2025
+  Liabilities:US:Chase:Slate                        -5.96 USD
+  Expenses:Food:Coffee                               5.96 USD
+
+2025-08-05 * "Uncle Boons" "" #trip-new-york-2025
+  Liabilities:US:Chase:Slate                       -41.38 USD
+  Expenses:Food:Restaurant                          41.38 USD
+
+2025-08-06 * "Laut" "" #trip-new-york-2025
+  Liabilities:US:Chase:Slate                       -29.79 USD
+  Expenses:Food:Restaurant                          29.79 USD
+
+2025-08-07 * "La Colombe" "" #trip-new-york-2025
+  Liabilities:US:Chase:Slate                        -6.09 USD
+  Expenses:Food:Coffee                               6.09 USD
+
+2025-08-07 * "Gimme! Coffee" "" #trip-new-york-2025
+  Liabilities:US:Chase:Slate                        -4.45 USD
+  Expenses:Food:Coffee                               4.45 USD
+
+2025-08-07 * "Consume vacation days"
+  Assets:US:Hooli:Vacation                            -64 VACHR
+  Expenses:Vacation                                    64 VACHR
+
+2025-08-07 event "location" "New Metropolis"
+
+2025-08-09 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       519.90 USD
+  Assets:US:BofA:Checking                         -519.90 USD
+
+2025-08-11 * "Uncle Boons" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -46.60 USD
+  Expenses:Food:Restaurant                          46.60 USD
+
+2025-08-12 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2025-08-16 * "Uncle Boons" "Eating out "
+  Liabilities:US:Chase:Slate                       -48.89 USD
+  Expenses:Food:Restaurant                          48.89 USD
+
+2025-08-17 * "Uncle Boons" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -22.66 USD
+  Expenses:Food:Restaurant                          22.66 USD
+
+2025-08-20 balance Liabilities:US:Chase:Slate    -1102.09 USD
+
+2025-08-21 * "Good Moods Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -66.90 USD
+  Expenses:Food:Groceries                           66.90 USD
+
+2025-08-22 * "Kin Soy" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -17.54 USD
+  Expenses:Food:Restaurant                          17.54 USD
+
+2025-08-27 * "Jewel of Morroco" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -29.15 USD
+  Expenses:Food:Restaurant                          29.15 USD
+
+2025-08-27 * "Good Moods Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -74.80 USD
+  Expenses:Food:Groceries                           74.80 USD
+
+2025-08-29 * "Jewel of Morroco" "Eating out "
+  Liabilities:US:Chase:Slate                       -25.75 USD
+  Expenses:Food:Restaurant                          25.75 USD
+
+2025-08-30 * "China Garden" "Eating out "
+  Liabilities:US:Chase:Slate                       -40.39 USD
+  Expenses:Food:Restaurant                          40.39 USD
+
+2025-09-04 * "China Garden" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -28.25 USD
+  Expenses:Food:Restaurant                          28.25 USD
+
+2025-09-09 * "Uncle Boons" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -23.18 USD
+  Expenses:Food:Restaurant                          23.18 USD
+
+2025-09-09 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       497.51 USD
+  Assets:US:BofA:Checking                         -497.51 USD
+
+2025-09-11 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2025-09-12 * "China Garden" "Eating out "
+  Liabilities:US:Chase:Slate                       -56.85 USD
+  Expenses:Food:Restaurant                          56.85 USD
+
+2025-09-14 * "Good Moods Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                      -101.31 USD
+  Expenses:Food:Groceries                          101.31 USD
+
+2025-09-15 * "Uncle Boons" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -57.02 USD
+  Expenses:Food:Restaurant                          57.02 USD
+
+2025-09-16 balance Liabilities:US:Chase:Slate    -1245.72 USD
+
+2025-09-20 * "China Garden" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -36.57 USD
+  Expenses:Food:Restaurant                          36.57 USD
+
+2025-09-23 * "Kin Soy" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -46.09 USD
+  Expenses:Food:Restaurant                          46.09 USD
+
+2025-09-28 * "Kin Soy" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -35.14 USD
+  Expenses:Food:Restaurant                          35.14 USD
+
+2025-09-29 * "Kin Soy" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -38.59 USD
+  Expenses:Food:Restaurant                          38.59 USD
+
+2025-09-30 * "Goba Goba" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -24.24 USD
+  Expenses:Food:Restaurant                          24.24 USD
+
+2025-10-04 * "Farmer Fresh" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -50.12 USD
+  Expenses:Food:Groceries                           50.12 USD
+
+2025-10-05 * "Chichipotle" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -73.13 USD
+  Expenses:Food:Restaurant                          73.13 USD
+
+2025-10-07 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       660.17 USD
+  Assets:US:BofA:Checking                         -660.17 USD
+
+2025-10-08 * "Kin Soy" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -21.11 USD
+  Expenses:Food:Restaurant                          21.11 USD
+
+2025-10-09 * "Farmer Fresh" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -57.10 USD
+  Expenses:Food:Groceries                           57.10 USD
+
+2025-10-10 * "Jewel of Morroco" "Eating out "
+  Liabilities:US:Chase:Slate                       -21.10 USD
+  Expenses:Food:Restaurant                          21.10 USD
+
+2025-10-10 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2025-10-12 * "Chichipotle" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -31.84 USD
+  Expenses:Food:Restaurant                          31.84 USD
+
+2025-10-14 * "Uncle Boons" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -41.35 USD
+  Expenses:Food:Restaurant                          41.35 USD
+
+2025-10-15 * "Kin Soy" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -65.88 USD
+  Expenses:Food:Restaurant                          65.88 USD
+
+2025-10-16 balance Liabilities:US:Chase:Slate    -1247.81 USD
+
+2025-10-18 * "Onion Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -78.97 USD
+  Expenses:Food:Groceries                           78.97 USD
+
+2025-10-20 * "Jewel of Morroco" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -47.96 USD
+  Expenses:Food:Restaurant                          47.96 USD
+
+2025-10-22 * "Rose Flower" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -56.96 USD
+  Expenses:Food:Restaurant                          56.96 USD
+
+2025-10-26 * "Uncle Boons" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -14.21 USD
+  Expenses:Food:Restaurant                          14.21 USD
+
+2025-10-26 * "Farmer Fresh" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -39.49 USD
+  Expenses:Food:Groceries                           39.49 USD
+
+2025-10-29 * "Cafe Modagor" "Eating out "
+  Liabilities:US:Chase:Slate                       -42.48 USD
+  Expenses:Food:Restaurant                          42.48 USD
+
+2025-11-01 * "Cafe Modagor" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -14.11 USD
+  Expenses:Food:Restaurant                          14.11 USD
+
+2025-11-04 * "Chichipotle" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -33.23 USD
+  Expenses:Food:Restaurant                          33.23 USD
+
+2025-11-04 * "Onion Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -97.46 USD
+  Expenses:Food:Groceries                           97.46 USD
+
+2025-11-07 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       808.59 USD
+  Assets:US:BofA:Checking                         -808.59 USD
+
+2025-11-08 * "Chichipotle" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -46.45 USD
+  Expenses:Food:Restaurant                          46.45 USD
+
+2025-11-10 * "Chichipotle" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -40.92 USD
+  Expenses:Food:Restaurant                          40.92 USD
+
+2025-11-10 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2025-11-11 * "China Garden" "Eating out "
+  Liabilities:US:Chase:Slate                       -19.18 USD
+  Expenses:Food:Restaurant                          19.18 USD
+
+2025-11-12 * "Cafe Modagor" "Eating out "
+  Liabilities:US:Chase:Slate                       -46.72 USD
+  Expenses:Food:Restaurant                          46.72 USD
+
+2025-11-13 * "Rose Flower" "Eating out "
+  Liabilities:US:Chase:Slate                       -28.07 USD
+  Expenses:Food:Restaurant                          28.07 USD
+
+2025-11-14 * "Good Moods Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -72.59 USD
+  Expenses:Food:Groceries                           72.59 USD
+
+2025-11-15 balance Liabilities:US:Chase:Slate    -1238.02 USD
+
+2025-11-16 * "Kin Soy" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -38.80 USD
+  Expenses:Food:Restaurant                          38.80 USD
+
+2025-11-17 * "Rose Flower" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -25.13 USD
+  Expenses:Food:Restaurant                          25.13 USD
+
+2025-11-21 * "Jewel of Morroco" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -17.29 USD
+  Expenses:Food:Restaurant                          17.29 USD
+
+2025-11-25 * "Jewel of Morroco" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -19.48 USD
+  Expenses:Food:Restaurant                          19.48 USD
+
+2025-11-30 * "Rose Flower" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -27.55 USD
+  Expenses:Food:Restaurant                          27.55 USD
+
+2025-12-02 * "Onion Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -87.86 USD
+  Expenses:Food:Groceries                           87.86 USD
+
+2025-12-03 * "Jewel of Morroco" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -27.37 USD
+  Expenses:Food:Restaurant                          27.37 USD
+
+2025-12-05 * "Cafe Modagor" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -29.04 USD
+  Expenses:Food:Restaurant                          29.04 USD
+
+2025-12-06 balance Liabilities:US:Chase:Slate    -1510.54 USD
+
+2025-12-09 * "Kin Soy" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                      -105.10 USD
+  Expenses:Food:Restaurant                         105.10 USD
+
+2025-12-10 * "Kin Soy" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -37.73 USD
+  Expenses:Food:Restaurant                          37.73 USD
+
+2025-12-10 * "Farmer Fresh" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -66.50 USD
+  Expenses:Food:Groceries                           66.50 USD
+
+2025-12-10 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       742.83 USD
+  Assets:US:BofA:Checking                         -742.83 USD
+
+2025-12-11 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2025-12-14 * "Goba Goba" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -27.36 USD
+  Expenses:Food:Restaurant                          27.36 USD
+
+2025-12-15 event "location" "Chicago"
+
+2025-12-16 * "Argo Tea" "" #trip-chicago-2025
+  Liabilities:US:Chase:Slate                        -6.27 USD
+  Expenses:Food:Coffee                               6.27 USD
+
+2025-12-17 * "Star of Siam" "" #trip-chicago-2025
+  Liabilities:US:Chase:Slate                       -25.24 USD
+  Expenses:Food:Restaurant                          25.24 USD
+
+2025-12-17 * "Mercadito" "" #trip-chicago-2025
+  Liabilities:US:Chase:Slate                       -45.19 USD
+  Expenses:Food:Restaurant                          45.19 USD
+
+2025-12-20 * "25 Degrees Burger Bar" "" #trip-chicago-2025
+  Liabilities:US:Chase:Slate                       -23.89 USD
+  Expenses:Food:Restaurant                          23.89 USD
+
+2025-12-21 * "Star of Siam" "" #trip-chicago-2025
+  Liabilities:US:Chase:Slate                       -19.56 USD
+  Expenses:Food:Restaurant                          19.56 USD
+
+2025-12-21 * "Eataly Chicago" "" #trip-chicago-2025
+  Liabilities:US:Chase:Slate                       -39.92 USD
+  Expenses:Food:Restaurant                          39.92 USD
+
+2025-12-21 * "Another Sports Pub" "" #trip-chicago-2025
+  Liabilities:US:Chase:Slate                       -11.10 USD
+  Expenses:Food:Alcohol                             11.10 USD
+
+2025-12-22 * "Argo Tea" "" #trip-chicago-2025
+  Liabilities:US:Chase:Slate                        -4.92 USD
+  Expenses:Food:Coffee                               4.92 USD
+
+2025-12-23 * "Eataly Chicago" "" #trip-chicago-2025
+  Liabilities:US:Chase:Slate                       -38.48 USD
+  Expenses:Food:Restaurant                          38.48 USD
+
+2025-12-23 * "Another Sports Pub" "" #trip-chicago-2025
+  Liabilities:US:Chase:Slate                        -9.09 USD
+  Expenses:Food:Alcohol                              9.09 USD
+
+2025-12-24 * "Argo Tea" "" #trip-chicago-2025
+  Liabilities:US:Chase:Slate                        -5.72 USD
+  Expenses:Food:Coffee                               5.72 USD
+
+2025-12-25 * "Star of Siam" "" #trip-chicago-2025
+  Liabilities:US:Chase:Slate                       -21.57 USD
+  Expenses:Food:Restaurant                          21.57 USD
+
+2025-12-25 * "25 Degrees Burger Bar" "" #trip-chicago-2025
+  Liabilities:US:Chase:Slate                       -24.89 USD
+  Expenses:Food:Restaurant                          24.89 USD
+
+2025-12-26 * "Another Sports Pub" "" #trip-chicago-2025
+  Liabilities:US:Chase:Slate                       -11.19 USD
+  Expenses:Food:Alcohol                             11.19 USD
+
+2025-12-27 * "25 Degrees Burger Bar" "" #trip-chicago-2025
+  Liabilities:US:Chase:Slate                       -19.34 USD
+  Expenses:Food:Restaurant                          19.34 USD
+
+2025-12-27 * "Argo Tea" "" #trip-chicago-2025
+  Liabilities:US:Chase:Slate                        -6.99 USD
+  Expenses:Food:Coffee                               6.99 USD
+
+2025-12-28 * "Mercadito" "" #trip-chicago-2025
+  Liabilities:US:Chase:Slate                       -33.05 USD
+  Expenses:Food:Restaurant                          33.05 USD
+
+2025-12-28 * "Another Sports Pub" "" #trip-chicago-2025
+  Liabilities:US:Chase:Slate                       -14.16 USD
+  Expenses:Food:Alcohol                             14.16 USD
+
+2025-12-29 * "Star of Siam" "" #trip-chicago-2025
+  Liabilities:US:Chase:Slate                       -26.32 USD
+  Expenses:Food:Restaurant                          26.32 USD
+
+2025-12-29 * "Eataly Chicago" "" #trip-chicago-2025
+  Liabilities:US:Chase:Slate                       -28.38 USD
+  Expenses:Food:Restaurant                          28.38 USD
+
+2025-12-29 * "Another Sports Pub" "" #trip-chicago-2025
+  Liabilities:US:Chase:Slate                       -15.10 USD
+  Expenses:Food:Alcohol                             15.10 USD
+
+2025-12-29 * "Argo Tea" "" #trip-chicago-2025
+  Liabilities:US:Chase:Slate                        -6.25 USD
+  Expenses:Food:Coffee                               6.25 USD
+
+2025-12-30 * "Another Sports Pub" "" #trip-chicago-2025
+  Liabilities:US:Chase:Slate                        -9.13 USD
+  Expenses:Food:Alcohol                              9.13 USD
+
+2025-12-31 * "Another Sports Pub" "" #trip-chicago-2025
+  Liabilities:US:Chase:Slate                       -10.67 USD
+  Expenses:Food:Alcohol                             10.67 USD
+
+2025-12-31 * "Consume vacation days"
+  Assets:US:Hooli:Vacation                           -128 VACHR
+  Expenses:Vacation                                   128 VACHR
+
+2025-12-31 event "location" "New Metropolis"
+
+2026-01-02 * "Uncle Boons" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -31.41 USD
+  Expenses:Food:Restaurant                          31.41 USD
+
+2026-01-03 balance Liabilities:US:Chase:Slate    -1612.23 USD
+
+2026-01-05 * "Jewel of Morroco" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -36.39 USD
+  Expenses:Food:Restaurant                          36.39 USD
+
+2026-01-06 * "Kin Soy" "Eating out "
+  Liabilities:US:Chase:Slate                       -12.07 USD
+  Expenses:Food:Restaurant                          12.07 USD
+
+2026-01-08 * "Kin Soy" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -44.10 USD
+  Expenses:Food:Restaurant                          44.10 USD
+
+2026-01-08 * "Corner Deli" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -87.23 USD
+  Expenses:Food:Groceries                           87.23 USD
+
+2026-01-09 * "Kin Soy" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -60.35 USD
+  Expenses:Food:Restaurant                          60.35 USD
+
+2026-01-11 * "Chichipotle" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -35.25 USD
+  Expenses:Food:Restaurant                          35.25 USD
+
+2026-01-11 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       520.66 USD
+  Assets:US:BofA:Checking                         -520.66 USD
+
+2026-01-13 * "Good Moods Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                      -126.52 USD
+  Expenses:Food:Groceries                          126.52 USD
+
+2026-01-13 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2026-01-14 * "Chichipotle" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -21.34 USD
+  Expenses:Food:Restaurant                          21.34 USD
+
+2026-01-18 * "China Garden" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -39.21 USD
+  Expenses:Food:Restaurant                          39.21 USD
+
+2026-01-22 * "Uncle Boons" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -32.80 USD
+  Expenses:Food:Restaurant                          32.80 USD
+
+2026-01-24 * "Chichipotle" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -24.79 USD
+  Expenses:Food:Restaurant                          24.79 USD
+
+2026-01-24 * "Good Moods Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -93.73 USD
+  Expenses:Food:Groceries                           93.73 USD
+
+2026-01-27 * "Chichipotle" "Eating out "
+  Liabilities:US:Chase:Slate                       -42.92 USD
+  Expenses:Food:Restaurant                          42.92 USD
+
+2026-01-29 balance Liabilities:US:Chase:Slate    -1868.27 USD
+
+2026-01-29 * "Chichipotle" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -38.52 USD
+  Expenses:Food:Restaurant                          38.52 USD
+
+2026-02-03 * "Rose Flower" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -33.27 USD
+  Expenses:Food:Restaurant                          33.27 USD
+
+2026-02-07 * "Goba Goba" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -15.16 USD
+  Expenses:Food:Restaurant                          15.16 USD
+
+2026-02-09 * "Chichipotle" "Eating out "
+  Liabilities:US:Chase:Slate                       -30.19 USD
+  Expenses:Food:Restaurant                          30.19 USD
+
+2026-02-10 * "Cafe Modagor" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -56.02 USD
+  Expenses:Food:Restaurant                          56.02 USD
+
+2026-02-10 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       674.47 USD
+  Assets:US:BofA:Checking                         -674.47 USD
+
+2026-02-13 * "Onion Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -74.76 USD
+  Expenses:Food:Groceries                           74.76 USD
+
+2026-02-15 * "Uncle Boons" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -22.18 USD
+  Expenses:Food:Restaurant                          22.18 USD
+
+2026-02-15 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2026-02-18 * "Chichipotle" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -37.49 USD
+  Expenses:Food:Restaurant                          37.49 USD
+
+2026-02-18 * "Good Moods Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -83.98 USD
+  Expenses:Food:Groceries                           83.98 USD
+
+2026-02-20 * "Rose Flower" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -13.36 USD
+  Expenses:Food:Restaurant                          13.36 USD
+
+2026-02-21 balance Liabilities:US:Chase:Slate    -1718.73 USD
+
+2026-02-24 * "Rose Flower" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -24.86 USD
+  Expenses:Food:Restaurant                          24.86 USD
+
+2026-02-25 * "Cafe Modagor" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -29.99 USD
+  Expenses:Food:Restaurant                          29.99 USD
+
+2026-02-27 * "Cafe Modagor" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -50.16 USD
+  Expenses:Food:Restaurant                          50.16 USD
+
+2026-03-04 * "Rose Flower" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -31.40 USD
+  Expenses:Food:Restaurant                          31.40 USD
+
+2026-03-09 * "Jewel of Morroco" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -21.78 USD
+  Expenses:Food:Restaurant                          21.78 USD
+
+2026-03-10 * "Farmer Fresh" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -80.64 USD
+  Expenses:Food:Groceries                           80.64 USD
+
+2026-03-11 * "Chase:Slate" "Paying off credit card"
+  Liabilities:US:Chase:Slate                       627.49 USD
+  Assets:US:BofA:Checking                         -627.49 USD
+
+2026-03-13 * "China Garden" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -36.89 USD
+  Expenses:Food:Restaurant                          36.89 USD
+
+2026-03-14 * "Jewel of Morroco" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -22.87 USD
+  Expenses:Food:Restaurant                          22.87 USD
+
+2026-03-15 * "Chichipotle" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -46.16 USD
+  Expenses:Food:Restaurant                          46.16 USD
+
+2026-03-18 * "Jewel of Morroco" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -31.83 USD
+  Expenses:Food:Restaurant                          31.83 USD
+
+2026-03-19 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2026-03-20 balance Liabilities:US:Chase:Slate    -1587.82 USD
+
+2026-03-23 * "Cafe Modagor" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -24.84 USD
+  Expenses:Food:Restaurant                          24.84 USD
+
+2026-03-25 * "Jewel of Morroco" "Eating out after work"
+  Liabilities:US:Chase:Slate                       -20.39 USD
+  Expenses:Food:Restaurant                          20.39 USD
+
+2026-03-28 * "Cafe Modagor" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -24.36 USD
+  Expenses:Food:Restaurant                          24.36 USD
+
+2026-03-28 * "Good Moods Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -88.32 USD
+  Expenses:Food:Groceries                           88.32 USD
+
+2026-03-29 * "Jewel of Morroco" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -20.22 USD
+  Expenses:Food:Restaurant                          20.22 USD
+
+2026-03-30 * "China Garden" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -15.81 USD
+  Expenses:Food:Restaurant                          15.81 USD
+
+2026-03-31 * "Kin Soy" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -23.68 USD
+  Expenses:Food:Restaurant                          23.68 USD
+
+2026-04-04 * "Chichipotle" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -21.91 USD
+  Expenses:Food:Restaurant                          21.91 USD
+
+2026-04-05 * "Chichipotle" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -21.79 USD
+  Expenses:Food:Restaurant                          21.79 USD
+
+2026-04-08 * "Chichipotle" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -23.85 USD
+  Expenses:Food:Restaurant                          23.85 USD
+
+2026-04-10 * "Onion Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -63.54 USD
+  Expenses:Food:Groceries                           63.54 USD
+
+2026-04-12 * "China Garden" "Eating out alone"
+  Liabilities:US:Chase:Slate                       -20.25 USD
+  Expenses:Food:Restaurant                          20.25 USD
+
+2026-04-14 balance Liabilities:US:Chase:Slate    -1956.78 USD
+
+2026-04-15 * "Goba Goba" "Eating out with work buddies"
+  Liabilities:US:Chase:Slate                       -27.89 USD
+  Expenses:Food:Restaurant                          27.89 USD
+
+2026-04-17 * "Metro Transport Authority" "Tram tickets"
+  Liabilities:US:Chase:Slate                      -120.00 USD
+  Expenses:Transport:Tram                          120.00 USD
+
+2026-04-18 * "China Garden" "Eating out with Bill"
+  Liabilities:US:Chase:Slate                       -37.97 USD
+  Expenses:Food:Restaurant                          37.97 USD
+
+2026-04-22 * "Chichipotle" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -47.53 USD
+  Expenses:Food:Restaurant                          47.53 USD
+
+2026-04-24 * "Onion Market" "Buying groceries"
+  Liabilities:US:Chase:Slate                      -111.40 USD
+  Expenses:Food:Groceries                          111.40 USD
+
+2026-04-25 * "China Garden" "Eating out with Natasha"
+  Liabilities:US:Chase:Slate                       -18.75 USD
+  Expenses:Food:Restaurant                          18.75 USD
+
+2026-04-30 * "Chichipotle" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -11.51 USD
+  Expenses:Food:Restaurant                          11.51 USD
+
+2026-05-04 * "Uncle Boons" "Eating out with Julie"
+  Liabilities:US:Chase:Slate                       -56.19 USD
+  Expenses:Food:Restaurant                          56.19 USD
+
+
+
+* Taxable Investments
+
+2024-01-01 open Assets:US:ETrade:Cash                       USD
+2024-01-01 open Assets:US:ETrade:ITOT                       ITOT
+2024-01-01 open Assets:US:ETrade:VEA                       VEA
+2024-01-01 open Assets:US:ETrade:VHT                       VHT
+2024-01-01 open Assets:US:ETrade:GLD                       GLD
+2024-01-01 open Income:US:ETrade:PnL                        USD
+2024-01-01 open Income:US:ETrade:ITOT:Dividend              USD
+2024-01-01 open Income:US:ETrade:VEA:Dividend              USD
+2024-01-01 open Income:US:ETrade:VHT:Dividend              USD
+2024-01-01 open Income:US:ETrade:GLD:Dividend              USD
+
+2024-09-16 * "Buy shares of VEA"
+  Assets:US:ETrade:Cash                          -1060.15 USD
+  Assets:US:ETrade:VEA                                 16 VEA {65.70 USD, 2024-09-16}
+  Expenses:Financial:Commissions                     8.95 USD
+
+2024-09-16 * "Buy shares of GLD"
+  Assets:US:ETrade:Cash                           -953.15 USD
+  Assets:US:ETrade:GLD                                  4 GLD {236.05 USD, 2024-09-16}
+  Expenses:Financial:Commissions                     8.95 USD
+
+2024-09-16 * "Buy shares of ITOT"
+  Assets:US:ETrade:Cash                          -1072.25 USD
+  Assets:US:ETrade:ITOT                                14 ITOT {75.95 USD, 2024-09-16}
+  Expenses:Financial:Commissions                     8.95 USD
+
+2024-09-17 * "Dividends on portfolio"
+  Assets:US:ETrade:Cash                             12.23 USD
+  Income:US:ETrade:VHT:Dividend                    -12.23 USD
+
+2024-11-12 * "Buy shares of VHT"
+  Assets:US:ETrade:Cash                          -4859.35 USD
+  Assets:US:ETrade:VHT                                 30 VHT {161.68 USD, 2024-11-12}
+  Expenses:Financial:Commissions                     8.95 USD
+
+2024-12-17 * "Dividends on portfolio"
+  Assets:US:ETrade:Cash                             31.64 USD
+  Income:US:ETrade:GLD:Dividend                    -31.64 USD
+
+2025-01-01 * "Sell shares of ITOT"
+  Assets:US:ETrade:ITOT                               -14 ITOT {75.95 USD, 2024-09-16} @ 67.63 USD
+  Assets:US:ETrade:Cash                            937.87 USD
+  Expenses:Financial:Commissions                     8.95 USD
+  Income:US:ETrade:PnL                             116.48 USD
+
+2025-01-17 * "Sell shares of VHT"
+  Assets:US:ETrade:VHT                                -30 VHT {161.68 USD, 2024-11-12} @ 170.48 USD
+  Assets:US:ETrade:Cash                           5105.45 USD
+  Expenses:Financial:Commissions                     8.95 USD
+  Income:US:ETrade:PnL                            -264.00 USD
+
+2025-03-03 * "Buy shares of VHT"
+  Assets:US:ETrade:Cash                          -1865.85 USD
+  Assets:US:ETrade:VHT                                 10 VHT {185.69 USD, 2025-03-03}
+  Expenses:Financial:Commissions                     8.95 USD
+
+2025-03-03 * "Buy shares of ITOT"
+  Assets:US:ETrade:Cash                          -1945.28 USD
+  Assets:US:ETrade:ITOT                                29 ITOT {66.77 USD, 2025-03-03}
+  Expenses:Financial:Commissions                     8.95 USD
+
+2025-03-03 * "Buy shares of VEA"
+  Assets:US:ETrade:Cash                          -1974.81 USD
+  Assets:US:ETrade:VEA                                 26 VEA {75.61 USD, 2025-03-03}
+  Expenses:Financial:Commissions                     8.95 USD
+
+2025-03-18 * "Dividends on portfolio"
+  Assets:US:ETrade:Cash                             54.67 USD
+  Income:US:ETrade:VEA:Dividend                    -54.67 USD
+
+2025-05-22 * "Sell shares of VHT"
+  Assets:US:ETrade:VHT                                -10 VHT {185.69 USD, 2025-03-03} @ 170.33 USD
+  Assets:US:ETrade:Cash                           1694.35 USD
+  Expenses:Financial:Commissions                     8.95 USD
+  Income:US:ETrade:PnL                             153.60 USD
+
+2025-06-18 * "Dividends on portfolio"
+  Assets:US:ETrade:Cash                             54.67 USD
+  Income:US:ETrade:VHT:Dividend                    -54.67 USD
+
+2025-06-30 * "Buy shares of ITOT"
+  Assets:US:ETrade:Cash                           -332.03 USD
+  Assets:US:ETrade:ITOT                                 4 ITOT {80.77 USD, 2025-06-30}
+  Expenses:Financial:Commissions                     8.95 USD
+
+2025-06-30 * "Buy shares of VHT"
+  Assets:US:ETrade:Cash                           -335.37 USD
+  Assets:US:ETrade:VHT                                  2 VHT {163.21 USD, 2025-06-30}
+  Expenses:Financial:Commissions                     8.95 USD
+
+2025-06-30 * "Buy shares of VEA"
+  Assets:US:ETrade:Cash                           -401.70 USD
+  Assets:US:ETrade:VEA                                  5 VEA {78.55 USD, 2025-06-30}
+  Expenses:Financial:Commissions                     8.95 USD
+
+2025-06-30 * "Buy shares of GLD"
+  Assets:US:ETrade:Cash                           -275.12 USD
+  Assets:US:ETrade:GLD                                  1 GLD {266.17 USD, 2025-06-30}
+  Expenses:Financial:Commissions                     8.95 USD
+
+2025-09-18 * "Dividends on portfolio"
+  Assets:US:ETrade:Cash                             59.91 USD
+  Income:US:ETrade:ITOT:Dividend                   -59.91 USD
+
+2025-09-22 * "Sell shares of ITOT"
+  Assets:US:ETrade:ITOT                               -29 ITOT {66.77 USD, 2025-03-03} @ 82.06 USD
+  Assets:US:ETrade:Cash                           2370.79 USD
+  Expenses:Financial:Commissions                     8.95 USD
+  Income:US:ETrade:PnL                            -443.41 USD
+
+2025-10-18 * "Buy shares of ITOT"
+  Assets:US:ETrade:Cash                          -6961.10 USD
+  Assets:US:ETrade:ITOT                                85 ITOT {81.79 USD, 2025-10-18}
+  Expenses:Financial:Commissions                     8.95 USD
+
+2025-11-26 * "Sell shares of VEA"
+  Assets:US:ETrade:VEA                                -16 VEA {65.70 USD, 2024-09-16} @ 84.27 USD
+  Assets:US:ETrade:Cash                           1339.37 USD
+  Expenses:Financial:Commissions                     8.95 USD
+  Income:US:ETrade:PnL                            -297.12 USD
+
+2025-11-27 * "Buy shares of ITOT"
+  Assets:US:ETrade:Cash                          -1407.73 USD
+  Assets:US:ETrade:ITOT                                18 ITOT {77.71 USD, 2025-11-27}
+  Expenses:Financial:Commissions                     8.95 USD
+
+2025-11-27 * "Buy shares of VEA"
+  Assets:US:ETrade:Cash                          -1357.27 USD
+  Assets:US:ETrade:VEA                                 16 VEA {84.27 USD, 2025-11-27}
+  Expenses:Financial:Commissions                     8.95 USD
+
+2025-11-27 * "Buy shares of VHT"
+  Assets:US:ETrade:Cash                          -1264.71 USD
+  Assets:US:ETrade:VHT                                  8 VHT {156.97 USD, 2025-11-27}
+  Expenses:Financial:Commissions                     8.95 USD
+
+2025-11-27 * "Buy shares of GLD"
+  Assets:US:ETrade:Cash                          -1162.91 USD
+  Assets:US:ETrade:GLD                                  4 GLD {288.49 USD, 2025-11-27}
+  Expenses:Financial:Commissions                     8.95 USD
+
+2025-12-17 * "Dividends on portfolio"
+  Assets:US:ETrade:Cash                            108.34 USD
+  Income:US:ETrade:VEA:Dividend                   -108.34 USD
+
+2026-03-18 * "Dividends on portfolio"
+  Assets:US:ETrade:Cash                            108.34 USD
+  Income:US:ETrade:VHT:Dividend                   -108.34 USD
+
+
+
+* Vanguard Investments
+
+2024-01-01 open Assets:US:Vanguard:VBMPX                     VBMPX
+  number: "882882"
+2024-01-01 open Assets:US:Vanguard:RGAGX                     RGAGX
+  number: "882882"
+2024-01-01 open Assets:US:Vanguard                            USD
+  institution: "Vanguard Group"
+  address: "P.O. Box 1110, Valley Forge, PA 19482-1110"
+  phone: "+1.800.523.1188"
+2024-01-01 open Income:US:Hooli:Match401k                   USD
+2024-01-01 open Assets:US:Vanguard:Cash                       USD
+  number: "882882"
+
+2024-01-05 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2024-01-08 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.347 VBMPX {110.42 USD, 2024-01-08}
+  Assets:US:Vanguard:Cash                         -480.00 USD
+
+2024-01-08 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          5.329 RGAGX {135.10 USD, 2024-01-08}
+  Assets:US:Vanguard:Cash                         -719.95 USD
+
+2024-01-08 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.174 VBMPX {110.42 USD, 2024-01-08}
+  Assets:US:Vanguard:Cash                         -240.05 USD
+
+2024-01-08 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          2.665 RGAGX {135.10 USD, 2024-01-08}
+  Assets:US:Vanguard:Cash                         -360.04 USD
+
+2024-01-19 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2024-01-22 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.323 VBMPX {111.02 USD, 2024-01-22}
+  Assets:US:Vanguard:Cash                         -479.94 USD
+
+2024-01-22 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          5.299 RGAGX {135.86 USD, 2024-01-22}
+  Assets:US:Vanguard:Cash                         -719.92 USD
+
+2024-01-22 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.162 VBMPX {111.02 USD, 2024-01-22}
+  Assets:US:Vanguard:Cash                         -240.03 USD
+
+2024-01-22 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          2.650 RGAGX {135.86 USD, 2024-01-22}
+  Assets:US:Vanguard:Cash                         -360.03 USD
+
+2024-02-02 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2024-02-05 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.289 VBMPX {111.91 USD, 2024-02-05}
+  Assets:US:Vanguard:Cash                         -479.98 USD
+
+2024-02-05 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          5.146 RGAGX {139.91 USD, 2024-02-05}
+  Assets:US:Vanguard:Cash                         -719.98 USD
+
+2024-02-05 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.145 VBMPX {111.91 USD, 2024-02-05}
+  Assets:US:Vanguard:Cash                         -240.05 USD
+
+2024-02-05 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          2.573 RGAGX {139.91 USD, 2024-02-05}
+  Assets:US:Vanguard:Cash                         -359.99 USD
+
+2024-02-16 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2024-02-19 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.378 VBMPX {109.64 USD, 2024-02-19}
+  Assets:US:Vanguard:Cash                         -480.00 USD
+
+2024-02-19 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          5.337 RGAGX {134.91 USD, 2024-02-19}
+  Assets:US:Vanguard:Cash                         -720.01 USD
+
+2024-02-19 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.189 VBMPX {109.64 USD, 2024-02-19}
+  Assets:US:Vanguard:Cash                         -240.00 USD
+
+2024-02-19 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          2.669 RGAGX {134.91 USD, 2024-02-19}
+  Assets:US:Vanguard:Cash                         -360.07 USD
+
+2024-03-01 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2024-03-04 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.379 VBMPX {109.61 USD, 2024-03-04}
+  Assets:US:Vanguard:Cash                         -479.98 USD
+
+2024-03-04 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          5.429 RGAGX {132.62 USD, 2024-03-04}
+  Assets:US:Vanguard:Cash                         -719.99 USD
+
+2024-03-04 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.190 VBMPX {109.61 USD, 2024-03-04}
+  Assets:US:Vanguard:Cash                         -240.05 USD
+
+2024-03-04 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          2.714 RGAGX {132.62 USD, 2024-03-04}
+  Assets:US:Vanguard:Cash                         -359.93 USD
+
+2024-03-15 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2024-03-18 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.405 VBMPX {108.98 USD, 2024-03-18}
+  Assets:US:Vanguard:Cash                         -480.06 USD
+
+2024-03-18 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          5.422 RGAGX {132.79 USD, 2024-03-18}
+  Assets:US:Vanguard:Cash                         -719.99 USD
+
+2024-03-18 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.202 VBMPX {108.98 USD, 2024-03-18}
+  Assets:US:Vanguard:Cash                         -239.97 USD
+
+2024-03-18 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          2.711 RGAGX {132.79 USD, 2024-03-18}
+  Assets:US:Vanguard:Cash                         -359.99 USD
+
+2024-03-29 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2024-04-01 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.411 VBMPX {108.81 USD, 2024-04-01}
+  Assets:US:Vanguard:Cash                         -479.96 USD
+
+2024-04-01 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          5.547 RGAGX {129.80 USD, 2024-04-01}
+  Assets:US:Vanguard:Cash                         -720.00 USD
+
+2024-04-01 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.206 VBMPX {108.81 USD, 2024-04-01}
+  Assets:US:Vanguard:Cash                         -240.03 USD
+
+2024-04-01 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          2.774 RGAGX {129.80 USD, 2024-04-01}
+  Assets:US:Vanguard:Cash                         -360.07 USD
+
+2024-04-12 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2024-04-15 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.350 VBMPX {110.34 USD, 2024-04-15}
+  Assets:US:Vanguard:Cash                         -479.98 USD
+
+2024-04-15 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          5.309 RGAGX {135.61 USD, 2024-04-15}
+  Assets:US:Vanguard:Cash                         -719.95 USD
+
+2024-04-15 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.175 VBMPX {110.34 USD, 2024-04-15}
+  Assets:US:Vanguard:Cash                         -239.99 USD
+
+2024-04-15 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          2.655 RGAGX {135.61 USD, 2024-04-15}
+  Assets:US:Vanguard:Cash                         -360.04 USD
+
+2024-04-26 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2024-04-29 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.326 VBMPX {110.96 USD, 2024-04-29}
+  Assets:US:Vanguard:Cash                         -480.01 USD
+
+2024-04-29 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          5.279 RGAGX {136.38 USD, 2024-04-29}
+  Assets:US:Vanguard:Cash                         -719.95 USD
+
+2024-04-29 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.163 VBMPX {110.96 USD, 2024-04-29}
+  Assets:US:Vanguard:Cash                         -240.01 USD
+
+2024-04-29 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          2.640 RGAGX {136.38 USD, 2024-04-29}
+  Assets:US:Vanguard:Cash                         -360.04 USD
+
+2024-05-10 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2024-05-13 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.265 VBMPX {112.54 USD, 2024-05-13}
+  Assets:US:Vanguard:Cash                         -479.98 USD
+
+2024-05-13 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          5.100 RGAGX {141.18 USD, 2024-05-13}
+  Assets:US:Vanguard:Cash                         -720.02 USD
+
+2024-05-13 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.132 VBMPX {112.54 USD, 2024-05-13}
+  Assets:US:Vanguard:Cash                         -239.94 USD
+
+2024-05-13 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          2.550 RGAGX {141.18 USD, 2024-05-13}
+  Assets:US:Vanguard:Cash                         -360.01 USD
+
+2024-05-24 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2024-05-27 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.278 VBMPX {112.20 USD, 2024-05-27}
+  Assets:US:Vanguard:Cash                         -479.99 USD
+
+2024-05-27 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          5.047 RGAGX {142.65 USD, 2024-05-27}
+  Assets:US:Vanguard:Cash                         -719.95 USD
+
+2024-05-27 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.139 VBMPX {112.20 USD, 2024-05-27}
+  Assets:US:Vanguard:Cash                         -240.00 USD
+
+2024-05-27 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          2.524 RGAGX {142.65 USD, 2024-05-27}
+  Assets:US:Vanguard:Cash                         -360.05 USD
+
+2024-06-07 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2024-06-10 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.315 VBMPX {111.23 USD, 2024-06-10}
+  Assets:US:Vanguard:Cash                         -479.96 USD
+
+2024-06-10 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          4.999 RGAGX {144.04 USD, 2024-06-10}
+  Assets:US:Vanguard:Cash                         -720.06 USD
+
+2024-06-10 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.158 VBMPX {111.23 USD, 2024-06-10}
+  Assets:US:Vanguard:Cash                         -240.03 USD
+
+2024-06-10 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          2.499 RGAGX {144.04 USD, 2024-06-10}
+  Assets:US:Vanguard:Cash                         -359.96 USD
+
+2024-06-21 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2024-06-24 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.466 VBMPX {107.48 USD, 2024-06-24}
+  Assets:US:Vanguard:Cash                         -480.01 USD
+
+2024-06-24 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          4.901 RGAGX {146.92 USD, 2024-06-24}
+  Assets:US:Vanguard:Cash                         -720.05 USD
+
+2024-06-24 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.233 VBMPX {107.48 USD, 2024-06-24}
+  Assets:US:Vanguard:Cash                         -240.00 USD
+
+2024-06-24 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          2.450 RGAGX {146.92 USD, 2024-06-24}
+  Assets:US:Vanguard:Cash                         -359.95 USD
+
+2024-07-05 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2024-07-08 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.547 VBMPX {105.57 USD, 2024-07-08}
+  Assets:US:Vanguard:Cash                         -480.03 USD
+
+2024-07-08 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          4.743 RGAGX {151.81 USD, 2024-07-08}
+  Assets:US:Vanguard:Cash                         -720.03 USD
+
+2024-07-08 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.273 VBMPX {105.57 USD, 2024-07-08}
+  Assets:US:Vanguard:Cash                         -239.96 USD
+
+2024-07-08 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          2.371 RGAGX {151.81 USD, 2024-07-08}
+  Assets:US:Vanguard:Cash                         -359.94 USD
+
+2024-07-19 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2024-07-22 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.635 VBMPX {103.56 USD, 2024-07-22}
+  Assets:US:Vanguard:Cash                         -480.00 USD
+
+2024-07-22 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          4.718 RGAGX {152.61 USD, 2024-07-22}
+  Assets:US:Vanguard:Cash                         -720.01 USD
+
+2024-07-22 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.318 VBMPX {103.56 USD, 2024-07-22}
+  Assets:US:Vanguard:Cash                         -240.05 USD
+
+2024-07-22 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          2.359 RGAGX {152.61 USD, 2024-07-22}
+  Assets:US:Vanguard:Cash                         -360.01 USD
+
+2024-08-02 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          250.00 USD
+  Income:US:Hooli:Match401k                       -250.00 USD
+
+2024-08-05 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          1.973 VBMPX {101.37 USD, 2024-08-05}
+  Assets:US:Vanguard:Cash                         -200.00 USD
+
+2024-08-05 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.975 RGAGX {151.87 USD, 2024-08-05}
+  Assets:US:Vanguard:Cash                         -299.94 USD
+
+2024-08-05 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          0.987 VBMPX {101.37 USD, 2024-08-05}
+  Assets:US:Vanguard:Cash                         -100.05 USD
+
+2024-08-05 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          0.988 RGAGX {151.87 USD, 2024-08-05}
+  Assets:US:Vanguard:Cash                         -150.05 USD
+
+2025-01-03 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2025-01-06 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.889 VBMPX {98.18 USD, 2025-01-06}
+  Assets:US:Vanguard:Cash                         -480.00 USD
+
+2025-01-06 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          4.043 RGAGX {178.07 USD, 2025-01-06}
+  Assets:US:Vanguard:Cash                         -719.94 USD
+
+2025-01-06 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.444 VBMPX {98.18 USD, 2025-01-06}
+  Assets:US:Vanguard:Cash                         -239.95 USD
+
+2025-01-06 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          2.022 RGAGX {178.07 USD, 2025-01-06}
+  Assets:US:Vanguard:Cash                         -360.06 USD
+
+2025-01-17 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2025-01-20 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.964 VBMPX {96.69 USD, 2025-01-20}
+  Assets:US:Vanguard:Cash                         -479.97 USD
+
+2025-01-20 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          3.874 RGAGX {185.85 USD, 2025-01-20}
+  Assets:US:Vanguard:Cash                         -719.98 USD
+
+2025-01-20 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.482 VBMPX {96.69 USD, 2025-01-20}
+  Assets:US:Vanguard:Cash                         -239.98 USD
+
+2025-01-20 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.937 RGAGX {185.85 USD, 2025-01-20}
+  Assets:US:Vanguard:Cash                         -359.99 USD
+
+2025-01-31 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2025-02-03 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.920 VBMPX {97.56 USD, 2025-02-03}
+  Assets:US:Vanguard:Cash                         -480.00 USD
+
+2025-02-03 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          3.810 RGAGX {189.00 USD, 2025-02-03}
+  Assets:US:Vanguard:Cash                         -720.09 USD
+
+2025-02-03 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.460 VBMPX {97.56 USD, 2025-02-03}
+  Assets:US:Vanguard:Cash                         -240.00 USD
+
+2025-02-03 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.905 RGAGX {189.00 USD, 2025-02-03}
+  Assets:US:Vanguard:Cash                         -360.04 USD
+
+2025-02-14 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2025-02-17 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.840 VBMPX {99.17 USD, 2025-02-17}
+  Assets:US:Vanguard:Cash                         -479.98 USD
+
+2025-02-17 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          3.841 RGAGX {187.46 USD, 2025-02-17}
+  Assets:US:Vanguard:Cash                         -720.03 USD
+
+2025-02-17 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.420 VBMPX {99.17 USD, 2025-02-17}
+  Assets:US:Vanguard:Cash                         -239.99 USD
+
+2025-02-17 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.920 RGAGX {187.46 USD, 2025-02-17}
+  Assets:US:Vanguard:Cash                         -359.92 USD
+
+2025-02-28 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2025-03-03 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.720 VBMPX {101.69 USD, 2025-03-03}
+  Assets:US:Vanguard:Cash                         -479.98 USD
+
+2025-03-03 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          3.927 RGAGX {183.34 USD, 2025-03-03}
+  Assets:US:Vanguard:Cash                         -719.98 USD
+
+2025-03-03 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.360 VBMPX {101.69 USD, 2025-03-03}
+  Assets:US:Vanguard:Cash                         -239.99 USD
+
+2025-03-03 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.964 RGAGX {183.34 USD, 2025-03-03}
+  Assets:US:Vanguard:Cash                         -360.08 USD
+
+2025-03-14 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2025-03-17 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.671 VBMPX {102.77 USD, 2025-03-17}
+  Assets:US:Vanguard:Cash                         -480.04 USD
+
+2025-03-17 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          3.871 RGAGX {186.01 USD, 2025-03-17}
+  Assets:US:Vanguard:Cash                         -720.04 USD
+
+2025-03-17 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.335 VBMPX {102.77 USD, 2025-03-17}
+  Assets:US:Vanguard:Cash                         -239.97 USD
+
+2025-03-17 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.935 RGAGX {186.01 USD, 2025-03-17}
+  Assets:US:Vanguard:Cash                         -359.93 USD
+
+2025-03-28 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2025-03-31 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.674 VBMPX {102.69 USD, 2025-03-31}
+  Assets:US:Vanguard:Cash                         -479.97 USD
+
+2025-03-31 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          3.830 RGAGX {187.99 USD, 2025-03-31}
+  Assets:US:Vanguard:Cash                         -720.00 USD
+
+2025-03-31 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.337 VBMPX {102.69 USD, 2025-03-31}
+  Assets:US:Vanguard:Cash                         -239.99 USD
+
+2025-03-31 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.915 RGAGX {187.99 USD, 2025-03-31}
+  Assets:US:Vanguard:Cash                         -360.00 USD
+
+2025-04-11 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2025-04-14 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.694 VBMPX {102.27 USD, 2025-04-14}
+  Assets:US:Vanguard:Cash                         -480.06 USD
+
+2025-04-14 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          3.831 RGAGX {187.93 USD, 2025-04-14}
+  Assets:US:Vanguard:Cash                         -719.96 USD
+
+2025-04-14 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.347 VBMPX {102.27 USD, 2025-04-14}
+  Assets:US:Vanguard:Cash                         -240.03 USD
+
+2025-04-14 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.916 RGAGX {187.93 USD, 2025-04-14}
+  Assets:US:Vanguard:Cash                         -360.07 USD
+
+2025-04-25 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2025-04-28 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.709 VBMPX {101.92 USD, 2025-04-28}
+  Assets:US:Vanguard:Cash                         -479.94 USD
+
+2025-04-28 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          3.795 RGAGX {189.69 USD, 2025-04-28}
+  Assets:US:Vanguard:Cash                         -719.87 USD
+
+2025-04-28 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.355 VBMPX {101.92 USD, 2025-04-28}
+  Assets:US:Vanguard:Cash                         -240.02 USD
+
+2025-04-28 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.898 RGAGX {189.69 USD, 2025-04-28}
+  Assets:US:Vanguard:Cash                         -360.03 USD
+
+2025-05-09 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2025-05-12 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.618 VBMPX {103.95 USD, 2025-05-12}
+  Assets:US:Vanguard:Cash                         -480.04 USD
+
+2025-05-12 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          3.830 RGAGX {187.98 USD, 2025-05-12}
+  Assets:US:Vanguard:Cash                         -719.96 USD
+
+2025-05-12 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.309 VBMPX {103.95 USD, 2025-05-12}
+  Assets:US:Vanguard:Cash                         -240.02 USD
+
+2025-05-12 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.915 RGAGX {187.98 USD, 2025-05-12}
+  Assets:US:Vanguard:Cash                         -359.98 USD
+
+2025-05-23 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2025-05-26 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.633 VBMPX {103.61 USD, 2025-05-26}
+  Assets:US:Vanguard:Cash                         -480.03 USD
+
+2025-05-26 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          3.903 RGAGX {184.48 USD, 2025-05-26}
+  Assets:US:Vanguard:Cash                         -720.03 USD
+
+2025-05-26 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.316 VBMPX {103.61 USD, 2025-05-26}
+  Assets:US:Vanguard:Cash                         -239.96 USD
+
+2025-05-26 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.951 RGAGX {184.48 USD, 2025-05-26}
+  Assets:US:Vanguard:Cash                         -359.92 USD
+
+2025-06-06 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2025-06-09 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.642 VBMPX {103.42 USD, 2025-06-09}
+  Assets:US:Vanguard:Cash                         -480.08 USD
+
+2025-06-09 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          3.986 RGAGX {180.67 USD, 2025-06-09}
+  Assets:US:Vanguard:Cash                         -720.15 USD
+
+2025-06-09 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.320 VBMPX {103.42 USD, 2025-06-09}
+  Assets:US:Vanguard:Cash                         -239.93 USD
+
+2025-06-09 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.992 RGAGX {180.67 USD, 2025-06-09}
+  Assets:US:Vanguard:Cash                         -359.89 USD
+
+2025-06-20 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2025-06-23 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.563 VBMPX {105.20 USD, 2025-06-23}
+  Assets:US:Vanguard:Cash                         -480.03 USD
+
+2025-06-23 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          3.788 RGAGX {190.10 USD, 2025-06-23}
+  Assets:US:Vanguard:Cash                         -720.10 USD
+
+2025-06-23 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.281 VBMPX {105.20 USD, 2025-06-23}
+  Assets:US:Vanguard:Cash                         -239.96 USD
+
+2025-06-23 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.894 RGAGX {190.10 USD, 2025-06-23}
+  Assets:US:Vanguard:Cash                         -360.05 USD
+
+2025-07-04 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2025-07-07 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.570 VBMPX {105.02 USD, 2025-07-07}
+  Assets:US:Vanguard:Cash                         -479.94 USD
+
+2025-07-07 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          3.663 RGAGX {196.53 USD, 2025-07-07}
+  Assets:US:Vanguard:Cash                         -719.89 USD
+
+2025-07-07 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.286 VBMPX {105.02 USD, 2025-07-07}
+  Assets:US:Vanguard:Cash                         -240.08 USD
+
+2025-07-07 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.832 RGAGX {196.53 USD, 2025-07-07}
+  Assets:US:Vanguard:Cash                         -360.04 USD
+
+2025-07-18 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2025-07-21 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.567 VBMPX {105.11 USD, 2025-07-21}
+  Assets:US:Vanguard:Cash                         -480.04 USD
+
+2025-07-21 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          3.587 RGAGX {200.73 USD, 2025-07-21}
+  Assets:US:Vanguard:Cash                         -720.02 USD
+
+2025-07-21 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.283 VBMPX {105.11 USD, 2025-07-21}
+  Assets:US:Vanguard:Cash                         -239.97 USD
+
+2025-07-21 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.793 RGAGX {200.73 USD, 2025-07-21}
+  Assets:US:Vanguard:Cash                         -359.91 USD
+
+2025-08-01 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          250.00 USD
+  Income:US:Hooli:Match401k                       -250.00 USD
+
+2025-08-04 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          1.877 VBMPX {106.58 USD, 2025-08-04}
+  Assets:US:Vanguard:Cash                         -200.05 USD
+
+2025-08-04 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.528 RGAGX {196.37 USD, 2025-08-04}
+  Assets:US:Vanguard:Cash                         -300.05 USD
+
+2025-08-04 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          0.938 VBMPX {106.58 USD, 2025-08-04}
+  Assets:US:Vanguard:Cash                          -99.97 USD
+
+2025-08-04 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          0.764 RGAGX {196.37 USD, 2025-08-04}
+  Assets:US:Vanguard:Cash                         -150.03 USD
+
+2026-01-02 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2026-01-05 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.659 VBMPX {103.03 USD, 2026-01-05}
+  Assets:US:Vanguard:Cash                         -480.02 USD
+
+2026-01-05 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          3.679 RGAGX {195.68 USD, 2026-01-05}
+  Assets:US:Vanguard:Cash                         -719.91 USD
+
+2026-01-05 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.329 VBMPX {103.03 USD, 2026-01-05}
+  Assets:US:Vanguard:Cash                         -239.96 USD
+
+2026-01-05 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.840 RGAGX {195.68 USD, 2026-01-05}
+  Assets:US:Vanguard:Cash                         -360.05 USD
+
+2026-01-16 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2026-01-19 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.895 VBMPX {98.07 USD, 2026-01-19}
+  Assets:US:Vanguard:Cash                         -480.05 USD
+
+2026-01-19 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          3.712 RGAGX {193.99 USD, 2026-01-19}
+  Assets:US:Vanguard:Cash                         -720.09 USD
+
+2026-01-19 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.447 VBMPX {98.07 USD, 2026-01-19}
+  Assets:US:Vanguard:Cash                         -239.98 USD
+
+2026-01-19 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.855 RGAGX {193.99 USD, 2026-01-19}
+  Assets:US:Vanguard:Cash                         -359.85 USD
+
+2026-01-30 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2026-02-02 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.797 VBMPX {100.07 USD, 2026-02-02}
+  Assets:US:Vanguard:Cash                         -480.04 USD
+
+2026-02-02 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          3.756 RGAGX {191.72 USD, 2026-02-02}
+  Assets:US:Vanguard:Cash                         -720.10 USD
+
+2026-02-02 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.398 VBMPX {100.07 USD, 2026-02-02}
+  Assets:US:Vanguard:Cash                         -239.97 USD
+
+2026-02-02 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.877 RGAGX {191.72 USD, 2026-02-02}
+  Assets:US:Vanguard:Cash                         -359.86 USD
+
+2026-02-13 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2026-02-16 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.823 VBMPX {99.53 USD, 2026-02-16}
+  Assets:US:Vanguard:Cash                         -480.03 USD
+
+2026-02-16 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          3.722 RGAGX {193.48 USD, 2026-02-16}
+  Assets:US:Vanguard:Cash                         -720.13 USD
+
+2026-02-16 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.411 VBMPX {99.53 USD, 2026-02-16}
+  Assets:US:Vanguard:Cash                         -239.97 USD
+
+2026-02-16 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.860 RGAGX {193.48 USD, 2026-02-16}
+  Assets:US:Vanguard:Cash                         -359.87 USD
+
+2026-02-27 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2026-03-02 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.722 VBMPX {101.65 USD, 2026-03-02}
+  Assets:US:Vanguard:Cash                         -479.99 USD
+
+2026-03-02 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          3.545 RGAGX {203.11 USD, 2026-03-02}
+  Assets:US:Vanguard:Cash                         -720.02 USD
+
+2026-03-02 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.361 VBMPX {101.65 USD, 2026-03-02}
+  Assets:US:Vanguard:Cash                         -240.00 USD
+
+2026-03-02 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.773 RGAGX {203.11 USD, 2026-03-02}
+  Assets:US:Vanguard:Cash                         -360.11 USD
+
+2026-03-13 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2026-03-16 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.677 VBMPX {102.62 USD, 2026-03-16}
+  Assets:US:Vanguard:Cash                         -479.95 USD
+
+2026-03-16 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          3.420 RGAGX {210.51 USD, 2026-03-16}
+  Assets:US:Vanguard:Cash                         -719.94 USD
+
+2026-03-16 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.339 VBMPX {102.62 USD, 2026-03-16}
+  Assets:US:Vanguard:Cash                         -240.03 USD
+
+2026-03-16 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.710 RGAGX {210.51 USD, 2026-03-16}
+  Assets:US:Vanguard:Cash                         -359.97 USD
+
+2026-03-27 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2026-03-30 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.622 VBMPX {103.86 USD, 2026-03-30}
+  Assets:US:Vanguard:Cash                         -480.04 USD
+
+2026-03-30 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          3.473 RGAGX {207.32 USD, 2026-03-30}
+  Assets:US:Vanguard:Cash                         -720.02 USD
+
+2026-03-30 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.311 VBMPX {103.86 USD, 2026-03-30}
+  Assets:US:Vanguard:Cash                         -240.02 USD
+
+2026-03-30 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.736 RGAGX {207.32 USD, 2026-03-30}
+  Assets:US:Vanguard:Cash                         -359.91 USD
+
+2026-04-10 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2026-04-13 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.558 VBMPX {105.31 USD, 2026-04-13}
+  Assets:US:Vanguard:Cash                         -480.00 USD
+
+2026-04-13 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          3.537 RGAGX {203.58 USD, 2026-04-13}
+  Assets:US:Vanguard:Cash                         -720.06 USD
+
+2026-04-13 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.279 VBMPX {105.31 USD, 2026-04-13}
+  Assets:US:Vanguard:Cash                         -240.00 USD
+
+2026-04-13 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.768 RGAGX {203.58 USD, 2026-04-13}
+  Assets:US:Vanguard:Cash                         -359.93 USD
+
+2026-04-24 * "Employer match for contribution"
+  Assets:US:Vanguard:Cash                          600.00 USD
+  Income:US:Hooli:Match401k                       -600.00 USD
+
+2026-04-27 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          4.518 VBMPX {106.24 USD, 2026-04-27}
+  Assets:US:Vanguard:Cash                         -479.99 USD
+
+2026-04-27 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          3.407 RGAGX {211.34 USD, 2026-04-27}
+  Assets:US:Vanguard:Cash                         -720.04 USD
+
+2026-04-27 * "Investing 40% of cash in VBMPX"
+  Assets:US:Vanguard:VBMPX                          2.259 VBMPX {106.24 USD, 2026-04-27}
+  Assets:US:Vanguard:Cash                         -240.00 USD
+
+2026-04-27 * "Investing 60% of cash in RGAGX"
+  Assets:US:Vanguard:RGAGX                          1.704 RGAGX {211.34 USD, 2026-04-27}
+  Assets:US:Vanguard:Cash                         -360.12 USD
+
+
+
+* Sources of Income
+
+2024-01-01 open Income:US:Hooli:Salary                      USD
+2024-01-01 open Income:US:Hooli:GroupTermLife               USD
+2024-01-01 open Income:US:Hooli:Vacation                    VACHR
+2024-01-01 open Assets:US:Hooli:Vacation                    VACHR
+2024-01-01 open Expenses:Vacation                               VACHR
+2024-01-01 open Expenses:Health:Life:GroupTermLife
+2024-01-01 open Expenses:Health:Medical:Insurance
+2024-01-01 open Expenses:Health:Dental:Insurance
+2024-01-01 open Expenses:Health:Vision:Insurance
+
+2024-01-01 event "employer" "Hooli, 1 Carloston Rd, Mountain Beer, CA"
+
+2024-01-04 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2024:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-01-18 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2024:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-02-01 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2024:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-02-15 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2024:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-02-29 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2024:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-03-14 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2024:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-03-28 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2024:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-04-11 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2024:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-04-25 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2024:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-05-09 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2024:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-05-23 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2024:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-06-06 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2024:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-06-20 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2024:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-07-04 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2024:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-07-18 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2024:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-08-01 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         2050.60 USD
+  Assets:US:Vanguard:Cash                          500.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                    -500.00 IRAUSD
+  Expenses:Taxes:Y2024:US:Federal:PreTax401k       500.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-08-15 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         2550.60 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   281.54 USD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-08-29 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         2550.60 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   281.54 USD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-09-12 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         2550.60 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   281.54 USD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-09-26 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         2550.60 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   281.54 USD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-10-10 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         2550.60 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   281.54 USD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-10-24 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         2550.60 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   281.54 USD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-11-07 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         2550.60 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   281.54 USD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-11-21 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         2550.60 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   281.54 USD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-12-05 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         2589.06 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                   243.08 USD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2024-12-19 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         2832.14 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2024:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2024:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2024:US:State                    365.08 USD
+  Expenses:Taxes:Y2024:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2024:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2024:US:SocSec                     0.00 USD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-01-02 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2025:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-01-16 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2025:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-01-30 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2025:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-02-13 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2025:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-02-27 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2025:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-03-13 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2025:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-03-27 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2025:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-04-10 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2025:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-04-24 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2025:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-05-08 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2025:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-05-22 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2025:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-06-05 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2025:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-06-19 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2025:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-07-03 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2025:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-07-17 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2025:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-07-31 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         2050.60 USD
+  Assets:US:Vanguard:Cash                          500.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                    -500.00 IRAUSD
+  Expenses:Taxes:Y2025:US:Federal:PreTax401k       500.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-08-14 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         2550.60 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   281.54 USD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-08-28 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         2550.60 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   281.54 USD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-09-11 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         2550.60 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   281.54 USD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-09-25 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         2550.60 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   281.54 USD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-10-09 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         2550.60 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   281.54 USD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-10-23 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         2550.60 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   281.54 USD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-11-06 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         2550.60 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   281.54 USD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-11-20 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         2550.60 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   281.54 USD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-12-04 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         2589.06 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                   243.08 USD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2025-12-18 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         2832.14 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2025:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2025:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2025:US:State                    365.08 USD
+  Expenses:Taxes:Y2025:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2025:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2025:US:SocSec                     0.00 USD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2026-01-01 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2026:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2026:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2026:US:State                    365.08 USD
+  Expenses:Taxes:Y2026:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2026:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2026:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2026:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2026-01-15 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2026:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2026:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2026:US:State                    365.08 USD
+  Expenses:Taxes:Y2026:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2026:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2026:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2026:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2026-01-29 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2026:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2026:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2026:US:State                    365.08 USD
+  Expenses:Taxes:Y2026:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2026:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2026:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2026:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2026-02-12 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2026:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2026:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2026:US:State                    365.08 USD
+  Expenses:Taxes:Y2026:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2026:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2026:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2026:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2026-02-26 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2026:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2026:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2026:US:State                    365.08 USD
+  Expenses:Taxes:Y2026:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2026:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2026:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2026:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2026-03-12 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2026:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2026:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2026:US:State                    365.08 USD
+  Expenses:Taxes:Y2026:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2026:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2026:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2026:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2026-03-26 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2026:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2026:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2026:US:State                    365.08 USD
+  Expenses:Taxes:Y2026:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2026:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2026:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2026:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2026-04-09 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2026:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2026:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2026:US:State                    365.08 USD
+  Expenses:Taxes:Y2026:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2026:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2026:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2026:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+2026-04-23 * "Hooli" "Payroll"
+  Assets:US:BofA:Checking                         1350.60 USD
+  Assets:US:Vanguard:Cash                         1200.00 USD
+  Income:US:Hooli:Salary                         -4615.38 USD
+  Income:US:Hooli:GroupTermLife                    -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2026:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2026:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2026:US:State                    365.08 USD
+  Expenses:Taxes:Y2026:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2026:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2026:US:SocSec                   281.54 USD
+  Assets:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2026:US:Federal:PreTax401k      1200.00 IRAUSD
+  Assets:US:Hooli:Vacation                              5 VACHR
+  Income:US:Hooli:Vacation                             -5 VACHR
+
+
+
+* Taxes
+
+1980-05-12 open Income:US:Federal:PreTax401k                    IRAUSD
+1980-05-12 open Assets:US:Federal:PreTax401k                    IRAUSD
+
+
+
+** Tax Year 2024
+
+2024-01-01 open Expenses:Taxes:Y2024:US:Federal:PreTax401k      IRAUSD
+2024-01-01 open Expenses:Taxes:Y2024:US:Medicare                USD
+2024-01-01 open Expenses:Taxes:Y2024:US:Federal                 USD
+2024-01-01 open Expenses:Taxes:Y2024:US:CityNYC                 USD
+2024-01-01 open Expenses:Taxes:Y2024:US:SDI                     USD
+2024-01-01 open Expenses:Taxes:Y2024:US:State                   USD
+2024-01-01 open Expenses:Taxes:Y2024:US:SocSec                  USD
+
+2024-01-01 balance Assets:US:Federal:PreTax401k         0 IRAUSD
+
+2024-01-01 * "Allowed contributions for one year"
+  Income:US:Federal:PreTax401k                     -18500 IRAUSD
+  Assets:US:Federal:PreTax401k                      18500 IRAUSD
+
+2025-03-22 * "Filing taxes for 2024"
+  Expenses:Taxes:Y2024:US:Federal                  600.04 USD
+  Expenses:Taxes:Y2024:US:State                    354.45 USD
+  Liabilities:AccountsPayable                     -954.49 USD
+
+2025-03-25 * "STATE TAX & FINANC PYMT"
+  Assets:US:BofA:Checking                         -354.45 USD
+  Liabilities:AccountsPayable                      354.45 USD
+
+2025-03-26 * "FEDERAL TAXPYMT"
+  Assets:US:BofA:Checking                         -600.04 USD
+  Liabilities:AccountsPayable                      600.04 USD
+
+
+
+** Tax Year 2025
+
+2025-01-01 open Expenses:Taxes:Y2025:US:Federal:PreTax401k      IRAUSD
+2025-01-01 open Expenses:Taxes:Y2025:US:Medicare                USD
+2025-01-01 open Expenses:Taxes:Y2025:US:Federal                 USD
+2025-01-01 open Expenses:Taxes:Y2025:US:CityNYC                 USD
+2025-01-01 open Expenses:Taxes:Y2025:US:SDI                     USD
+2025-01-01 open Expenses:Taxes:Y2025:US:State                   USD
+2025-01-01 open Expenses:Taxes:Y2025:US:SocSec                  USD
+
+2025-01-01 balance Assets:US:Federal:PreTax401k         0 IRAUSD
+
+2025-01-01 * "Allowed contributions for one year"
+  Income:US:Federal:PreTax401k                     -18500 IRAUSD
+  Assets:US:Federal:PreTax401k                      18500 IRAUSD
+
+2026-03-21 * "Filing taxes for 2025"
+  Expenses:Taxes:Y2025:US:Federal                  574.92 USD
+  Expenses:Taxes:Y2025:US:State                    311.96 USD
+  Liabilities:AccountsPayable                     -886.88 USD
+
+2026-03-22 * "FEDERAL TAXPYMT"
+  Assets:US:BofA:Checking                         -574.92 USD
+  Liabilities:AccountsPayable                      574.92 USD
+
+2026-03-25 * "STATE TAX & FINANC PYMT"
+  Assets:US:BofA:Checking                         -311.96 USD
+  Liabilities:AccountsPayable                      311.96 USD
+
+
+
+** Tax Year 2026
+
+2026-01-01 open Expenses:Taxes:Y2026:US:Federal:PreTax401k      IRAUSD
+2026-01-01 open Expenses:Taxes:Y2026:US:Medicare                USD
+2026-01-01 open Expenses:Taxes:Y2026:US:Federal                 USD
+2026-01-01 open Expenses:Taxes:Y2026:US:CityNYC                 USD
+2026-01-01 open Expenses:Taxes:Y2026:US:SDI                     USD
+2026-01-01 open Expenses:Taxes:Y2026:US:State                   USD
+2026-01-01 open Expenses:Taxes:Y2026:US:SocSec                  USD
+
+2026-01-01 balance Assets:US:Federal:PreTax401k         0 IRAUSD
+
+2026-01-01 * "Allowed contributions for one year"
+  Income:US:Federal:PreTax401k                     -18500 IRAUSD
+  Assets:US:Federal:PreTax401k                      18500 IRAUSD
+
+
+
+* Expenses
+
+1980-05-12 open Expenses:Food:Groceries
+1980-05-12 open Expenses:Food:Restaurant
+1980-05-12 open Expenses:Food:Coffee
+1980-05-12 open Expenses:Food:Alcohol
+1980-05-12 open Expenses:Transport:Tram
+1980-05-12 open Expenses:Home:Rent
+1980-05-12 open Expenses:Home:Electricity
+1980-05-12 open Expenses:Home:Internet
+1980-05-12 open Expenses:Home:Phone
+1980-05-12 open Expenses:Financial:Fees
+1980-05-12 open Expenses:Financial:Commissions
+
+
+
+* Prices
+
+2024-01-05 price VBMPX                             110.42 USD
+2024-01-05 price RGAGX                             135.10 USD
+2024-01-05 price ITOT                               72.97 USD
+2024-01-05 price VEA                                68.47 USD
+2024-01-05 price VHT                               195.75 USD
+2024-01-05 price GLD                               194.35 USD
+2024-01-12 price VBMPX                             111.28 USD
+2024-01-12 price RGAGX                             135.08 USD
+2024-01-12 price ITOT                               73.15 USD
+2024-01-12 price VEA                                67.72 USD
+2024-01-12 price VHT                               188.32 USD
+2024-01-12 price GLD                               192.66 USD
+2024-01-19 price VBMPX                             111.02 USD
+2024-01-19 price RGAGX                             135.86 USD
+2024-01-19 price ITOT                               73.45 USD
+2024-01-19 price VEA                                68.05 USD
+2024-01-19 price VHT                               180.67 USD
+2024-01-19 price GLD                               194.44 USD
+2024-01-26 price VBMPX                             113.67 USD
+2024-01-26 price RGAGX                             136.46 USD
+2024-01-26 price ITOT                               72.91 USD
+2024-01-26 price VEA                                67.96 USD
+2024-01-26 price VHT                               177.88 USD
+2024-01-26 price GLD                               198.21 USD
+2024-02-02 price VBMPX                             111.91 USD
+2024-02-02 price RGAGX                             139.91 USD
+2024-02-02 price ITOT                               76.09 USD
+2024-02-02 price VEA                                68.15 USD
+2024-02-02 price VHT                               170.41 USD
+2024-02-02 price GLD                               195.37 USD
+2024-02-09 price VBMPX                             111.21 USD
+2024-02-09 price RGAGX                             139.86 USD
+2024-02-09 price ITOT                               75.28 USD
+2024-02-09 price VEA                                68.57 USD
+2024-02-09 price VHT                               173.73 USD
+2024-02-09 price GLD                               198.72 USD
+2024-02-16 price VBMPX                             109.64 USD
+2024-02-16 price RGAGX                             134.91 USD
+2024-02-16 price ITOT                               74.60 USD
+2024-02-16 price VEA                                68.11 USD
+2024-02-16 price VHT                               169.56 USD
+2024-02-16 price GLD                               197.64 USD
+2024-02-23 price VBMPX                             107.22 USD
+2024-02-23 price RGAGX                             134.10 USD
+2024-02-23 price ITOT                               73.62 USD
+2024-02-23 price VEA                                67.95 USD
+2024-02-23 price VHT                               167.89 USD
+2024-02-23 price GLD                               198.29 USD
+2024-03-01 price VBMPX                             109.61 USD
+2024-03-01 price RGAGX                             132.62 USD
+2024-03-01 price ITOT                               73.63 USD
+2024-03-01 price VEA                                67.57 USD
+2024-03-01 price VHT                               167.66 USD
+2024-03-01 price GLD                               204.95 USD
+2024-03-08 price VBMPX                             108.08 USD
+2024-03-08 price RGAGX                             133.09 USD
+2024-03-08 price ITOT                               74.66 USD
+2024-03-08 price VEA                                68.92 USD
+2024-03-08 price VHT                               171.87 USD
+2024-03-08 price GLD                               204.20 USD
+2024-03-15 price VBMPX                             108.98 USD
+2024-03-15 price RGAGX                             132.79 USD
+2024-03-15 price ITOT                               73.16 USD
+2024-03-15 price VEA                                69.06 USD
+2024-03-15 price VHT                               171.22 USD
+2024-03-15 price GLD                               203.93 USD
+2024-03-22 price VBMPX                             110.26 USD
+2024-03-22 price RGAGX                             129.98 USD
+2024-03-22 price ITOT                               72.30 USD
+2024-03-22 price VEA                                68.45 USD
+2024-03-22 price VHT                               174.96 USD
+2024-03-22 price GLD                               205.30 USD
+2024-03-29 price VBMPX                             108.81 USD
+2024-03-29 price RGAGX                             129.80 USD
+2024-03-29 price ITOT                               74.20 USD
+2024-03-29 price VEA                                67.31 USD
+2024-03-29 price VHT                               172.11 USD
+2024-03-29 price GLD                               199.77 USD
+2024-04-05 price VBMPX                             110.32 USD
+2024-04-05 price RGAGX                             130.96 USD
+2024-04-05 price ITOT                               74.62 USD
+2024-04-05 price VEA                                68.17 USD
+2024-04-05 price VHT                               173.92 USD
+2024-04-05 price GLD                               201.46 USD
+2024-04-12 price VBMPX                             110.34 USD
+2024-04-12 price RGAGX                             135.61 USD
+2024-04-12 price ITOT                               73.82 USD
+2024-04-12 price VEA                                67.90 USD
+2024-04-12 price VHT                               170.02 USD
+2024-04-12 price GLD                               199.91 USD
+2024-04-19 price VBMPX                             110.14 USD
+2024-04-19 price RGAGX                             136.45 USD
+2024-04-19 price ITOT                               73.24 USD
+2024-04-19 price VEA                                68.44 USD
+2024-04-19 price VHT                               165.84 USD
+2024-04-19 price GLD                               204.09 USD
+2024-04-26 price VBMPX                             110.96 USD
+2024-04-26 price RGAGX                             136.38 USD
+2024-04-26 price ITOT                               72.83 USD
+2024-04-26 price VEA                                68.11 USD
+2024-04-26 price VHT                               161.64 USD
+2024-04-26 price GLD                               206.38 USD
+2024-05-03 price VBMPX                             112.28 USD
+2024-05-03 price RGAGX                             138.47 USD
+2024-05-03 price ITOT                               72.85 USD
+2024-05-03 price VEA                                68.80 USD
+2024-05-03 price VHT                               159.50 USD
+2024-05-03 price GLD                               207.35 USD
+2024-05-10 price VBMPX                             112.54 USD
+2024-05-10 price RGAGX                             141.18 USD
+2024-05-10 price ITOT                               73.19 USD
+2024-05-10 price VEA                                69.06 USD
+2024-05-10 price VHT                               160.85 USD
+2024-05-10 price GLD                               211.37 USD
+2024-05-17 price VBMPX                             113.63 USD
+2024-05-17 price RGAGX                             142.67 USD
+2024-05-17 price ITOT                               70.85 USD
+2024-05-17 price VEA                                68.89 USD
+2024-05-17 price VHT                               156.77 USD
+2024-05-17 price GLD                               219.54 USD
+2024-05-24 price VBMPX                             112.20 USD
+2024-05-24 price RGAGX                             142.65 USD
+2024-05-24 price ITOT                               71.78 USD
+2024-05-24 price VEA                                69.18 USD
+2024-05-24 price VHT                               158.51 USD
+2024-05-24 price GLD                               222.97 USD
+2024-05-31 price VBMPX                             111.27 USD
+2024-05-31 price RGAGX                             141.30 USD
+2024-05-31 price ITOT                               72.99 USD
+2024-05-31 price VEA                                67.70 USD
+2024-05-31 price VHT                               159.36 USD
+2024-05-31 price GLD                               220.75 USD
+2024-06-07 price VBMPX                             111.23 USD
+2024-06-07 price RGAGX                             144.04 USD
+2024-06-07 price ITOT                               74.83 USD
+2024-06-07 price VEA                                67.38 USD
+2024-06-07 price VHT                               159.38 USD
+2024-06-07 price GLD                               222.71 USD
+2024-06-14 price VBMPX                             110.25 USD
+2024-06-14 price RGAGX                             143.67 USD
+2024-06-14 price ITOT                               76.31 USD
+2024-06-14 price VEA                                67.13 USD
+2024-06-14 price VHT                               159.87 USD
+2024-06-14 price GLD                               223.81 USD
+2024-06-21 price VBMPX                             107.48 USD
+2024-06-21 price RGAGX                             146.92 USD
+2024-06-21 price ITOT                               77.03 USD
+2024-06-21 price VEA                                66.40 USD
+2024-06-21 price VHT                               158.71 USD
+2024-06-21 price GLD                               226.11 USD
+2024-06-28 price VBMPX                             107.44 USD
+2024-06-28 price RGAGX                             152.12 USD
+2024-06-28 price ITOT                               75.83 USD
+2024-06-28 price VEA                                67.77 USD
+2024-06-28 price VHT                               162.69 USD
+2024-06-28 price GLD                               230.43 USD
+2024-07-05 price VBMPX                             105.57 USD
+2024-07-05 price RGAGX                             151.81 USD
+2024-07-05 price ITOT                               77.56 USD
+2024-07-05 price VEA                                67.68 USD
+2024-07-05 price VHT                               158.81 USD
+2024-07-05 price GLD                               231.93 USD
+2024-07-12 price VBMPX                             102.79 USD
+2024-07-12 price RGAGX                             150.58 USD
+2024-07-12 price ITOT                               77.97 USD
+2024-07-12 price VEA                                67.98 USD
+2024-07-12 price VHT                               157.44 USD
+2024-07-12 price GLD                               230.96 USD
+2024-07-19 price VBMPX                             103.56 USD
+2024-07-19 price RGAGX                             152.61 USD
+2024-07-19 price ITOT                               76.02 USD
+2024-07-19 price VEA                                66.29 USD
+2024-07-19 price VHT                               157.99 USD
+2024-07-19 price GLD                               228.62 USD
+2024-07-26 price VBMPX                             102.94 USD
+2024-07-26 price RGAGX                             154.48 USD
+2024-07-26 price ITOT                               77.30 USD
+2024-07-26 price VEA                                66.48 USD
+2024-07-26 price VHT                               161.15 USD
+2024-07-26 price GLD                               223.78 USD
+2024-08-02 price VBMPX                             101.37 USD
+2024-08-02 price RGAGX                             151.87 USD
+2024-08-02 price ITOT                               75.88 USD
+2024-08-02 price VEA                                67.03 USD
+2024-08-02 price VHT                               162.33 USD
+2024-08-02 price GLD                               221.88 USD
+2024-08-09 price VBMPX                             101.64 USD
+2024-08-09 price RGAGX                             152.88 USD
+2024-08-09 price ITOT                               74.67 USD
+2024-08-09 price VEA                                67.25 USD
+2024-08-09 price VHT                               163.46 USD
+2024-08-09 price GLD                               221.28 USD
+2024-08-16 price VBMPX                             101.65 USD
+2024-08-16 price RGAGX                             156.09 USD
+2024-08-16 price ITOT                               76.18 USD
+2024-08-16 price VEA                                65.92 USD
+2024-08-16 price VHT                               165.81 USD
+2024-08-16 price GLD                               230.03 USD
+2024-08-23 price VBMPX                             100.37 USD
+2024-08-23 price RGAGX                             157.06 USD
+2024-08-23 price ITOT                               75.38 USD
+2024-08-23 price VEA                                66.76 USD
+2024-08-23 price VHT                               170.39 USD
+2024-08-23 price GLD                               234.58 USD
+2024-08-30 price VBMPX                             101.00 USD
+2024-08-30 price RGAGX                             159.53 USD
+2024-08-30 price ITOT                               75.73 USD
+2024-08-30 price VEA                                65.85 USD
+2024-08-30 price VHT                               167.73 USD
+2024-08-30 price GLD                               239.39 USD
+2024-09-06 price VBMPX                             100.97 USD
+2024-09-06 price RGAGX                             159.03 USD
+2024-09-06 price ITOT                               76.63 USD
+2024-09-06 price VEA                                66.39 USD
+2024-09-06 price VHT                               167.12 USD
+2024-09-06 price GLD                               247.24 USD
+2024-09-13 price VBMPX                             100.26 USD
+2024-09-13 price RGAGX                             154.21 USD
+2024-09-13 price ITOT                               75.95 USD
+2024-09-13 price VEA                                65.70 USD
+2024-09-13 price VHT                               160.51 USD
+2024-09-13 price GLD                               236.05 USD
+2024-09-20 price VBMPX                             100.90 USD
+2024-09-20 price RGAGX                             155.07 USD
+2024-09-20 price ITOT                               74.43 USD
+2024-09-20 price VEA                                66.46 USD
+2024-09-20 price VHT                               157.99 USD
+2024-09-20 price GLD                               237.41 USD
+2024-09-27 price VBMPX                             101.26 USD
+2024-09-27 price RGAGX                             158.05 USD
+2024-09-27 price ITOT                               74.64 USD
+2024-09-27 price VEA                                66.18 USD
+2024-09-27 price VHT                               156.96 USD
+2024-09-27 price GLD                               240.83 USD
+2024-10-04 price VBMPX                             100.02 USD
+2024-10-04 price RGAGX                             159.78 USD
+2024-10-04 price ITOT                               72.06 USD
+2024-10-04 price VEA                                67.27 USD
+2024-10-04 price VHT                               158.72 USD
+2024-10-04 price GLD                               238.92 USD
+2024-10-11 price VBMPX                             100.04 USD
+2024-10-11 price RGAGX                             158.17 USD
+2024-10-11 price ITOT                               72.41 USD
+2024-10-11 price VEA                                66.69 USD
+2024-10-11 price VHT                               155.73 USD
+2024-10-11 price GLD                               242.52 USD
+2024-10-18 price VBMPX                              99.49 USD
+2024-10-18 price RGAGX                             157.41 USD
+2024-10-18 price ITOT                               70.81 USD
+2024-10-18 price VEA                                66.41 USD
+2024-10-18 price VHT                               155.40 USD
+2024-10-18 price GLD                               258.18 USD
+2024-10-25 price VBMPX                              98.34 USD
+2024-10-25 price RGAGX                             159.13 USD
+2024-10-25 price ITOT                               71.19 USD
+2024-10-25 price VEA                                66.27 USD
+2024-10-25 price VHT                               152.66 USD
+2024-10-25 price GLD                               253.36 USD
+2024-11-01 price VBMPX                              97.21 USD
+2024-11-01 price RGAGX                             163.26 USD
+2024-11-01 price ITOT                               70.87 USD
+2024-11-01 price VEA                                66.27 USD
+2024-11-01 price VHT                               154.09 USD
+2024-11-01 price GLD                               249.98 USD
+2024-11-08 price VBMPX                              96.77 USD
+2024-11-08 price RGAGX                             163.82 USD
+2024-11-08 price ITOT                               72.49 USD
+2024-11-08 price VEA                                67.94 USD
+2024-11-08 price VHT                               161.68 USD
+2024-11-08 price GLD                               248.65 USD
+2024-11-15 price VBMPX                              96.59 USD
+2024-11-15 price RGAGX                             164.34 USD
+2024-11-15 price ITOT                               71.48 USD
+2024-11-15 price VEA                                69.05 USD
+2024-11-15 price VHT                               158.86 USD
+2024-11-15 price GLD                               248.35 USD
+2024-11-22 price VBMPX                              96.65 USD
+2024-11-22 price RGAGX                             166.93 USD
+2024-11-22 price ITOT                               70.57 USD
+2024-11-22 price VEA                                69.84 USD
+2024-11-22 price VHT                               159.12 USD
+2024-11-22 price GLD                               243.26 USD
+2024-11-29 price VBMPX                              97.98 USD
+2024-11-29 price RGAGX                             165.52 USD
+2024-11-29 price ITOT                               69.25 USD
+2024-11-29 price VEA                                71.63 USD
+2024-11-29 price VHT                               156.88 USD
+2024-11-29 price GLD                               238.58 USD
+2024-12-06 price VBMPX                              99.10 USD
+2024-12-06 price RGAGX                             168.83 USD
+2024-12-06 price ITOT                               70.52 USD
+2024-12-06 price VEA                                71.76 USD
+2024-12-06 price VHT                               152.23 USD
+2024-12-06 price GLD                               244.54 USD
+2024-12-13 price VBMPX                              98.15 USD
+2024-12-13 price RGAGX                             165.80 USD
+2024-12-13 price ITOT                               69.55 USD
+2024-12-13 price VEA                                71.81 USD
+2024-12-13 price VHT                               159.31 USD
+2024-12-13 price GLD                               243.88 USD
+2024-12-20 price VBMPX                              99.18 USD
+2024-12-20 price RGAGX                             168.15 USD
+2024-12-20 price ITOT                               69.13 USD
+2024-12-20 price VEA                                73.53 USD
+2024-12-20 price VHT                               160.17 USD
+2024-12-20 price GLD                               238.55 USD
+2024-12-27 price VBMPX                              98.49 USD
+2024-12-27 price RGAGX                             171.10 USD
+2024-12-27 price ITOT                               67.63 USD
+2024-12-27 price VEA                                73.78 USD
+2024-12-27 price VHT                               166.08 USD
+2024-12-27 price GLD                               235.71 USD
+2025-01-03 price VBMPX                              98.18 USD
+2025-01-03 price RGAGX                             178.07 USD
+2025-01-03 price ITOT                               69.31 USD
+2025-01-03 price VEA                                73.93 USD
+2025-01-03 price VHT                               167.56 USD
+2025-01-03 price GLD                               237.69 USD
+2025-01-10 price VBMPX                              96.46 USD
+2025-01-10 price RGAGX                             181.43 USD
+2025-01-10 price ITOT                               69.13 USD
+2025-01-10 price VEA                                73.39 USD
+2025-01-10 price VHT                               169.74 USD
+2025-01-10 price GLD                               239.70 USD
+2025-01-17 price VBMPX                              96.69 USD
+2025-01-17 price RGAGX                             185.85 USD
+2025-01-17 price ITOT                               67.04 USD
+2025-01-17 price VEA                                73.00 USD
+2025-01-17 price VHT                               170.48 USD
+2025-01-17 price GLD                               243.71 USD
+2025-01-24 price VBMPX                              96.55 USD
+2025-01-24 price RGAGX                             189.40 USD
+2025-01-24 price ITOT                               67.00 USD
+2025-01-24 price VEA                                73.67 USD
+2025-01-24 price VHT                               172.60 USD
+2025-01-24 price GLD                               244.97 USD
+2025-01-31 price VBMPX                              97.56 USD
+2025-01-31 price RGAGX                             189.00 USD
+2025-01-31 price ITOT                               67.47 USD
+2025-01-31 price VEA                                73.37 USD
+2025-01-31 price VHT                               181.62 USD
+2025-01-31 price GLD                               245.70 USD
+2025-02-07 price VBMPX                              99.77 USD
+2025-02-07 price RGAGX                             186.12 USD
+2025-02-07 price ITOT                               67.00 USD
+2025-02-07 price VEA                                74.25 USD
+2025-02-07 price VHT                               187.34 USD
+2025-02-07 price GLD                               242.81 USD
+2025-02-14 price VBMPX                              99.17 USD
+2025-02-14 price RGAGX                             187.46 USD
+2025-02-14 price ITOT                               67.23 USD
+2025-02-14 price VEA                                74.23 USD
+2025-02-14 price VHT                               185.98 USD
+2025-02-14 price GLD                               240.61 USD
+2025-02-21 price VBMPX                             100.44 USD
+2025-02-21 price RGAGX                             184.40 USD
+2025-02-21 price ITOT                               67.47 USD
+2025-02-21 price VEA                                75.09 USD
+2025-02-21 price VHT                               189.21 USD
+2025-02-21 price GLD                               236.38 USD
+2025-02-28 price VBMPX                             101.69 USD
+2025-02-28 price RGAGX                             183.34 USD
+2025-02-28 price ITOT                               66.77 USD
+2025-02-28 price VEA                                75.61 USD
+2025-02-28 price VHT                               185.69 USD
+2025-02-28 price GLD                               240.87 USD
+2025-03-07 price VBMPX                             102.07 USD
+2025-03-07 price RGAGX                             185.37 USD
+2025-03-07 price ITOT                               68.32 USD
+2025-03-07 price VEA                                78.65 USD
+2025-03-07 price VHT                               184.10 USD
+2025-03-07 price GLD                               241.22 USD
+2025-03-14 price VBMPX                             102.77 USD
+2025-03-14 price RGAGX                             186.01 USD
+2025-03-14 price ITOT                               70.37 USD
+2025-03-14 price VEA                                78.33 USD
+2025-03-14 price VHT                               186.67 USD
+2025-03-14 price GLD                               246.69 USD
+2025-03-21 price VBMPX                             103.29 USD
+2025-03-21 price RGAGX                             187.48 USD
+2025-03-21 price ITOT                               72.73 USD
+2025-03-21 price VEA                                78.59 USD
+2025-03-21 price VHT                               179.28 USD
+2025-03-21 price GLD                               247.02 USD
+2025-03-28 price VBMPX                             102.69 USD
+2025-03-28 price RGAGX                             187.99 USD
+2025-03-28 price ITOT                               73.85 USD
+2025-03-28 price VEA                                78.69 USD
+2025-03-28 price VHT                               176.89 USD
+2025-03-28 price GLD                               249.35 USD
+2025-04-04 price VBMPX                             103.51 USD
+2025-04-04 price RGAGX                             191.51 USD
+2025-04-04 price ITOT                               74.28 USD
+2025-04-04 price VEA                                79.22 USD
+2025-04-04 price VHT                               177.21 USD
+2025-04-04 price GLD                               248.76 USD
+2025-04-11 price VBMPX                             102.27 USD
+2025-04-11 price RGAGX                             187.93 USD
+2025-04-11 price ITOT                               74.28 USD
+2025-04-11 price VEA                                79.09 USD
+2025-04-11 price VHT                               177.85 USD
+2025-04-11 price GLD                               245.15 USD
+2025-04-18 price VBMPX                             101.96 USD
+2025-04-18 price RGAGX                             186.16 USD
+2025-04-18 price ITOT                               74.13 USD
+2025-04-18 price VEA                                77.63 USD
+2025-04-18 price VHT                               177.73 USD
+2025-04-18 price GLD                               248.20 USD
+2025-04-25 price VBMPX                             101.92 USD
+2025-04-25 price RGAGX                             189.69 USD
+2025-04-25 price ITOT                               74.86 USD
+2025-04-25 price VEA                                76.81 USD
+2025-04-25 price VHT                               175.84 USD
+2025-04-25 price GLD                               247.41 USD
+2025-05-02 price VBMPX                             103.25 USD
+2025-05-02 price RGAGX                             186.06 USD
+2025-05-02 price ITOT                               75.39 USD
+2025-05-02 price VEA                                76.16 USD
+2025-05-02 price VHT                               173.21 USD
+2025-05-02 price GLD                               248.83 USD
+2025-05-09 price VBMPX                             103.95 USD
+2025-05-09 price RGAGX                             187.98 USD
+2025-05-09 price ITOT                               73.38 USD
+2025-05-09 price VEA                                77.17 USD
+2025-05-09 price VHT                               173.89 USD
+2025-05-09 price GLD                               244.96 USD
+2025-05-16 price VBMPX                             103.80 USD
+2025-05-16 price RGAGX                             189.96 USD
+2025-05-16 price ITOT                               75.41 USD
+2025-05-16 price VEA                                75.90 USD
+2025-05-16 price VHT                               170.33 USD
+2025-05-16 price GLD                               248.42 USD
+2025-05-23 price VBMPX                             103.61 USD
+2025-05-23 price RGAGX                             184.48 USD
+2025-05-23 price ITOT                               74.10 USD
+2025-05-23 price VEA                                76.88 USD
+2025-05-23 price VHT                               170.28 USD
+2025-05-23 price GLD                               261.14 USD
+2025-05-30 price VBMPX                             103.75 USD
+2025-05-30 price RGAGX                             181.93 USD
+2025-05-30 price ITOT                               74.63 USD
+2025-05-30 price VEA                                76.97 USD
+2025-05-30 price VHT                               172.49 USD
+2025-05-30 price GLD                               264.29 USD
+2025-06-06 price VBMPX                             103.42 USD
+2025-06-06 price RGAGX                             180.67 USD
+2025-06-06 price ITOT                               76.73 USD
+2025-06-06 price VEA                                77.79 USD
+2025-06-06 price VHT                               173.52 USD
+2025-06-06 price GLD                               252.41 USD
+2025-06-13 price VBMPX                             103.50 USD
+2025-06-13 price RGAGX                             186.15 USD
+2025-06-13 price ITOT                               77.03 USD
+2025-06-13 price VEA                                77.42 USD
+2025-06-13 price VHT                               176.63 USD
+2025-06-13 price GLD                               261.81 USD
+2025-06-20 price VBMPX                             105.20 USD
+2025-06-20 price RGAGX                             190.10 USD
+2025-06-20 price ITOT                               79.07 USD
+2025-06-20 price VEA                                79.13 USD
+2025-06-20 price VHT                               168.48 USD
+2025-06-20 price GLD                               261.98 USD
+2025-06-27 price VBMPX                             105.36 USD
+2025-06-27 price RGAGX                             192.89 USD
+2025-06-27 price ITOT                               80.77 USD
+2025-06-27 price VEA                                78.55 USD
+2025-06-27 price VHT                               163.21 USD
+2025-06-27 price GLD                               266.17 USD
+2025-07-04 price VBMPX                             105.02 USD
+2025-07-04 price RGAGX                             196.53 USD
+2025-07-04 price ITOT                               81.40 USD
+2025-07-04 price VEA                                78.70 USD
+2025-07-04 price VHT                               164.13 USD
+2025-07-04 price GLD                               265.81 USD
+2025-07-11 price VBMPX                             105.02 USD
+2025-07-11 price RGAGX                             199.95 USD
+2025-07-11 price ITOT                               84.88 USD
+2025-07-11 price VEA                                79.80 USD
+2025-07-11 price VHT                               164.48 USD
+2025-07-11 price GLD                               266.45 USD
+2025-07-18 price VBMPX                             105.11 USD
+2025-07-18 price RGAGX                             200.73 USD
+2025-07-18 price ITOT                               85.01 USD
+2025-07-18 price VEA                                80.20 USD
+2025-07-18 price VHT                               165.17 USD
+2025-07-18 price GLD                               270.93 USD
+2025-07-25 price VBMPX                             107.21 USD
+2025-07-25 price RGAGX                             196.91 USD
+2025-07-25 price ITOT                               84.81 USD
+2025-07-25 price VEA                                81.54 USD
+2025-07-25 price VHT                               166.64 USD
+2025-07-25 price GLD                               278.52 USD
+2025-08-01 price VBMPX                             106.58 USD
+2025-08-01 price RGAGX                             196.37 USD
+2025-08-01 price ITOT                               87.58 USD
+2025-08-01 price VEA                                80.03 USD
+2025-08-01 price VHT                               167.26 USD
+2025-08-01 price GLD                               275.37 USD
+2025-08-08 price VBMPX                             108.11 USD
+2025-08-08 price RGAGX                             202.73 USD
+2025-08-08 price ITOT                               85.02 USD
+2025-08-08 price VEA                                80.12 USD
+2025-08-08 price VHT                               165.59 USD
+2025-08-08 price GLD                               271.61 USD
+2025-08-15 price VBMPX                             108.40 USD
+2025-08-15 price RGAGX                             201.67 USD
+2025-08-15 price ITOT                               84.91 USD
+2025-08-15 price VEA                                80.37 USD
+2025-08-15 price VHT                               162.74 USD
+2025-08-15 price GLD                               284.39 USD
+2025-08-22 price VBMPX                             108.35 USD
+2025-08-22 price RGAGX                             201.61 USD
+2025-08-22 price ITOT                               83.28 USD
+2025-08-22 price VEA                                79.38 USD
+2025-08-22 price VHT                               162.36 USD
+2025-08-22 price GLD                               286.57 USD
+2025-08-29 price VBMPX                             106.73 USD
+2025-08-29 price RGAGX                             205.83 USD
+2025-08-29 price ITOT                               83.62 USD
+2025-08-29 price VEA                                79.17 USD
+2025-08-29 price VHT                               162.87 USD
+2025-08-29 price GLD                               290.54 USD
+2025-09-05 price VBMPX                             104.91 USD
+2025-09-05 price RGAGX                             202.79 USD
+2025-09-05 price ITOT                               81.40 USD
+2025-09-05 price VEA                                80.90 USD
+2025-09-05 price VHT                               162.02 USD
+2025-09-05 price GLD                               288.05 USD
+2025-09-12 price VBMPX                             103.31 USD
+2025-09-12 price RGAGX                             199.03 USD
+2025-09-12 price ITOT                               81.91 USD
+2025-09-12 price VEA                                81.26 USD
+2025-09-12 price VHT                               166.77 USD
+2025-09-12 price GLD                               285.81 USD
+2025-09-19 price VBMPX                             101.75 USD
+2025-09-19 price RGAGX                             202.30 USD
+2025-09-19 price ITOT                               82.06 USD
+2025-09-19 price VEA                                81.17 USD
+2025-09-19 price VHT                               166.79 USD
+2025-09-19 price GLD                               284.93 USD
+2025-09-26 price VBMPX                             102.62 USD
+2025-09-26 price RGAGX                             199.35 USD
+2025-09-26 price ITOT                               81.78 USD
+2025-09-26 price VEA                                82.46 USD
+2025-09-26 price VHT                               165.55 USD
+2025-09-26 price GLD                               287.67 USD
+2025-10-03 price VBMPX                             101.14 USD
+2025-10-03 price RGAGX                             196.78 USD
+2025-10-03 price ITOT                               82.91 USD
+2025-10-03 price VEA                                83.16 USD
+2025-10-03 price VHT                               165.88 USD
+2025-10-03 price GLD                               289.64 USD
+2025-10-10 price VBMPX                             101.27 USD
+2025-10-10 price RGAGX                             197.43 USD
+2025-10-10 price ITOT                               81.50 USD
+2025-10-10 price VEA                                84.70 USD
+2025-10-10 price VHT                               163.70 USD
+2025-10-10 price GLD                               284.65 USD
+2025-10-17 price VBMPX                              99.41 USD
+2025-10-17 price RGAGX                             197.84 USD
+2025-10-17 price ITOT                               81.79 USD
+2025-10-17 price VEA                                84.39 USD
+2025-10-17 price VHT                               166.29 USD
+2025-10-17 price GLD                               288.07 USD
+2025-10-24 price VBMPX                              99.48 USD
+2025-10-24 price RGAGX                             198.00 USD
+2025-10-24 price ITOT                               82.02 USD
+2025-10-24 price VEA                                84.03 USD
+2025-10-24 price VHT                               162.68 USD
+2025-10-24 price GLD                               292.04 USD
+2025-10-31 price VBMPX                             100.94 USD
+2025-10-31 price RGAGX                             199.46 USD
+2025-10-31 price ITOT                               81.80 USD
+2025-10-31 price VEA                                84.40 USD
+2025-10-31 price VHT                               161.91 USD
+2025-10-31 price GLD                               290.43 USD
+2025-11-07 price VBMPX                             100.81 USD
+2025-11-07 price RGAGX                             200.20 USD
+2025-11-07 price ITOT                               82.10 USD
+2025-11-07 price VEA                                83.73 USD
+2025-11-07 price VHT                               159.56 USD
+2025-11-07 price GLD                               287.41 USD
+2025-11-14 price VBMPX                             101.91 USD
+2025-11-14 price RGAGX                             196.20 USD
+2025-11-14 price ITOT                               80.60 USD
+2025-11-14 price VEA                                84.12 USD
+2025-11-14 price VHT                               161.47 USD
+2025-11-14 price GLD                               290.20 USD
+2025-11-21 price VBMPX                             102.69 USD
+2025-11-21 price RGAGX                             191.57 USD
+2025-11-21 price ITOT                               77.71 USD
+2025-11-21 price VEA                                84.27 USD
+2025-11-21 price VHT                               156.97 USD
+2025-11-21 price GLD                               288.49 USD
+2025-11-28 price VBMPX                             103.05 USD
+2025-11-28 price RGAGX                             194.03 USD
+2025-11-28 price ITOT                               78.45 USD
+2025-11-28 price VEA                                83.01 USD
+2025-11-28 price VHT                               161.42 USD
+2025-11-28 price GLD                               302.36 USD
+2025-12-05 price VBMPX                             105.35 USD
+2025-12-05 price RGAGX                             196.54 USD
+2025-12-05 price ITOT                               78.26 USD
+2025-12-05 price VEA                                84.45 USD
+2025-12-05 price VHT                               157.23 USD
+2025-12-05 price GLD                               306.19 USD
+2025-12-12 price VBMPX                             101.62 USD
+2025-12-12 price RGAGX                             198.01 USD
+2025-12-12 price ITOT                               79.14 USD
+2025-12-12 price VEA                                85.78 USD
+2025-12-12 price VHT                               152.83 USD
+2025-12-12 price GLD                               306.34 USD
+2025-12-19 price VBMPX                             101.22 USD
+2025-12-19 price RGAGX                             196.82 USD
+2025-12-19 price ITOT                               76.64 USD
+2025-12-19 price VEA                                85.84 USD
+2025-12-19 price VHT                               146.35 USD
+2025-12-19 price GLD                               301.55 USD
+2025-12-26 price VBMPX                             102.35 USD
+2025-12-26 price RGAGX                             196.17 USD
+2025-12-26 price ITOT                               76.77 USD
+2025-12-26 price VEA                                87.11 USD
+2025-12-26 price VHT                               143.09 USD
+2025-12-26 price GLD                               300.38 USD
+2026-01-02 price VBMPX                             103.03 USD
+2026-01-02 price RGAGX                             195.68 USD
+2026-01-02 price ITOT                               78.36 USD
+2026-01-02 price VEA                                88.06 USD
+2026-01-02 price VHT                               141.64 USD
+2026-01-02 price GLD                               301.25 USD
+2026-01-09 price VBMPX                             101.10 USD
+2026-01-09 price RGAGX                             195.26 USD
+2026-01-09 price ITOT                               78.81 USD
+2026-01-09 price VEA                                86.27 USD
+2026-01-09 price VHT                               143.89 USD
+2026-01-09 price GLD                               304.97 USD
+2026-01-16 price VBMPX                              98.07 USD
+2026-01-16 price RGAGX                             193.99 USD
+2026-01-16 price ITOT                               78.23 USD
+2026-01-16 price VEA                                86.62 USD
+2026-01-16 price VHT                               143.80 USD
+2026-01-16 price GLD                               303.33 USD
+2026-01-23 price VBMPX                              99.30 USD
+2026-01-23 price RGAGX                             190.70 USD
+2026-01-23 price ITOT                               78.14 USD
+2026-01-23 price VEA                                87.48 USD
+2026-01-23 price VHT                               145.43 USD
+2026-01-23 price GLD                               304.14 USD
+2026-01-30 price VBMPX                             100.07 USD
+2026-01-30 price RGAGX                             191.72 USD
+2026-01-30 price ITOT                               77.06 USD
+2026-01-30 price VEA                                86.54 USD
+2026-01-30 price VHT                               146.49 USD
+2026-01-30 price GLD                               305.68 USD
+2026-02-06 price VBMPX                              99.81 USD
+2026-02-06 price RGAGX                             195.58 USD
+2026-02-06 price ITOT                               76.45 USD
+2026-02-06 price VEA                                86.83 USD
+2026-02-06 price VHT                               147.27 USD
+2026-02-06 price GLD                               295.07 USD
+2026-02-13 price VBMPX                              99.53 USD
+2026-02-13 price RGAGX                             193.48 USD
+2026-02-13 price ITOT                               75.93 USD
+2026-02-13 price VEA                                86.89 USD
+2026-02-13 price VHT                               148.76 USD
+2026-02-13 price GLD                               297.82 USD
+2026-02-20 price VBMPX                             101.65 USD
+2026-02-20 price RGAGX                             200.14 USD
+2026-02-20 price ITOT                               74.72 USD
+2026-02-20 price VEA                                87.80 USD
+2026-02-20 price VHT                               153.25 USD
+2026-02-20 price GLD                               292.25 USD
+2026-02-27 price VBMPX                             101.65 USD
+2026-02-27 price RGAGX                             203.11 USD
+2026-02-27 price ITOT                               76.49 USD
+2026-02-27 price VEA                                87.64 USD
+2026-02-27 price VHT                               152.03 USD
+2026-02-27 price GLD                               289.44 USD
+2026-03-06 price VBMPX                             102.62 USD
+2026-03-06 price RGAGX                             204.43 USD
+2026-03-06 price ITOT                               73.74 USD
+2026-03-06 price VEA                                89.02 USD
+2026-03-06 price VHT                               147.04 USD
+2026-03-06 price GLD                               285.85 USD
+2026-03-13 price VBMPX                             102.62 USD
+2026-03-13 price RGAGX                             210.51 USD
+2026-03-13 price ITOT                               73.86 USD
+2026-03-13 price VEA                                88.03 USD
+2026-03-13 price VHT                               145.03 USD
+2026-03-13 price GLD                               279.95 USD
+2026-03-20 price VBMPX                             102.39 USD
+2026-03-20 price RGAGX                             213.29 USD
+2026-03-20 price ITOT                               74.58 USD
+2026-03-20 price VEA                                87.57 USD
+2026-03-20 price VHT                               147.52 USD
+2026-03-20 price GLD                               276.44 USD
+2026-03-27 price VBMPX                             103.86 USD
+2026-03-27 price RGAGX                             207.32 USD
+2026-03-27 price ITOT                               73.84 USD
+2026-03-27 price VEA                                87.78 USD
+2026-03-27 price VHT                               150.91 USD
+2026-03-27 price GLD                               275.90 USD
+2026-04-03 price VBMPX                             103.87 USD
+2026-04-03 price RGAGX                             206.27 USD
+2026-04-03 price ITOT                               73.17 USD
+2026-04-03 price VEA                                88.36 USD
+2026-04-03 price VHT                               148.18 USD
+2026-04-03 price GLD                               274.24 USD
+2026-04-10 price VBMPX                             105.31 USD
+2026-04-10 price RGAGX                             203.58 USD
+2026-04-10 price ITOT                               73.76 USD
+2026-04-10 price VEA                                87.70 USD
+2026-04-10 price VHT                               151.48 USD
+2026-04-10 price GLD                               276.87 USD
+2026-04-17 price VBMPX                             105.58 USD
+2026-04-17 price RGAGX                             208.74 USD
+2026-04-17 price ITOT                               74.15 USD
+2026-04-17 price VEA                                87.50 USD
+2026-04-17 price VHT                               156.67 USD
+2026-04-17 price GLD                               271.67 USD
+2026-04-24 price VBMPX                             106.24 USD
+2026-04-24 price RGAGX                             211.34 USD
+2026-04-24 price ITOT                               74.47 USD
+2026-04-24 price VEA                                86.99 USD
+2026-04-24 price VHT                               156.61 USD
+2026-04-24 price GLD                               270.65 USD
+2026-05-01 price VBMPX                             106.44 USD
+2026-05-01 price RGAGX                             206.86 USD
+2026-05-01 price ITOT                               72.92 USD
+2026-05-01 price VEA                                87.82 USD
+2026-05-01 price VHT                               154.00 USD
+2026-05-01 price GLD                               260.11 USD
+
+
+
+* Cash
+


### PR DESCRIPTION
## Summary

Beancount's documented semantics: \`balance\` directives apply at the **beginning** of their date. doppio's \`sort_entries_by_date\` was naïve about this -- a same-date \`balance\` directive that came AFTER a transaction in source order would fire after the transaction's effects, giving the wrong assertion result.

Surfaced concretely in bean-example, which has 2026-01-01 entries in source order:

1. Hooli payroll transaction (deducts -1200 IRAUSD from PreTax401k)
2. \`balance Assets:US:Federal:PreTax401k 0 IRAUSD\`
3. "Allowed contributions for one year" (+18500 IRAUSD)

Stable date-sort kept this order. The Jan 1 payroll deducted -1200 *before* the assertion fired, so the assertion saw -1200 instead of 0.

Closes #212.

## Implementation

Extend the date-sort key from \`Option<Date>\` to a composite \`(Option<Date>, SameDayOrder)\`. Within a date:

\`\`\`
Pad < Balance < During (transactions, prices, etc.)
\`\`\`

- **Pad** sorts before **Balance** so a same-date pad-and-balance pair correctly fills the gap (#147's pad evaluator path stays intact).
- **Balance** sorts before **During**, so balance assertions fire at the *start* of the date.
- Stable-within-bucket preserves source order for transactions on a given date.

Localized fix: just \`grammars/beancount/mod.rs\`, no AST or elaborator changes.

## Vendored bean-example

Together with #210 (cost-basis balance for ledger/Beancount), this closes every elaboration error in \`bean-example --seed 42\` -- a realistic multi-year personal-finance journal generated by Beancount's own tooling: payroll, 401k contributions in IRAUSD tracker, brokerage buys/sells with cost basis, currency conversions, fiscal-year balance assertions.

Vendored as \`tests/parity/bean-example.beancount\` with a header recording the regeneration command + version pin (\`beancount==3.2.0\`, matching the CI workflow).

## Parity-harness change

\`beancount_balances\` in \`scripts/parity_check.py\` now aggregates per-lot positions into a single (account, commodity, total) tuple before comparison. Beancount tracks lots individually (so an account with three ITOT purchases at different costs has three position rows for the same currency); doppio reports the aggregate.

Per-lot inventory fidelity is a separate concern (#185); this change ensures the existing sum-across-lots equivalence is captured by the harness without false-positive mismatches.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo test --workspace\` (287 doppio lib + 49 elaborator + ...; all green; no test changes)
- [x] Parity: 7 positive (incl. new \`beancount:example\`), 3 negative; all green locally
- [x] \`bean-check tests/parity/bean-example.beancount\` (passes natively)

## Investigation chain

\`bean-example\` surfaced multiple gaps over the past few PRs:

- #198 -- per-transaction balance tolerance (cleared sub-cent residuals)
- #210 -- per-frontend lot {cost}/@price balance semantics (cleared the Sell-AAPL 116 USD residual)
- **#212 (this PR)** -- same-day directive ordering (clears the Jan 1 PreTax401k IRAUSD assertion)

After this lands, the \`bean-example\` corpus is fully agreed between doppio and bean-check; future bean-example regenerations against new beancount versions are a natural smoke test for the broader Beancount frontend.