### PR TITLE
parity: vendor 3 upstream fixtures (#197)

### DIFF
--- a/scripts/parity_check.py
+++ b/scripts/parity_check.py
@@ -109,7 +109,7 @@ _LEDGER_AMOUNT = re.compile(
     r"\s*"
     r"(?P<num>[-+]?[\d,]+(?:\.\d+)?)"           # numeric body
     r"\s*"
-    r"(?P<suffix>[A-Z][A-Z0-9_'.\-]*)?"         # commodity suffix word
+    r"(?P<suffix>[A-Za-z][A-Za-z0-9_'.\-]*)?"   # commodity suffix word (case-insensitive; ledger-cli allows lowercase like `bytes`)
     r"\s*$"
 )
 
@@ -232,6 +232,8 @@ POSITIVE: list[Case] = [
     # Upstream-sourced corpus under tests/parity/. Each fixture's
     # leading comment block records source URL + commit SHA + license
     # per the convention documented in tests/parity/README.md.
+    Case("ledger:transfer",       REPO / "tests/parity/ledger-transfer.ledger",  ledger_balances),
+    Case("hledger:quickstart",    REPO / "tests/parity/hledger-quickstart.journal", hledger_balances),
     Case("hledger:ascii",         REPO / "tests/parity/hledger-ascii.journal", hledger_balances),
     Case("hledger:zerostar",      REPO / "tests/parity/hledger-zerostar.journal", hledger_balances),
     Case("hledger:zerostar-subtree", REPO / "tests/parity/hledger-zerostar-subtree.journal", hledger_balances),
@@ -239,6 +241,7 @@ POSITIVE: list[Case] = [
     Case("beancount:example",     REPO / "tests/parity/bean-example.beancount", beancount_balances),
     Case("beancount:subtree-balance", REPO / "tests/parity/beancount-subtree-balance.beancount", beancount_balances),
     Case("beancount:subtree-pad",     REPO / "tests/parity/beancount-subtree-pad.beancount",     beancount_balances),
+    Case("beancount:starter",         REPO / "tests/parity/beancount-starter.beancount",         beancount_balances),
 ]
 
 NEGATIVE: list[Case] = [

--- a/tests/parity/beancount-starter.beancount
+++ b/tests/parity/beancount-starter.beancount
@@ -1,0 +1,383 @@
+;;; Vendored from beancount's example corpus (examples/simple/starter.beancount).
+;;;
+;;; Source:    https://github.com/beancount/beancount/blob/5704a86108948b4dff84cfff816d9a34a0a5da30/examples/simple/starter.beancount
+;;; Commit:    5704a86108948b4dff84cfff816d9a34a0a5da30 (master, 2026-05)
+;;; Fetched:   2026-05-07
+;;; License:   GPL-2.0-only (test fixture; not distributed in the doppio binary.)
+;;; Exercises: option directives, event directives, open with single-commodity
+;;;            restriction, pad + balance, lots with cost annotations
+;;;            ({701.20 USD}), multi-commodity portfolios with synthesised
+;;;            commodities (BRICKHOME), price directives, Emacs org-mode
+;;;            section headers (treated as comments by Beancount).
+
+#!/usr/bin/env bean-web
+;; -*- mode: org; mode: beancount; coding: utf-8; fill-column: 400; -*-
+;; Starter Kit Example Ledger
+
+* Initialization
+;; This is a starter example file that you should copy to get started
+;; using Beancount. This is an example starting point, with the same
+;; organization choices and style in which I (the author) write my own
+;; ledger files. You should delete all these explanatory comments
+;; and put your own instead. When you start, the best way to begin is
+;; to create one of these, with all your assets and liabilities, so
+;; that you can see your balance sheet and your net worth.
+;;
+;; This example is written from the perspective of someone starting
+;; their ledger file on 2013-12-22.
+;;
+;; This example uses headers in the Emacs outline mode style. Note
+;; that you don't have to do that if you don't use Emacs, it's not
+;; required, but it's just really convenient if you do, as you can
+;; fold and unfold large sections of your input file and get an
+;; overview of its structure..
+;;
+;; The order of directives in the file does not matter. I choose to
+;; organize my transactions by-account, mostly. I create one section
+;; for each accounts, and above that, I organize sections by country
+;; and institution. It's entirely arbitrary, just a choice based on
+;; whatever feels most comfortable for you.
+;;
+;; In this example file the choice of account names follows my own
+;; favorite hierarchy:
+;;
+;; - The type (Assets/Liabilities/Equity/Expense/Income), which
+;;   is required by Beancount;
+;;
+;; - Country. This is useful if you have accounts in multiple places;
+;;
+;; - Institution. These contain multiple accounts. For example, a
+;;   bank has checking and savings accounts, typically. They don't
+;;   have to be physical real institution at this level, but I like
+;;   to have that level, it's the name of the company that holds the
+;;   account, even if the account is fictional.
+;;
+;; - Account name within the institution.
+;;
+;; Again, this is entirely arbitrary, but I've evolved into this
+;; choice over several years of usage, and I think it's pretty neat.
+;; Feel free to elide the country, or design your own account
+;; hierarchy, it should work just the same, Beancount does not
+;; depend on this choice at all, beyond the first component for the
+;; type. Several examples below.
+
+** Options
+;; We begin with the declaration of some global options.
+;; Run "bean-doctor list_options" for the full list of available options.
+
+option "title" "Starter Kit Beancount Ledger"
+
+;; We will assume this user operates in US dollars.
+option "operating_currency" "USD"
+
+
+
+** General Accounts
+;; We need to declare a few general accounts that we will use below.
+
+;; Declare some sort of account to use as the source for padding
+;; entries (see below). Use your birth date... that's when you began
+;; accumulating equity!
+1982-04-01 open Equity:Opening-Balances
+
+** Events
+;; This is a section where I declare some general properties.
+
+;; Enter the date when this address last changed and its curent value.
+2008-07-01 event "address" "12345 Brick Lane, New York City, NY 10011, USD"
+
+;; Same thing with your employer.
+2011-02-15 event "employer" "Boogle Tech Inc."
+
+;; You can track trips here too by changing the value of a "location"
+;; event (variable). Insert one of these every time you travel. It can
+;; be used for various purposes (see documentation). You can also
+;; choose to put them along your cash expenses somewhere below, which
+;; is what I do (remember: the order of declarations in the file is
+;; not important).
+2013-12-22 event "location" "New York City, USA"
+
+
+* USA Accounts
+** BofA Bank
+;; This example individual has some regular accounts in Bank of America
+;; (we'll abbreviate as BofA) and a credit card with them.
+
+*** Checking
+;; A main checking account.
+
+;; Open the account at the approximate date where you think you
+;; actually created it if you don't remember; if you do, find the
+;; date and put it here.
+;; You don't really have to put a currency constraint, but for a
+;; bank account it makes sense to do so, because it really
+;; cannot contain any other kinds of beans. This is a US dollar
+;; account, so I choose to introduce the "USD" currency here (it's
+;; otherwise not pre-defined in any way, it just comes into being
+;; as you use it, I could have typed any other all-caps word
+;; instead of "USD" here, like "EUR", or "POINTS").
+2004-08-01 open Assets:US:BofABank:Checking     USD
+
+;; Then we don't want to have to go and enter all the history from the
+;; past here before we get working... so we'll declare a padding
+;; directive right at the opening date that will take care of
+;; inserting the correct amount to make the following assert balance.
+2004-08-01 pad  Assets:US:BofABank:Checking  Equity:Opening-Balances
+
+;; Now insert the balance as of the last date that you have a
+;; statement for (or if this is available, you can log into your
+;; online account and check that your current account balance is).
+2013-12-22 balance  Assets:US:BofABank:Checking   973.03 USD
+
+;; That's it! That is the main template. The rest of this file
+;; just follows this example in order to setup all the available
+;; accounts. From this point on, you can add or import new
+;; transactions following the check date.
+
+
+
+*** Savings
+;; A high-interest savings account, presumably opened on the same date..
+
+2004-08-01 open   Assets:US:BofABank:Savings  USD
+2004-08-01 pad    Assets:US:BofABank:Savings  Equity:Opening-Balances
+2013-12-22 balance  Assets:US:BofABank:Savings  2402.81 USD
+
+
+
+*** Mortgage
+;; A mortgage loan account associated with a Brick Lane property
+;; declared below. The date is the same as the purchase of the
+;; property, because that's when the mortgage loan began.
+
+2010-03-20 open   Liabilities:US:BofABank:Mortgage  USD
+
+;; Pad this for payments whose detail we won't enter yet.
+2010-03-20 pad    Liabilities:US:BofABank:Mortgage  Equity:Opening-Balances
+
+;; Current value of mortgage.
+2013-12-22 balance   Liabilities:US:BofABank:Mortgage  -101832.34 USD
+
+
+
+** American Express
+; He also has an American Express BlueCash Everyday card (we'll
+;; abbreviate as Amex).
+
+2009-08-01 open   Liabilities:US:Amex:BlueCash  USD
+2009-08-01 pad    Liabilities:US:Amex:BlueCash  Equity:Opening-Balances
+2013-12-22 balance  Liabilities:US:Amex:BlueCash  -1121.26 USD
+
+
+
+** Fidelity Investments
+;; His employer deposits 401k matching amounts in a Fidelity 401k
+;; account.
+
+;; Also, note how I create a subaccount for each instrument type
+;; being held; this is not strickly necessary, but I like to do this,
+;; as it results in nicer output, where each type of instrument has
+;; its own journal and it's just overall less messy.
+;;
+;; Since this is a 401k account and all the amounts deposited are
+;; immediately invested, there is no need to declare a Cash account.
+
+2009-08-01 open  Assets:US:Fidelity:Boogle401k:RGAGX  RGAGX
+2009-08-01 open  Assets:US:Fidelity:Boogle401k:VBMPX  VBMPX
+
+2009-08-01 pad    Assets:US:Fidelity:Boogle401k:RGAGX  Equity:Opening-Balances
+2009-08-01 pad    Assets:US:Fidelity:Boogle401k:VBMPX  Equity:Opening-Balances
+
+;; Here we just add the contents of the investment account (mutual
+;; funds) and their current market value, because this is a registered
+;; account (401k) and it is not taxable, so we don't care about the
+;; capital gains detail. If you decide later on to add all the
+;; purchase transactions, you would find the capital gain appearing.
+;;
+
+2013-12-22 balance  Assets:US:Fidelity:Boogle401k:RGAGX  201.02 RGAGX
+2013-12-22 balance  Assets:US:Fidelity:Boogle401k:VBMPX  743.82 VBMPX
+
+2013-12-22 price RGAGX  40.93 USD
+2013-12-22 price VBMPX  10.02 USD
+
+
+
+
+** E*Trade
+;; In addition, he has an E*Trade taxable trading account with some
+;; stocks he buys into.
+
+;; In this account, we do have a cash component, which holds our
+;; deposits and whose contents is converted against stock during
+;; transactions. We pad the cash account to account for past
+;; deposits.
+2011-03-15 open   Assets:US:ETrade:Investment:Cash  USD
+2011-03-15 pad    Assets:US:ETrade:Investment:Cash  Equity:Opening-Balances
+2013-12-22 balance  Assets:US:ETrade:Investment:Cash  102.10 USD
+
+
+;; These we won't pad; because there's a tax consequence on the
+;; capital gain, we want to make sure that we have at least the
+;; book value for each position. (Ideally we'd go backwards
+;; and enter all the real transactions in the past.)
+2011-03-15 open   Assets:US:ETrade:Investment:HOOL  HOOL
+2011-03-15 open   Assets:US:ETrade:Investment:AAPL  AAPL
+
+
+;; For each of our current positions, add an assertion for the
+;; position, as well as the original transaction that got us
+;; that position, which provides its cost (book value).
+
+2013-02-03 * "Bought some stock"
+  Assets:US:ETrade:Investment:HOOL         8 HOOL {701.20 USD}
+  Expenses:Financial:Commissions         7.95 USD
+  Assets:US:ETrade:Investment:Cash
+
+2013-09-03 * "Bought some stock"
+  Assets:US:ETrade:Investment:HOOL         4 HOOL {850.08 USD}
+  Expenses:Financial:Commissions         7.95 USD
+  Assets:US:ETrade:Investment:Cash
+
+2013-12-22 balance  Assets:US:ETrade:Investment:HOOL  12 HOOL
+2013-12-22 price  HOOL   1101.02 USD
+
+
+;; Some other stock.
+
+2013-06-02 * "Bought some Apple stock"
+  Assets:US:ETrade:Investment:AAPL         10 AAPL {450.72 USD}
+  Expenses:Financial:Commissions         7.95 USD
+  Assets:US:ETrade:Investment:Cash
+
+2013-12-22 balance  Assets:US:ETrade:Investment:AAPL  10 AAPL
+2013-12-22 price  AAPL   549.02 USD
+
+
+
+** Brick Lane Home
+;; A while back, he bought a property on Brick Lane. Since there
+;; is no stock ticker or currency denomination for "his property,"
+;; we'll simply create one as a new symbol: "BRICKHOME" and we'll
+;; deposit 1 unit of this home in an account. If he bought another
+;; home we would create a different symbol.
+
+2010-03-20 open Assets:US:RealEstate:BrickHome  BRICKHOME
+
+2010-03-20 * "Bought the beautiful Brick Lane house from Joe Oldowner"
+  Assets:US:RealEstate:BrickHome      1 BRICKHOME {175000 USD}
+  Assets:US:BofABank:Checking                      -50000 USD  ; Downpayment
+  Liabilities:US:BofABank:Mortgage                -125000 USD  ; Loan
+
+
+;; Now, for a large asset that has been held over a long period of
+;; time, it's unlikely that its current value is the same as that
+;; it was when it was purchased, so we'll put as a price the most
+;; current evaluation.
+2013-06-15 price BRICKHOME  210000 USD
+
+
+
+
+* Expenses
+;; You should declare a list of buckets for booking expenses into.
+;; This is useful in your income statement, to see where your
+;; money is going, where it is being spent.
+;;
+;; I keep all the unused ones commented, because Beancount generates
+;; a warning for unused accounts. Uncomment as needed. Because this
+;; ledger does not yet contain any history of spending, they're
+;; almost all commented out for now.
+
+;1982-04-01 open Expenses:Financial:Fees
+1982-04-01 open Expenses:Financial:Commissions    USD
+;1982-04-01 open Expenses:Financial:Interest
+;1982-04-01 open Expenses:Insurance:Life
+;1982-04-01 open Expenses:Communications:Phone
+;1982-04-01 open Expenses:Communications:Email
+;1982-04-01 open Expenses:Communications:Internet
+;1982-04-01 open Expenses:Clothing
+;1982-04-01 open Expenses:Clothing:Cleaning
+;1982-04-01 open Expenses:Beauty:Hair
+;1982-04-01 open Expenses:Health:Massage
+;1982-04-01 open Expenses:Sports:Gear
+;1982-04-01 open Expenses:Sports:Cycling
+;1982-04-01 open Expenses:Sports:Yoga
+;1982-04-01 open Expenses:Fun:Movie
+;1982-04-01 open Expenses:Fun:Theater
+;1982-04-01 open Expenses:Fun:Concerts
+;1982-04-01 open Expenses:Fun:Museum
+;1982-04-01 open Expenses:Food:Restaurant
+;1982-04-01 open Expenses:Food:Grocery
+;1982-04-01 open Expenses:Food:Alcohol
+;1982-04-01 open Expenses:Books
+;1982-04-01 open Expenses:Gifts
+;1982-04-01 open Expenses:Travel:Accommodation
+;1982-04-01 open Expenses:Travel:Gear
+;1982-04-01 open Expenses:Travel:Documents
+;1982-04-01 open Expenses:Travel:Tours
+;1982-04-01 open Expenses:Travel:Communications
+;1982-04-01 open Expenses:Travel:Insurance
+;1982-04-01 open Expenses:Transportation:Flights
+;1982-04-01 open Expenses:Transportation:Parking
+;1982-04-01 open Expenses:Transportation:Taxi
+;1982-04-01 open Expenses:Transportation:Train
+;1982-04-01 open Expenses:Transportation:Bus
+;1982-04-01 open Expenses:Transportation:Car-Rental
+;1982-04-01 open Expenses:Transportation:Gas
+;1982-04-01 open Expenses:Moving
+;1982-04-01 open Expenses:Toys:Photography
+;1982-04-01 open Expenses:Toys:Computer
+;1982-04-01 open Expenses:Toys:Electronics
+;1982-04-01 open Expenses:Office-Supplies
+;1982-04-01 open Expenses:Misc
+;1982-04-01 open Expenses:Govt-Services:Drivers-License
+;1982-04-01 open Expenses:Medical:Insurance                 ;; Paying for insurance coverage
+;1982-04-01 open Expenses:Medical:Copay                     ;; Copays
+;1982-04-01 open Expenses:Medical:Deductible                ;; Amount towards deductible
+;1982-04-01 open Expenses:Medical:MaxOutOfPocket            ;; Amount towards max out-of-pocket expenses
+;1982-04-01 open Expenses:Medical:Drugs                     ;; Pills, drugs, and other OTC medicine
+;1982-04-01 open Expenses:Medical:Dental                    ;; Costs of dentist
+;1982-04-01 open Expenses:Medical:Glasses                   ;; Corrective glasses
+;1982-04-01 open Expenses:Medical:Acupuncture
+;1982-04-01 open Expenses:Charity
+;1982-04-01 open Expenses:Tips
+
+;;; ... add more here, add your own categories ...
+
+
+
+* Cash Daybook
+;; This is a section you can use to enter transactions by hand,
+;; that is, not from imported OFX files.
+
+
+
+
+;;------------------------------------------------------------------------------------------------------------------------
+;; That's it! Run bean-web on this file and you should view a basic
+;; balance sheet.
+;;
+;; Now, the income statement will be sparse and won't reflect the
+;; reality of spending and income. You then need to add transactions to
+;; it. You can do a few things from here on:
+;;
+;; 1. You can simply forget all the past history, and begin entering
+;;    new transactions from this point onwards.
+;;
+;; 2. You can decide to enter the details of the past history of
+;;    these accounts back to the beginnign of the calendar year.
+;;    This provides a good useful starting dataset, because you
+;;    will be able to use the ledger to figure out amounts to
+;;    declare on your taxes.
+;;
+;; 3. For some accounts, you may decide to enter all the past history
+;;    back to the actual beginning of the account. This would make
+;;    sense for your investment accounts, for instance, if you don't
+;;    have too many transactions. For each account whose detail has
+;;    been fully entered until its beginning, you can delete the
+;;    corresponding pad entry.
+;;
+;;    Depending on how excited you are about this, you might even
+;;    choose to try to complete all your accounts a few years back.
+;;    It's entirely up to you.

--- a/tests/parity/hledger-quickstart.journal
+++ b/tests/parity/hledger-quickstart.journal
@@ -1,0 +1,58 @@
+; Vendored from hledger's example corpus (examples/quickstart.journal).
+;
+; Source:    https://github.com/simonmichael/hledger/blob/029ba15ddfea8dbd1516475c9b83bef5285d6b2a/examples/quickstart.journal
+; Commit:    029ba15ddfea8dbd1516475c9b83bef5285d6b2a (master, 2026-05)
+; Fetched:   2026-05-07
+; License:   GPL-3.0 (compatible: doppio's MIT does not preclude vendoring
+;            GPL test fixtures into a non-GPL repo so long as they are not
+;            distributed as part of the doppio binary; these files are tests
+;            only, never linked into the crate.)
+; Exercises: default `commodity` directive, account-type tags
+;            (`type:A`/`C`/`L`/`E`/`V`/`R`/`X`), implicit-balance postings,
+;            inline transaction comments.
+
+; keep synced: site/src/index.md > Quick start
+
+commodity $1000.00
+
+account assets                   ; type:A
+account assets:bank              ; type:C
+account assets:bank:checking
+account assets:bank:savings
+account assets:cash              ; type:C
+
+account liabilities              ; type:L
+account liabilities:credit card
+
+account equity                   ; type:E
+account equity:conversion        ; type:V
+account equity:opening/closing
+
+account income                   ; type:R
+account income:salary
+account income:gifts
+
+account expenses                 ; type:X
+account expenses:rent
+account expenses:food
+account expenses:gifts
+
+
+2023-01-01 opening balances            ; <- First transaction sets starting balances.
+    assets:bank:checking        $1000  ; <- Account names can be anything.
+    assets:bank:savings         $2000  ; <- Colons indicate subaccounts.
+    assets:cash                  $100  ; <- 2+ spaces are required before the amount.
+    liabilities:credit card      $-50  ; <- A debt; these are negative.
+    equity:opening/closing     $-3050  ; <- Starting balances come from equity.
+                                       ;    Equity is also usually negative.
+                                       ;    (Reports can show as positive when needed.)
+
+2023-02-01 GOODWORKS CORP              ; <- Date order is recommended but optional.
+    assets:bank:checking       $1000
+    income:salary                      ; <- $-1000 is inferred here to balance the txn.
+                                       ;    Income amounts are negative.
+
+2023-02-15 market
+    expenses:food             $50
+    assets:cash                        ; <- $-50 is inferred here.
+

--- a/tests/parity/ledger-transfer.ledger
+++ b/tests/parity/ledger-transfer.ledger
@@ -1,0 +1,230 @@
+; Vendored from ledger-cli's test corpus (test/input/transfer.dat).
+;
+; Source:    https://github.com/ledger/ledger/blob/21a84425bb7c651d890ee363f14d28ce646acadf/test/input/transfer.dat
+; Commit:    21a84425bb7c651d890ee363f14d28ce646acadf (master, 2026-05-05)
+; Fetched:   2026-05-07
+; License:   BSD-3-Clause (compatible with doppio's MIT)
+; Exercises: long sequences of transactions in a non-monetary commodity
+;            (`bytes`); implicit-balance postings (last posting blank);
+;            same-day directive ordering across many entries.
+
+2004/08/02 Transfer to hcoop.net
+    Expenses:Internet                  59820 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/08/02 Transfer to hcoop.net
+    Expenses:Internet                  58626 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/08/02 Transfer to hcoop.net
+    Expenses:Internet                  2997279 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/08/03 Transfer to hcoop.net
+    Expenses:Internet                  227266 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/08/03 Transfer to hcoop.net
+    Expenses:Internet                  54375 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/08/05 Transfer to hcoop.net
+    Expenses:Internet                  54353 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/08/07 Transfer to hcoop.net
+    Expenses:Internet                  54353 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/08/16 Transfer to hcoop.net
+    Expenses:Internet                  54353 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/08/20 Transfer to hcoop.net
+    Expenses:Internet                  133967 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/08/20 Transfer to hcoop.net
+    Expenses:Internet                  124438 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/08/21 Transfer to hcoop.net
+    Expenses:Internet                  148691 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/08/22 Transfer to hcoop.net
+    Expenses:Internet                  660168 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/08/22 Transfer to hcoop.net
+    Expenses:Internet                  2876287 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/08/24 Transfer to hcoop.net
+    Expenses:Internet                  55166 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/08/24 Transfer to hcoop.net
+    Expenses:Internet                  54743 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/08/28 Transfer to hcoop.net
+    Expenses:Internet                  2414720 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/08/30 Transfer to hcoop.net
+    Expenses:Internet                  396873 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/08/30 Transfer to hcoop.net
+    Expenses:Internet                  2482301 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/08/31 Transfer to hcoop.net
+    Expenses:Internet                  3696731 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/01 Transfer to hcoop.net
+    Expenses:Internet                  2748364 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/05 Transfer to hcoop.net
+    Expenses:Internet                  2500517 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/06 Transfer to hcoop.net
+    Expenses:Internet                  54910 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/06 Transfer to hcoop.net
+    Expenses:Internet                  9196055 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/07 Transfer to hcoop.net
+    Expenses:Internet                  2640950 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/07 Transfer to hcoop.net
+    Expenses:Internet                  94442 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/08 Transfer to hcoop.net
+    Expenses:Internet                  2579158 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/08 Transfer to hcoop.net
+    Expenses:Internet                  530904 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/08 Transfer to hcoop.net
+    Expenses:Internet                  27368 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/08 Transfer to hcoop.net
+    Expenses:Internet                  6593 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/08 Transfer to hcoop.net
+    Expenses:Internet                  279 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/08 Transfer to hcoop.net
+    Expenses:Internet                  773 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/09 Transfer to hcoop.net
+    Expenses:Internet                  4217461 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/10 Transfer to hcoop.net
+    Expenses:Internet                  100241 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/10 Transfer to hcoop.net
+    Expenses:Internet                  117866 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/10 Transfer to hcoop.net
+    Expenses:Internet                  111275 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/11 Transfer to hcoop.net
+    Expenses:Internet                  2717020 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/12 Transfer to hcoop.net
+    Expenses:Internet                  88188 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/13 Transfer to hcoop.net
+    Expenses:Internet                  3046553 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/13 Transfer to hcoop.net
+    Expenses:Internet                  3370971 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/13 Transfer to hcoop.net
+    Expenses:Internet                  2941407 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/13 Transfer to hcoop.net
+    Expenses:Internet                  2101943 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/15 Transfer to hcoop.net
+    Expenses:Internet                  3050131 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/15 Transfer to hcoop.net
+    Expenses:Internet                  2638687 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/15 Transfer to hcoop.net
+    Expenses:Internet                  2668178 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/16 Transfer to hcoop.net
+    Expenses:Internet                  2645212 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/17 Transfer to hcoop.net
+    Expenses:Internet                  336579 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/17 Transfer to hcoop.net
+    Expenses:Internet                  104305 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/18 Transfer to hcoop.net
+    Expenses:Internet                  3117533 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/19 Transfer to hcoop.net
+    Expenses:Internet                  120777 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/20 Transfer to hcoop.net
+    Expenses:Internet                  193151 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/20 Transfer to hcoop.net
+    Expenses:Internet                  56204 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/21 Transfer to hcoop.net
+    Expenses:Internet                  315126 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/22 Transfer to hcoop.net
+    Expenses:Internet                  138076 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/09/24 Transfer to hcoop.net
+    Expenses:Internet                  817190 bytes
+    Liabilities:Payable:hcoop.net
+
+2004/10/05 Transfer to hcoop.net
+    Expenses:Internet                  356104 bytes
+    Liabilities:Payable:hcoop.net
+


### PR DESCRIPTION
## Summary

Round 2 of corpus expansion under #197. Vendors one fixture per frontend from each tool's own example/test corpus, plus a small harness regex fix.

### New fixtures

| Fixture | Source | Exercises |
|---------|--------|-----------|
| \`tests/parity/ledger-transfer.ledger\` | \`ledger/ledger@21a8442:test/input/transfer.dat\` | non-money commodity (\`bytes\`), implicit-balance postings, long sequence of same-day transactions |
| \`tests/parity/hledger-quickstart.journal\` | \`simonmichael/hledger@029ba15:examples/quickstart.journal\` | default \`commodity\` directive, full account-type tag matrix (\`type:A/C/L/E/V/R/X\`), implicit-balance postings |
| \`tests/parity/beancount-starter.beancount\` | \`beancount/beancount@5704a86:examples/simple/starter.beancount\` | option/event directives, single-commodity \`open\`, \`pad\` + \`balance\`, lots with cost annotations, multi-commodity portfolios, price directives, org-mode section headers |

Each fixture's leading comment block records source URL + commit SHA + license per \`tests/parity/README.md\`.

### Harness fix

\`scripts/parity_check.py\`'s \`_LEDGER_AMOUNT\` regex previously required commodity suffixes to start with an uppercase letter. ledger-cli accepts arbitrary commodity names including \`bytes\`. Loosened the suffix pattern to be case-insensitive.

### Gaps surfaced (filed separately, fixtures NOT vendored until fixed)

- **#219** -- ledger frontend rejects automated transactions (\`= /pattern/\`). Blocks vendoring \`drewr3.dat\`, \`sample.dat\`, and any real-world ledger file using auto-rules.
- **#220** -- Beancount \`pad\` only synthesises one commodity. Blocks vendoring \`basic.beancount\`'s multi-currency \`pad Assets:Cash\` pattern.

Both fixtures stay un-vendored per the corpus-expansion convention: don't add to \`POSITIVE\` until the gap has its own issue and is either fixed or the fixture trimmed.

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo test --workspace\` -- 449 tests pass (no code changes; tests confirm nothing regresses).
- [x] \`python3 scripts/parity_check.py\` -- all 13 fixtures pass against bean-check 3.2.0, hledger 1.40, ledger 3.3.2.

## Related

- #197 -- corpus expansion (this PR is round 2 of incremental adds).
- #219 -- ledger automated-transactions parser gap (newly filed).
- #220 -- Beancount multi-commodity \`pad\` gap (newly filed).