### PR TITLE
test: pin hledger account-type tag inheritance (closes #217)

### DIFF
--- a/crates/doppio/src/grammars/hledger/mod.rs
+++ b/crates/doppio/src/grammars/hledger/mod.rs
@@ -1418,6 +1418,36 @@ nothing after this matters
         assert_eq!(re.amount_in("EUR"), Some(dec!(-30.00)));
     }
 
+    /// hledger's `account Foo ; type:R` tag is captured as metadata on
+    /// the declared account; the elaborator's existing ancestor walk
+    /// then propagates it to undeclared descendants. No tree type, no
+    /// new path — generic metadata inheritance already covers the type
+    /// tag. Pinning this here so the behaviour can't silently regress.
+    #[test]
+    fn account_type_tag_inherits_to_undeclared_descendant() {
+        let input = "\
+account Income          ; type:R
+
+2024-01-15 * Salary
+    Income:Salary    -100 USD
+    Assets:Cash       100 USD
+";
+        let ast = parse_hledger(input).expect("parse");
+        let hir: crate::resolution::HIR = ast.try_into().expect("resolution");
+        let journal: crate::elaboration::Journal = crate::elaborate(hir).expect("elaboration");
+        let salary = journal
+            .accounts
+            .get("Income:Salary")
+            .expect("Income:Salary in elaborated accounts");
+        assert_eq!(
+            salary.metadata.get("type").map(String::as_str),
+            Some("R"),
+            "type:R declared on parent Income must propagate to undeclared Income:Salary; \
+             got metadata = {:?}",
+            salary.metadata
+        );
+    }
+
     #[test]
     fn test_lot_annotation_double_brace_total_form() {
         // `{{$1500}}` declares the total lot cost. The adapter records


### PR DESCRIPTION
## Summary

Adds a regression test confirming that hledger's \`account Foo ; type:R\` tag already inherits to undeclared descendants under doppio's existing generic metadata-inheritance machinery. No code change.

## Background

\`#217\` was filed during the sub-account hierarchy audit on the suspicion that hledger account-type tags would need a dedicated inheritance path. They don't:

1. The hledger parser captures \`; type:R\` as a note string \`\"type:R\"\`.
2. \`HIR::resolve_metadata\` parses every \`key: value\` note into \`account_properties[name].metadata\` (\`crates/doppio/src/resolution.rs:735\`).
3. The elaborator already walks each account's ancestor chain (\`ancestor_prefixes\`) and merges parent metadata onto the descendant before emit (\`crates/doppio/src/elaborator.rs:1280-1312\`).

So \`type\` rides for free on the same generic path that handles every other account tag.

## Test

\`account_type_tag_inherits_to_undeclared_descendant\` in the hledger frontend's tests module: declares \`type:R\` on \`Income\`, posts to \`Income:Salary\` (undeclared), asserts the elaborated \`Income:Salary\` carries \`metadata[\"type\"] == \"R\"\`. Pinning so a future refactor can't silently break it.

## Out of scope

Adding consumers that *use* \`metadata.type\` -- \`incomestatement\` / \`balancesheet\` reports, schema-aware exports -- is a separate feature, file when prioritised.

Closes #217.