### PR TITLE
hierarchy: subtree-aware balance for Beancount and hledger ==* (#214)

### DIFF
--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -376,6 +376,7 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
         let tolerance_mode = value.global_context.tolerance_mode;
         let tolerance_overrides = value.global_context.tolerance_overrides.clone();
         let balance_mode = value.global_context.balance_mode.clone();
+        let assertion_scope = value.global_context.assertion_scope;
 
         for entry in value.entries {
             let entry_context = &value.contexts[entry.context_id];
@@ -403,12 +404,27 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                         )?;
 
                     // Look up the account's current balance for this commodity.
-                    let mut actual_amount = state
-                        .account_balances
-                        .get(&assertion.account)
-                        .and_then(|ab| ab.commodity.get(&expected_commodity))
-                        .copied()
-                        .unwrap_or(Decimal::ZERO);
+                    // Beancount's `balance` directive aggregates the entire account
+                    // subtree (parent + every descendant); ledger-cli/hledger's
+                    // posting-level `=`/`==` and the doppio-extended top-level form
+                    // check the named account in isolation. The frontend selects via
+                    // [`crate::resolution::AssertionScope`]. A pending pad on the
+                    // same account uses the same lookup so the synthesized
+                    // pad amount is the residual against the right scope.
+                    let mut actual_amount = match assertion_scope {
+                        crate::resolution::AssertionScope::Direct => state
+                            .account_balances
+                            .get(&assertion.account)
+                            .and_then(|ab| ab.commodity.get(&expected_commodity))
+                            .copied()
+                            .unwrap_or(Decimal::ZERO),
+                        crate::resolution::AssertionScope::Subtree => {
+                            subtree_commodity_balance(&state.account_balances, &assertion.account)
+                                .get(&expected_commodity)
+                                .copied()
+                                .unwrap_or(Decimal::ZERO)
+                        }
+                    };
 
                     // If a pad on this account is pending, synthesize a
                     // balancing transaction (back-dated to the pad's date)
@@ -765,29 +781,17 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                                         &state,
                                     )?;
 
-                                    // Aggregate the named account *and its subtree* (every
-                                    // account whose name has `account_name + ":"` as a prefix).
-                                    // hledger's `==*` operates on the entire subtree, not just
-                                    // the named account: e.g. `Income ==* 0` zeroes the whole
-                                    // `Income:*` subtree by synthesizing a corrective posting
-                                    // on `Income` itself.
-                                    let prefix = format!("{account_name}:");
-                                    let mut subtree_totals: BTreeMap<String, Decimal> =
-                                        BTreeMap::new();
-                                    for (name, balances) in &state.account_balances {
-                                        if name == &account_name || name.starts_with(&prefix) {
-                                            for (c, v) in &balances.commodity {
-                                                if !v.is_zero() {
-                                                    *subtree_totals
-                                                        .entry(c.clone())
-                                                        .or_default() += *v;
-                                                }
-                                            }
-                                        }
-                                    }
-                                    let deltas: Vec<(String, Decimal)> = subtree_totals
+                                    // Aggregate the named account *and its subtree*. hledger's
+                                    // `==*` operates on the entire subtree, not just the named
+                                    // account: e.g. `Income ==* 0` zeroes the whole `Income:*`
+                                    // subtree by synthesizing a corrective posting on `Income`
+                                    // itself.
+                                    let deltas: Vec<(String, Decimal)> =
+                                        subtree_commodity_balance(
+                                            &state.account_balances,
+                                            &account_name,
+                                        )
                                         .into_iter()
-                                        .filter(|(_, v)| !v.is_zero())
                                         .map(|(c, v)| (c, target_value - v))
                                         .collect();
 
@@ -1326,6 +1330,46 @@ fn ancestor_prefixes(name: &str) -> Vec<String> {
     }
     prefixes.push(name.to_string());
     prefixes
+}
+
+/// Visit `account` itself (if present in `map`) and every descendant
+/// whose name has `account + ":"` as a prefix, in lexicographic order.
+///
+/// Account names are colon-separated paths. With keys held in a flat
+/// `BTreeMap<String, _>`, the subtree is exactly the half-open range
+/// `[account + ":", account + ";")`: `:` is `0x3A` and `;` is `0x3B`,
+/// and no byte sequence sorts strictly between them, so every key in
+/// that range begins with `account + ":"`. The named account itself
+/// is fetched separately because it sorts immediately before the
+/// range.
+fn for_each_descendant<T>(map: &BTreeMap<String, T>, account: &str, mut f: impl FnMut(&str, &T)) {
+    let prefix = format!("{account}:");
+    let upper = format!("{account};");
+    if let Some((k, v)) = map.get_key_value(account) {
+        f(k.as_str(), v);
+    }
+    for (k, v) in map.range::<String, _>(prefix..upper) {
+        f(k.as_str(), v);
+    }
+}
+
+/// Per-commodity sum of the running balance across `account` and
+/// every descendant. Used by Beancount's subtree-aware `balance`
+/// directive (#214) and by hledger's `==*` synthesis (#207). Zero
+/// entries are dropped.
+fn subtree_commodity_balance(
+    account_balances: &BTreeMap<String, AccountBalances>,
+    account: &str,
+) -> BTreeMap<String, Decimal> {
+    let mut out: BTreeMap<String, Decimal> = BTreeMap::new();
+    for_each_descendant(account_balances, account, |_, balances| {
+        for (c, v) in &balances.commodity {
+            if !v.is_zero() {
+                *out.entry(c.clone()).or_default() += *v;
+            }
+        }
+    });
+    out
 }
 
 /// Evaluate tag-level assert/check directives for a set of metadata key-value pairs.

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -765,17 +765,31 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                                         &state,
                                     )?;
 
-                                    // Snapshot the account's non-zero commodities; the per-
-                                    // commodity delta is `target - current_balance`.
-                                    let deltas: Vec<(String, Decimal)> = account_balance
-                                        .map(|ab| {
-                                            ab.commodity
-                                                .iter()
-                                                .filter(|(_, v)| !v.is_zero())
-                                                .map(|(c, v)| (c.clone(), target_value - v))
-                                                .collect()
-                                        })
-                                        .unwrap_or_default();
+                                    // Aggregate the named account *and its subtree* (every
+                                    // account whose name has `account_name + ":"` as a prefix).
+                                    // hledger's `==*` operates on the entire subtree, not just
+                                    // the named account: e.g. `Income ==* 0` zeroes the whole
+                                    // `Income:*` subtree by synthesizing a corrective posting
+                                    // on `Income` itself.
+                                    let prefix = format!("{account_name}:");
+                                    let mut subtree_totals: BTreeMap<String, Decimal> =
+                                        BTreeMap::new();
+                                    for (name, balances) in &state.account_balances {
+                                        if name == &account_name || name.starts_with(&prefix) {
+                                            for (c, v) in &balances.commodity {
+                                                if !v.is_zero() {
+                                                    *subtree_totals
+                                                        .entry(c.clone())
+                                                        .or_default() += *v;
+                                                }
+                                            }
+                                        }
+                                    }
+                                    let deltas: Vec<(String, Decimal)> = subtree_totals
+                                        .into_iter()
+                                        .filter(|(_, v)| !v.is_zero())
+                                        .map(|(c, v)| (c, target_value - v))
+                                        .collect();
 
                                     if !accounts.contains_key(&account_name) {
                                         accounts.insert(account_name.clone(), Default::default());

--- a/crates/doppio/src/grammars/beancount/mod.rs
+++ b/crates/doppio/src/grammars/beancount/mod.rs
@@ -865,6 +865,11 @@ impl crate::frontend::Frontend for BeancountFrontend {
             crate::resolution::ToleranceMode::FractionOfSmallestPrecision(
                 rust_decimal::Decimal::new(5, 1),
             );
+        // Beancount's `balance` directive aggregates the entire
+        // account subtree (#214). A `pad` that targets the same
+        // account synthesizes its corrective amount against the
+        // subtree sum.
+        hir.global_context.assertion_scope = crate::resolution::AssertionScope::Subtree;
         // Honour `option "inferred_tolerance_default" "COMMODITY:VALUE"`
         // directives. Each occurrence overrides any previous value for
         // the same commodity (last write wins). The directive is
@@ -1877,6 +1882,11 @@ option \"inferred_tolerance_default\" \"USD:0.1\"
             crate::resolution::ToleranceMode::FractionOfSmallestPrecision(
                 rust_decimal::Decimal::new(5, 1),
             );
+        // Match BeancountFrontend's subtree-aware `balance` semantics
+        // (#214). bean-check aggregates the entire account subtree;
+        // pad uses the same scope when computing its corrective
+        // amount.
+        hir.global_context.assertion_scope = crate::resolution::AssertionScope::Subtree;
         for (k, v) in &options {
             if k == "inferred_tolerance_default"
                 && let Some((commodity, decimal)) = v.split_once(':')
@@ -2055,5 +2065,89 @@ option \"inferred_tolerance_default\" \"USD:0.1\"
             pad_txs, 0,
             "pad whose gap is zero should not emit a synthesized transaction"
         );
+    }
+
+    // -- subtree balance / pad (#214) ---------------------------------------
+
+    /// `balance` on a parent account aggregates the subtree: the parent
+    /// has no direct postings, the child does, and the asserted amount
+    /// equals the descendant's balance. Direct-only semantics would
+    /// see 0 on the parent and reject; subtree semantics pass.
+    #[test]
+    fn balance_directive_aggregates_subtree() {
+        let input = "\
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Income:Salary USD
+2024-01-01 open Income:Salary:Base USD
+
+2024-06-01 * \"Salary\"
+  Assets:Cash             100.00 USD
+  Income:Salary:Base     -100.00 USD
+
+2024-12-31 balance Income:Salary -100.00 USD
+";
+        elaborate(input).expect("balance on parent must reach the descendant's posting");
+    }
+
+    /// `pad` computes its corrective amount against the *subtree* sum
+    /// of the next-balance account, not just the literal account's
+    /// direct balance. The synthesized posting still lands on the
+    /// literal pad target.
+    #[test]
+    fn pad_residual_uses_subtree_sum() {
+        let input = "\
+2024-01-01 open Equity:OpeningBalances
+2024-01-01 open Assets:Bank USD
+2024-01-01 open Assets:Bank:Checking USD
+2024-01-01 open Assets:Bank:Savings USD
+
+2024-01-02 pad Assets:Bank Equity:OpeningBalances
+
+2024-01-15 * \"Existing\"
+  Assets:Bank:Checking   100.00 USD
+  Assets:Bank:Savings    200.00 USD
+  Equity:OpeningBalances
+
+2024-12-31 balance Assets:Bank 1000.00 USD
+";
+        let elab = elaborate(input).expect("subtree pad must reconcile against subtree sum");
+        let pad_txs: Vec<_> = elab
+            .transactions
+            .iter()
+            .filter(|t| t.metadata.contains_key("pad"))
+            .collect();
+        assert_eq!(pad_txs.len(), 1, "exactly one pad txn expected");
+        let pad_tx = pad_txs[0];
+        // Pad amount = 1000 - (100 + 200) = +700 on the parent account.
+        let target = pad_tx
+            .postings
+            .iter()
+            .find(|p| p.account == "Assets:Bank")
+            .expect("synthesized posting must land on the literal pad target");
+        assert_eq!(target.amount_in("USD"), Some(dec!(700.00)));
+        let source = pad_tx
+            .postings
+            .iter()
+            .find(|p| p.account == "Equity:OpeningBalances")
+            .expect("synthesized source posting");
+        assert_eq!(source.amount_in("USD"), Some(dec!(-700.00)));
+    }
+
+    /// Direct-balance assertion still works when the named account is
+    /// itself the leaf (no descendants); the subtree reduces to a
+    /// single account.
+    #[test]
+    fn balance_directive_on_leaf_is_unchanged() {
+        let input = "\
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Income:Salary USD
+
+2024-06-01 * \"Salary\"
+  Assets:Cash             100.00 USD
+  Income:Salary          -100.00 USD
+
+2024-12-31 balance Income:Salary -100.00 USD
+";
+        elaborate(input).expect("leaf-account assertion must still pass");
     }
 }

--- a/crates/doppio/src/grammars/hledger/mod.rs
+++ b/crates/doppio/src/grammars/hledger/mod.rs
@@ -1376,6 +1376,48 @@ nothing after this matters
         ));
     }
 
+    /// `==*` aggregates the named account's full subtree: the synthesized
+    /// posting on the parent must offset the sum across descendants.
+    /// See #207.
+    #[test]
+    fn assertion_star_aggregates_subtree() {
+        let input = "\
+2024-01-15 * Salary
+    Assets:Cash:USD          200.00 USD
+    Income:Salary           -200.00 USD
+
+2024-02-01 * Royalty
+    Assets:Cash:EUR           30.00 EUR
+    Income:Royalties         -30.00 EUR
+
+2024-12-31 * Retain earnings
+    Income                    ==* 0
+    Equity:Retained-Earnings
+";
+        let ast = parse_hledger(input).expect("parse");
+        let hir: crate::resolution::HIR = ast.try_into().expect("resolution");
+        let journal: crate::elaboration::Journal = crate::elaborate(hir).expect("elaboration");
+        let retain = journal
+            .transactions
+            .iter()
+            .find(|t| t.description == "Retain earnings")
+            .expect("retain earnings tx");
+        let income = retain
+            .postings
+            .iter()
+            .find(|p| p.account == "Income")
+            .expect("synthesized Income posting");
+        assert_eq!(income.amount_in("USD"), Some(dec!(200.00)));
+        assert_eq!(income.amount_in("EUR"), Some(dec!(30.00)));
+        let re = retain
+            .postings
+            .iter()
+            .find(|p| p.account == "Equity:Retained-Earnings")
+            .expect("retained-earnings absorber");
+        assert_eq!(re.amount_in("USD"), Some(dec!(-200.00)));
+        assert_eq!(re.amount_in("EUR"), Some(dec!(-30.00)));
+    }
+
     #[test]
     fn test_lot_annotation_double_brace_total_form() {
         // `{{$1500}}` declares the total lot cost. The adapter records

--- a/crates/doppio/src/resolution.rs
+++ b/crates/doppio/src/resolution.rs
@@ -139,6 +139,10 @@ pub struct GlobalContext {
     /// transaction balance when the posting carries both `{cost}` and
     /// `@price` annotations. See [`BalanceMode`].
     pub balance_mode: BalanceMode,
+    /// Whether top-level `balance` directives ([`Entry::Assertion`])
+    /// check the named account in isolation or aggregate the entire
+    /// account subtree. See [`AssertionScope`].
+    pub assertion_scope: AssertionScope,
 }
 
 /// Strategy for computing a posting's cash-equivalent during the
@@ -168,6 +172,32 @@ pub enum BalanceMode {
     /// with what Beancount/ledger-cli inputs produce). Matches
     /// hledger.
     AtPriceWithSynthesis { gains_account: String },
+}
+
+/// Scope of a top-level `balance` directive's account lookup.
+///
+/// Three frontends, two semantics:
+///
+/// - **Beancount** (`balance Account X CUR`): the running balance is
+///   summed across `Account` itself and every descendant whose name
+///   has `Account + ":"` as a prefix. A `pad` that targets the same
+///   account computes its corrective amount from the same subtree
+///   sum.
+/// - **ledger-cli / hledger** (`Account = X CUR` posting assertion or
+///   the doppio-extended top-level form): the running balance is the
+///   direct posting balance of the named account only. hledger's
+///   strict `==` form is explicit about this in its own error message
+///   ("excluding subaccounts"). hledger's `==*` posting form is
+///   subtree-aware, but it is encoded as a separate
+///   [`crate::ast::AmountDetails::BalanceAssignmentAllCommodities`]
+///   variant rather than via this scope flag.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum AssertionScope {
+    /// The named account's running balance only. Default.
+    #[default]
+    Direct,
+    /// Sum of the named account and every descendant.
+    Subtree,
 }
 
 /// Per-transaction balance tolerance policy.

--- a/scripts/parity_check.py
+++ b/scripts/parity_check.py
@@ -234,6 +234,7 @@ POSITIVE: list[Case] = [
     # per the convention documented in tests/parity/README.md.
     Case("hledger:ascii",         REPO / "tests/parity/hledger-ascii.journal", hledger_balances),
     Case("hledger:zerostar",      REPO / "tests/parity/hledger-zerostar.journal", hledger_balances),
+    Case("hledger:zerostar-subtree", REPO / "tests/parity/hledger-zerostar-subtree.journal", hledger_balances),
     Case("hledger:block-comment", REPO / "tests/parity/hledger-block-comment.journal", hledger_balances),
     Case("beancount:example",     REPO / "tests/parity/bean-example.beancount", beancount_balances),
 ]

--- a/scripts/parity_check.py
+++ b/scripts/parity_check.py
@@ -237,6 +237,8 @@ POSITIVE: list[Case] = [
     Case("hledger:zerostar-subtree", REPO / "tests/parity/hledger-zerostar-subtree.journal", hledger_balances),
     Case("hledger:block-comment", REPO / "tests/parity/hledger-block-comment.journal", hledger_balances),
     Case("beancount:example",     REPO / "tests/parity/bean-example.beancount", beancount_balances),
+    Case("beancount:subtree-balance", REPO / "tests/parity/beancount-subtree-balance.beancount", beancount_balances),
+    Case("beancount:subtree-pad",     REPO / "tests/parity/beancount-subtree-pad.beancount",     beancount_balances),
 ]
 
 NEGATIVE: list[Case] = [

--- a/tests/parity/beancount-subtree-balance.beancount
+++ b/tests/parity/beancount-subtree-balance.beancount
@@ -1,0 +1,26 @@
+; Beancount's `balance` directive aggregates the entire account
+; subtree (parent + every descendant). Introduced for #214.
+;
+; Setup: only the descendant `Income:Salary:Base` has direct postings
+; (-100 USD); the parent `Income:Salary` has none.
+;   - subtree sum on `Income:Salary` = -100 USD
+;   - direct balance on `Income:Salary` = 0 USD
+;
+; Asserting `-100 USD` on `Income:Salary` therefore distinguishes the
+; two: subtree-aware semantics pass, direct-only semantics fail.
+;
+; bean-check 3.2.0 accepts this file (exit 0), confirming subtree
+; semantics. doppio's frontend selects the same scope via
+; `AssertionScope::Subtree`.
+
+option "operating_currency" "USD"
+
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Income:Salary USD
+2024-01-01 open Income:Salary:Base USD
+
+2024-06-01 * "Salary"
+    Assets:Cash             100.00 USD
+    Income:Salary:Base     -100.00 USD
+
+2024-12-31 balance Income:Salary -100 USD

--- a/tests/parity/beancount-subtree-pad.beancount
+++ b/tests/parity/beancount-subtree-pad.beancount
@@ -1,0 +1,36 @@
+; Beancount's `pad` directive computes its corrective amount against
+; the *subtree* sum of the next balance assertion's account. Introduced
+; for #214.
+;
+; Setup:
+;   - children `Assets:Bank:Checking` (+100) and `Assets:Bank:Savings`
+;     (+200) have direct postings; subtree sum on `Assets:Bank` is
+;     +300 USD.
+;   - parent `Assets:Bank` has no direct postings.
+;   - `pad Assets:Bank Equity:OpeningBalances` then
+;     `balance Assets:Bank 1000.00 USD`.
+;
+; bean-check synthesises a +700 USD posting on the literal parent
+; `Assets:Bank` (target 1000 - subtree 300 = +700). After synthesis:
+;   - parent direct: +700 USD  (synthesized)
+;   - child Checking: +100 USD (unchanged)
+;   - child Savings:  +200 USD (unchanged)
+;   - subtree sum:    +1000 USD ✓
+;
+; Verified empirically against bean-check 3.2.0.
+
+option "operating_currency" "USD"
+
+2024-01-01 open Equity:OpeningBalances
+2024-01-01 open Assets:Bank USD
+2024-01-01 open Assets:Bank:Checking USD
+2024-01-01 open Assets:Bank:Savings USD
+
+2024-01-02 pad Assets:Bank Equity:OpeningBalances
+
+2024-01-15 * "Existing"
+    Assets:Bank:Checking   100.00 USD
+    Assets:Bank:Savings    200.00 USD
+    Equity:OpeningBalances
+
+2024-12-31 balance Assets:Bank 1000.00 USD

--- a/tests/parity/hledger-zerostar-subtree.journal
+++ b/tests/parity/hledger-zerostar-subtree.journal
@@ -1,0 +1,29 @@
+; Hand-crafted fixture exercising hledger's `==* 0` strict-zero balance
+; assignment when the named account has no direct postings but its
+; subtree does. Introduced for #207.
+;
+; `Income ==* 0` zeroes the entire `Income:*` subtree. Since `Income`
+; itself has no direct postings, hledger synthesizes a corrective
+; posting on `Income` that offsets every commodity held in the subtree;
+; `Equity:Retained-Earnings` absorbs the multi-commodity total.
+;
+; Running this through `hledger -f hledger-zerostar-subtree.journal
+; balance --no-total --flat` produces, among other rows:
+;     200 USD  Income           <-- synthesized by ==*
+;      30 EUR  Income
+;    -200 USD  Income:Salary
+;     -30 EUR  Income:Royalties
+;
+; Doppio must agree on those per-account totals.
+
+2024-01-15 * "Salary"
+    Assets:Cash:USD                200.00 USD
+    Income:Salary                 -200.00 USD
+
+2024-02-01 * "Royalty in EUR"
+    Assets:Cash:EUR                 30.00 EUR
+    Income:Royalties               -30.00 EUR
+
+2024-12-31 * "Retain earnings (zero out Income subtree across all commodities)"
+    Income                              ==* 0
+    Equity:Retained-Earnings


### PR DESCRIPTION
## Summary

Resolves the **balancing-related** sub-account hierarchy gaps under umbrella #214. Started narrow as the #207 hledger `==*` fix; expanded after a comprehensive cross-tool audit confirmed the same shape applies to Beancount's `balance` and `pad` directives.

What landed:

- New helper `for_each_descendant(map, account, f)` in the elaborator. Walks an account and every descendant via a `BTreeMap` half-open range over `[name + ":", name + ";")`. ASCII `:` (0x3A) and `;` (0x3B) are adjacent, so the range exactly captures the subtree.
- `subtree_commodity_balance` builds on it: per-commodity sum across the subtree, zero entries dropped.
- #207 (hledger `==*`) refactored to use the helper. Same behaviour, fewer lines.
- New `AssertionScope { Direct, Subtree }` enum in resolution; `GlobalContext` carries the per-frontend choice.
- `Entry::Assertion` and the pad-residual computation branch on the scope. Pad synthesis still lands on the literal target account.
- `BeancountFrontend::parse` opts in to `AssertionScope::Subtree`. The Beancount test-helper `elaborate` mirrors that default.

## Cross-tool semantics (verified empirically)

| Tool | Operator | Scope |
|------|----------|-------|
| Beancount | `balance` | Subtree (now matched) |
| Beancount | `pad` (residual) | Subtree (now matched) |
| ledger-cli | `=` posting assertion | Direct (unchanged) |
| hledger | `==`, `=` | Direct (unchanged) |
| hledger | `==*`, `=*` | Subtree (matched in #207) |

Probes are documented in the audit findings on #214 and (more comprehensively) in the new `docs/PTA_TOOL_SEMANTICS.md` reference doc.

## Wire-format compatibility

**Zero impact on `.dop`**. Account names stay flat colon-separated strings; hierarchy is computed at runtime.

## Behavior changes (corrections, not regressions)

- Beancount `balance` becomes subtree-aware — alignment with bean-check.
- Beancount `pad` becomes subtree-residual — alignment with bean-check.
- No existing fixture asserts on an inner-node account, so no parity regressions.

## Tests

- `tests/parity/hledger-zerostar-subtree.journal` (existing from #207) — hledger `==*` on a parent.
- `tests/parity/beancount-subtree-balance.beancount` (new) — Beancount balance on a parent with descendant postings.
- `tests/parity/beancount-subtree-pad.beancount` (new) — Beancount pad+balance on a parent; expected pad synthesis amount = `target − subtree-sum`.
- Three new elaborator unit tests in the Beancount frontend covering subtree balance, subtree pad residual, and the no-descendant leaf edge.
- Existing `assertion_star_aggregates_subtree` in the hledger frontend continues to pass after the refactor.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace` — 460 tests pass (291 in doppio lib, +3 from this commit)
- [x] `python3 scripts/parity_check.py` — all 10 cases pass against bean-check 3.2.0, hledger 1.40, ledger 3.3.2

## Related

- Closes #207 (narrow hledger `==*`).
- Closes the balancing scope of #214 (umbrella for sub-account hierarchy).
- #216 — CLI tree-mode rendering should use the same helper (refactor, deferred).
- #217 — hledger account-type tag inheritance (latent, deferred).