### PR TITLE
beancount: pad covers every asserted commodity on the same target (#220)

### DIFF
--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -60,12 +60,19 @@ struct RunningState {
 }
 
 /// A pad directive observed but not yet consumed by a balance assertion.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 struct PendingPad {
     /// The pad's own date -- used as the synthesized transaction's date.
     date: chrono::NaiveDate,
     /// The counter-account that will absorb the padding amount.
     source_account: String,
+    /// Commodities for which this pad has already fired a synthesised
+    /// transaction. Beancount fires the pad once per commodity at the
+    /// first balance assertion that references it; subsequent
+    /// assertions in the same commodity check the running balance
+    /// against the asserted amount without re-padding. Different
+    /// commodities can each consume the pad once.
+    padded_commodities: std::collections::BTreeSet<String>,
 }
 
 /// A commodity name (e.g. `"USD"`, `"BTC"`, `"$"`).
@@ -382,15 +389,18 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
             let entry_context = &value.contexts[entry.context_id];
             match entry.data {
                 resolution::Entry::Pad(p) => {
-                    // Beancount `pad`: remember the (target, source) pair until
-                    // the next balance assertion on `target` consumes it. A
-                    // second pad on the same target before any assertion
-                    // overwrites the first (most-recent-pad-wins).
+                    // Beancount `pad`: remember the (target, source) pair so
+                    // upcoming balance assertions on `target` can each fire
+                    // it once per commodity. A second pad on the same target
+                    // overwrites the first (most-recent-pad-wins) -- the new
+                    // pad's `padded_commodities` set starts empty, re-arming
+                    // it for every commodity.
                     state.pending_pads.insert(
                         p.target_account,
                         PendingPad {
                             date: p.date,
                             source_account: p.source_account,
+                            padded_commodities: std::collections::BTreeSet::new(),
                         },
                     );
                 }
@@ -426,7 +436,8 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                         }
                     };
 
-                    // If a pad on this account is pending, synthesize a
+                    // If a pad on this account is pending and has not yet
+                    // fired for the asserted commodity, synthesize a
                     // balancing transaction (back-dated to the pad's date)
                     // that brings `actual_amount` up to `expected_amount`,
                     // and apply it to the running state so the assertion
@@ -434,17 +445,24 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                     // transaction is also pushed into the output journal so
                     // downstream consumers see the inserted postings.
                     //
-                    // The pad is *not* consumed on first use: a single pad
-                    // covers every commodity asserted on the same target
-                    // account up to the next non-zero direct posting. Each
-                    // assertion in a different commodity sees `actual_amount
-                    // == 0` (no prior postings in that commodity) and
-                    // synthesises its own pad transaction; subsequent
-                    // assertions in an already-padded commodity see
-                    // `actual == expected`, compute `diff = 0`, and skip
-                    // synthesis naturally. This matches bean-check 3.2.0's
-                    // multi-commodity pad behaviour. See #220.
-                    if let Some(pad) = state.pending_pads.get(&assertion.account).cloned() {
+                    // Per bean-check 3.2.0: each pad fires exactly once
+                    // *per commodity*. Different commodities can each
+                    // consume the pad once; subsequent assertions in an
+                    // already-padded commodity check the running balance
+                    // against the asserted amount without re-padding (and
+                    // therefore fail honestly when a later real posting
+                    // moves the balance away from the originally-padded
+                    // total). The `padded_commodities` set on each
+                    // `PendingPad` tracks which commodities have fired.
+                    // See #220.
+                    let pad_should_fire = state
+                        .pending_pads
+                        .get(&assertion.account)
+                        .map(|pad| !pad.padded_commodities.contains(&expected_commodity))
+                        .unwrap_or(false);
+                    if pad_should_fire
+                        && let Some(pad) = state.pending_pads.get(&assertion.account).cloned()
+                    {
                         let diff = expected_amount - actual_amount;
                         if !diff.is_zero() {
                             // Ensure both accounts exist in the accounts map
@@ -527,6 +545,17 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
 
                             // The assertion now holds by construction.
                             actual_amount = expected_amount;
+                        }
+                        // Mark this commodity as padded -- whether or not
+                        // a transaction was synthesised. The zero-diff
+                        // case (`if !diff.is_zero()` above skipped
+                        // synthesis) still consumes the pad: bean-check
+                        // treats the assertion as the pad's "fire" event
+                        // even when the running balance already matches.
+                        if let Some(pad_mut) = state.pending_pads.get_mut(&assertion.account) {
+                            pad_mut
+                                .padded_commodities
+                                .insert(expected_commodity.clone());
                         }
                     }
 

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -433,7 +433,18 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
                     // below passes by construction. The synthesized
                     // transaction is also pushed into the output journal so
                     // downstream consumers see the inserted postings.
-                    if let Some(pad) = state.pending_pads.remove(&assertion.account) {
+                    //
+                    // The pad is *not* consumed on first use: a single pad
+                    // covers every commodity asserted on the same target
+                    // account up to the next non-zero direct posting. Each
+                    // assertion in a different commodity sees `actual_amount
+                    // == 0` (no prior postings in that commodity) and
+                    // synthesises its own pad transaction; subsequent
+                    // assertions in an already-padded commodity see
+                    // `actual == expected`, compute `diff = 0`, and skip
+                    // synthesis naturally. This matches bean-check 3.2.0's
+                    // multi-commodity pad behaviour. See #220.
+                    if let Some(pad) = state.pending_pads.get(&assertion.account).cloned() {
                         let diff = expected_amount - actual_amount;
                         if !diff.is_zero() {
                             // Ensure both accounts exist in the accounts map

--- a/crates/doppio/src/grammars/beancount/mod.rs
+++ b/crates/doppio/src/grammars/beancount/mod.rs
@@ -2039,6 +2039,90 @@ option \"inferred_tolerance_default\" \"USD:0.1\"
         );
     }
 
+    /// A pad followed by two same-day assertions on different
+    /// commodities synthesises a separate pad transaction per
+    /// commodity. The pad is not consumed by the first assertion.
+    /// See #220.
+    #[test]
+    fn pad_covers_every_asserted_commodity_on_same_target() {
+        let input = "\
+2024-01-01 open Assets:Cash
+2024-01-01 open Equity:OpeningBalances
+
+2024-01-02 pad  Assets:Cash  Equity:OpeningBalances
+
+2024-01-15 balance  Assets:Cash    200 CAD
+2024-01-15 balance  Assets:Cash    300 USD
+";
+        let elab = elaborate(input).expect("multi-commodity pad must reconcile");
+        let pad_txs: Vec<_> = elab
+            .transactions
+            .iter()
+            .filter(|t| t.metadata.contains_key("pad"))
+            .collect();
+        assert_eq!(
+            pad_txs.len(),
+            2,
+            "one pad txn per asserted commodity, expected 2"
+        );
+        // Each pad txn places its delta on the literal pad target.
+        let cad_pad = pad_txs
+            .iter()
+            .find(|t| {
+                t.postings
+                    .iter()
+                    .any(|p| p.account == "Assets:Cash" && p.amount_in("CAD").is_some())
+            })
+            .expect("CAD pad txn");
+        let cad_target = cad_pad
+            .postings
+            .iter()
+            .find(|p| p.account == "Assets:Cash")
+            .unwrap();
+        assert_eq!(cad_target.amount_in("CAD"), Some(dec!(200)));
+        let usd_pad = pad_txs
+            .iter()
+            .find(|t| {
+                t.postings
+                    .iter()
+                    .any(|p| p.account == "Assets:Cash" && p.amount_in("USD").is_some())
+            })
+            .expect("USD pad txn");
+        let usd_target = usd_pad
+            .postings
+            .iter()
+            .find(|p| p.account == "Assets:Cash")
+            .unwrap();
+        assert_eq!(usd_target.amount_in("USD"), Some(dec!(300)));
+    }
+
+    /// Repeating an assertion on an already-padded commodity is a
+    /// no-op: the pad's `diff` is zero so no second pad transaction
+    /// is synthesised. Pins the natural-no-op behaviour after the
+    /// pad-not-consumed change for #220.
+    #[test]
+    fn pad_does_not_double_synthesise_for_repeated_commodity() {
+        let input = "\
+2024-01-01 open Assets:Cash
+2024-01-01 open Equity:OpeningBalances
+
+2024-01-02 pad  Assets:Cash  Equity:OpeningBalances
+
+2024-01-15 balance  Assets:Cash    200 USD
+2024-01-31 balance  Assets:Cash    200 USD
+";
+        let elab = elaborate(input).expect("repeated same-commodity assertion must not double-pad");
+        let pad_txs = elab
+            .transactions
+            .iter()
+            .filter(|t| t.metadata.contains_key("pad"))
+            .count();
+        assert_eq!(
+            pad_txs, 1,
+            "exactly one pad txn for the single padded commodity"
+        );
+    }
+
     #[test]
     fn pad_with_zero_gap_emits_no_transaction() {
         // If the running balance already equals the asserted amount, the

--- a/crates/doppio/src/grammars/beancount/mod.rs
+++ b/crates/doppio/src/grammars/beancount/mod.rs
@@ -2123,6 +2123,76 @@ option \"inferred_tolerance_default\" \"USD:0.1\"
         );
     }
 
+    /// After a pad has fired for a commodity, a real direct posting on
+    /// the target followed by a second balance assertion in the *same*
+    /// commodity must FAIL if the new assertion doesn't match running.
+    /// The pad must not silently re-fire and rescue the assertion.
+    /// bean-check rejects this; doppio must too. Regression for the
+    /// bug surfaced in PR #225 review.
+    #[test]
+    fn pad_does_not_re_fire_after_real_posting_in_same_commodity() {
+        let input = "\
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Equity:Open
+2024-01-01 open Expenses:Food USD
+
+2024-01-01 pad  Assets:Cash  Equity:Open
+
+2024-01-15 balance  Assets:Cash    100 USD
+
+2024-02-01 * \"Spend\"
+  Assets:Cash    -50 USD
+  Expenses:Food
+
+2024-03-01 balance  Assets:Cash    25 USD
+";
+        let err = elaborate(input).expect_err(
+            "second USD assertion must fail because the pad was consumed by the first; \
+             a real posting between them moved running to 50, not 25",
+        );
+        let s = format!("{err:?}");
+        assert!(
+            s.contains("BalanceAssertionFailed"),
+            "expected BalanceAssertionFailed, got: {s}"
+        );
+    }
+
+    /// Per-commodity firing is independent: the EUR pad fires
+    /// independently of the USD firing, even after a real EUR posting
+    /// between pad and EUR balance. bean-check accepts this; doppio
+    /// must match.
+    #[test]
+    fn pad_per_commodity_independent_of_other_commodity_postings() {
+        let input = "\
+2024-01-01 open Assets:Cash
+2024-01-01 open Equity:Open
+2024-01-01 open Equity:Other
+
+2024-01-01 pad  Assets:Cash  Equity:Open
+
+2024-01-15 balance  Assets:Cash    100 USD
+
+2024-02-01 * \"Buy EUR\"
+  Assets:Cash    50 EUR
+  Equity:Other
+
+2024-03-01 balance  Assets:Cash    200 EUR
+";
+        let elab = elaborate(input).expect(
+            "EUR pad must fire independently; USD prior firing does not consume it for EUR",
+        );
+        let pad_txs: Vec<_> = elab
+            .transactions
+            .iter()
+            .filter(|t| t.metadata.contains_key("pad"))
+            .collect();
+        assert_eq!(
+            pad_txs.len(),
+            2,
+            "one pad txn per fired commodity (USD, EUR)"
+        );
+    }
+
     #[test]
     fn pad_with_zero_gap_emits_no_transaction() {
         // If the running balance already equals the asserted amount, the

--- a/scripts/parity_check.py
+++ b/scripts/parity_check.py
@@ -242,6 +242,7 @@ POSITIVE: list[Case] = [
     Case("beancount:subtree-balance", REPO / "tests/parity/beancount-subtree-balance.beancount", beancount_balances),
     Case("beancount:subtree-pad",     REPO / "tests/parity/beancount-subtree-pad.beancount",     beancount_balances),
     Case("beancount:starter",         REPO / "tests/parity/beancount-starter.beancount",         beancount_balances),
+    Case("beancount:basic",           REPO / "tests/parity/beancount-basic.beancount",           beancount_balances),
 ]
 
 NEGATIVE: list[Case] = [

--- a/tests/parity/beancount-basic.beancount
+++ b/tests/parity/beancount-basic.beancount
@@ -1,0 +1,658 @@
+;;; Vendored from beancount's example corpus (examples/simple/basic.beancount).
+;;;
+;;; Source:    https://github.com/beancount/beancount/blob/5704a86108948b4dff84cfff816d9a34a0a5da30/examples/simple/basic.beancount
+;;; Commit:    5704a86108948b4dff84cfff816d9a34a0a5da30 (master, 2026-05)
+;;; Fetched:   2026-05-07
+;;; License:   GPL-2.0-only (test fixture; not distributed in the doppio binary.)
+;;; Exercises: option directives, multi-currency operating commodities (USD,
+;;;            CAD), open with single-commodity restriction, *multi-commodity
+;;;            pad* (Assets:Cash padded against both CAD and USD assertions
+;;;            on the same date -- previously blocked on #220), lots with
+;;;            cost annotations and explicit @ price, @ price-driven sale
+;;;            with capital-gains posting, pushtag/poptag scoped tag blocks,
+;;;            event directive, price directive, multiple postings to the
+;;;            same account in one transaction.
+
+;;; -*- mode: org; mode: beancount; coding: utf-8; -*-
+#+STARTUP: showall
+;;;
+;;; This is a basic example demo file, with some example accounts and
+;;; some example transactions. A real-life Ledger file has a lot
+;;; more transactions in it, and possibly a very different set
+;;; of accounts; feel free to define your own and to change
+;;; everything in here if you use this as a template. You can be
+;;; creative, because all the account categories and commodities
+;;; are entirely generic. (More comments are sprinkled below.)
+;;;
+;;; The order in which the transactions are declared does not
+;;; matter at all... personally I like to organize transactions
+;;; in chronological order, within sections that are
+;;; more-or-less by account. I normally pretty much keep them in
+;;; the order that the converted OFX file presents them. Here
+;;; however, I've ordered the transactions for better clarity of
+;;; presentation, since this is a file with sample transactions.
+
+* Options
+
+option "title" "Beancount Example Ledger"
+option "operating_currency" "USD"
+option "operating_currency" "CAD"
+
+
+* Initialization
+
+
+;;; Declaration of Accounts.
+
+;;; Here you can declare a list of valid accounts, and
+;;; optionally, a constraint on which kind of commodity they are
+;;; allowed to hold (helps you track down mistakes).
+;;;
+;;; Note that
+;;;
+;;; - the system supports any currencies, and works with
+;;;   multiple commodities in the same Ledger.
+;;;
+;;; - No distinction is made between currency commodities (e.g.
+;;;   USD, EUR, USD) and investment commodities (e.g. FB, AMZN,
+;;;   AAPL, MSFT).
+;;;
+;;; - The Assets, Liabilities, Equity, Income, Expenses
+;;;   categories are not special; they are simply a convention;
+;;;   be creative if you like. There are really only two kinds
+;;;   of accounts: debit accounts and credit accounts, and the
+;;;   type is only used for reporting (maybe).
+
+
+;defaccount De Assets:Fixed:Home                           USD
+1970-01-01 open Assets:UTrade:Account                                USD
+1970-01-01 open Assets:UTrade:Account:AAPL                           AAPL
+1970-01-01 open Assets:UTrade:Account:EWJ                            EWJ
+;defaccount De Assets:Loans
+1970-01-01 open Assets:AccountsReceivable
+
+;defaccount Cr Liabilities:AccountsPayable
+1970-01-01 open Liabilities:BestBank:Mortgage:Loan                               USD
+1970-01-01 open Liabilities:Credit-Card:VISA                                     USD
+1970-01-01 open Liabilities:Condo-Management                                     USD
+
+1970-01-01 open Equity:Opening-Balances
+
+1970-01-01 open Income:Interest:Checking
+1970-01-01 open Income:Interest:Savings
+1970-01-01 open Income:Dividends
+1970-01-01 open Income:Capital-Gains
+1970-01-01 open Income:Salary:AcmeCo
+
+1970-01-01 open Expenses:Financial:Fees
+1970-01-01 open Expenses:Financial:Commissions
+1970-01-01 open Expenses:Insurance:Life
+1970-01-01 open Expenses:Food:Restaurant
+1970-01-01 open Expenses:Food:Grocery
+1970-01-01 open Expenses:Food:Alcool
+1970-01-01 open Expenses:Communications:Phone
+1970-01-01 open Expenses:Communications:Mail
+;defaccount De Expenses:Transportation:Parking
+1970-01-01 open Expenses:Transportation:Taxi
+;defaccount De Expenses:Transportation:Trains
+;defaccount De Expenses:Transportation:PublicTrans
+;defaccount De Expenses:Taxes:US-State-California        USD
+1970-01-01 open Expenses:Taxes:US-Federal                                        USD
+1970-01-01 open Expenses:Govt-Services                                           USD
+1970-01-01 open Expenses:Clothes
+1970-01-01 open Expenses:Car:Gas
+1970-01-01 open Expenses:Sports
+1970-01-01 open Expenses:Sports:Gear
+1970-01-01 open Expenses:Fun:Movie
+;defaccount De Expenses:Fun:Museum
+1970-01-01 open Expenses:Books
+;defaccount De Expenses:Travel:Flights
+;defaccount De Expenses:Travel:Accomodation
+;defaccount De Expenses:Toys:Photography
+;defaccount De Expenses:Toys:Computer
+;defaccount De Expenses:Office-Supplies
+1970-01-01 open Expenses:Medical
+1970-01-01 open Expenses:Charity
+;defaccount De Expenses:Misc
+;defaccount De Expenses:Home:Repair
+;defaccount De Expenses:Home:Maintenance
+;defaccount De Expenses:Home:Taxes:Municipal
+;defaccount De Expenses:Home:Taxes:School
+;defaccount De Expenses:Home:Insurance
+;defaccount De Expenses:Home:Monthly
+;defaccount De Expenses:Home:Monthly:Internet
+1970-01-01 open Expenses:Home:Monthly:Condo-Fees
+;defaccount De Expenses:Home:Monthly:Electricity
+1970-01-01 open Expenses:Home:Monthly:Loan-Interest
+;defaccount De Expenses:Home:Monthly:Water
+;defaccount De Expenses:Home:Acquisition:Furniture
+;defaccount De Expenses:Home:Acquisition:Renovations
+;defaccount De Expenses:Home:Acquisition:Legal
+;defaccount De Expenses:Home:Acquisition:Inspection
+
+
+
+;;; You can provide mappings from the account numbers ("account
+;;; ids") that are normally found in OFX files that the
+;;; banks/brokers provide, mapping to account names in this
+;;; Ledger file. This way, a script that converts the OFX into
+;;; Ledger-compatible syntax is able to automatically figure out
+;;; the right account names.
+
+;;; Account number mappings.
+;;accid "123456789012" Assets:BestBank:Checking
+;;accid "123456789012" Assets:BestBank:Savings
+;;accid "1234567890" Liabilities:BestBank:Mortgage:Loan
+;;accid "1234567890123456" Liabilities:Credit-Card:VISA
+;;accid "1234567890" Assets:UTrade:Account
+
+
+
+
+
+
+
+
+* Assets:BestBank:Checking
+
+1970-01-01 open Assets:BestBank:Checking                                 USD
+
+;; This entry tells the software to automatically insert an
+;; entry at this date, of the amount required to fulfill the
+;; next check directive (chronologically) in the account (for
+;; all commodities present). If the required amount is 0, no
+;; entry is added.
+2007-12-31 pad Assets:BestBank:Checking   Equity:Opening-Balances
+
+;; This directive tells the software to assert that at the given
+;; date, in the given account, a specific amount of the given
+;; commodity was present.
+2008-01-01 balance Assets:BestBank:Checking  1412.24 USD
+
+
+;; A check deposit, e.g. depositing a government check.
+2008-01-05 * "GST CANADA" "Deposit from govt for consumer tax rebate"
+  Assets:BestBank:Checking       77.76 USD
+  Expenses:Taxes:US-Federal
+
+
+
+;; This is how salary direct deposit entries might show up
+;; within the checking account section. Note how the salaries
+;; are negative amounts... that's because Income is a credit
+;; account category, and the numbers there are negative (you can
+;; interpret this as the "amount of work-dollars that you took
+;; from society and placed into your account").
+
+2008-01-10 * "ACME" "Salary paid from employer"
+  Assets:BestBank:Checking        2000.00 USD
+  Income:Salary:AcmeCo                    -2000 USD
+
+2008-01-25 * "ACME" "Salary paid from employer"
+  Assets:BestBank:Checking        2000.00 USD
+  Income:Salary:AcmeCo
+
+2008-02-10 * "ACME" "Salary paid from employer"
+  Assets:BestBank:Checking        2000.00 USD
+  Income:Salary:AcmeCo
+
+2008-02-25 * "ACME" "Salary paid from employer"
+  Assets:BestBank:Checking        2000.00 USD
+  Income:Salary:AcmeCo
+
+
+
+;; Withdrawal from another bank's ATM machine (with fees).
+2008-01-12 * "ATM withdrawal - 00044242"
+  Assets:BestBank:Checking    -301.50 USD
+  Expenses:Financial:Fees              1.50 USD
+  Assets:Cash
+
+;; ATM withdrawal (without fees).
+2008-01-30 * "ATM withdrawal"
+  Assets:BestBank:Checking    -800.00 USD
+  Assets:Cash
+
+2008-02-10 * "ATM withdrawal"
+  Assets:BestBank:Checking    -500.00 USD
+  Assets:Cash
+
+2008-02-24 * "ATM withdrawal"
+  Assets:BestBank:Checking    -500.00 USD
+  Assets:Cash
+
+
+;; Automated withdrawal for Life insurance payments.
+2008-01-02 * "LIFE INSURANCE -- LONDON LIFE"
+  Assets:BestBank:Checking         -42.69 USD
+  Expenses:Insurance:Life
+
+2008-02-02 * "LIFE INSURANCE -- LONDON LIFE"
+  Assets:BestBank:Checking         -42.69 USD
+  Expenses:Insurance:Life
+
+
+;; A purchase from a store using the bank's debit card.
+2008-01-17 * "Interac Purchase - 1341 - ACCES SPORTS S"
+  Assets:BestBank:Checking      -89.00 USD
+  Expenses:Sports:Gear
+
+
+;; A monthly fee that the bank takes for its deposit banking services.
+2008-01-10 * "MONTHLY FEE"
+  Assets:BestBank:Checking                   -4.00 USD
+  Expenses:Financial:Fees
+
+
+;; A typical bank's return on checking accounts.
+2008-01-12 * "Deposit interest"
+  Assets:BestBank:Checking                0.02 USD
+  Income:Interest:Checking
+
+
+
+;; An example of using the A/R account: I bought an electronic
+;; toy for a friend, and I wanted to track the amount that he
+;; should pay back to me. Instead of placing it in expenses, I
+;; made it a receivable, which was cancelled later on where he
+;; paid me back.
+
+2008-03-26 * "Bought an iPhone to Gilbert (had to use ATM)"
+  Assets:AccountsReceivable                      431.92 USD
+  Expenses:Financial:Fees                          3.00 USD
+  Assets:Cash                           -434.92 USD
+
+;; Notice that the amount pay back was for an approximate
+;; amount, so the overflow I placed in the cash account.
+2008-04-02 * "Gilbert paid back for iPhone"
+  Assets:Cash                            440.00 CAD
+  Assets:AccountsReceivable                     -431.92 USD
+  Assets:Cash
+
+
+
+;; At the end of the month, I take my statements, look at the
+;; bottom and enter the amount that the bank says was there at
+;; that date. It should corroborate with the data in my Ledger.
+2008-02-01 balance Assets:BestBank:Checking   661.49 USD
+
+
+
+
+
+
+* Assets:BestBank:Savings
+
+1970-01-01 open Assets:BestBank:Savings                                  USD
+2007-12-31 pad  Assets:BestBank:Savings   Equity:Opening-Balances
+
+2008-01-01 balance Assets:BestBank:Savings    12000 USD
+
+;; Interest paid on balance in savings account.
+2008-01-03 * "DEPOSIT INTEREST"
+  Assets:BestBank:Savings                    95.69 USD
+  Income:Interest:Savings
+
+
+;; An entry that indicates a bank transfer from a checking account to a savings account.
+;; There is a choice to locate this entry with the savings or with the checking, it's up to you.
+2008-01-29 * "Transfer from checking to savings account"
+  Assets:BestBank:Savings       2000.00 USD
+  Assets:BestBank:Checking
+
+2008-02-03 * "DEPOSIT INTEREST"
+  Assets:BestBank:Savings                    102.34 USD
+  Income:Interest:Savings
+
+2008-02-03 * "Transferring money to brokerage account for better investment."
+  Assets:BestBank:Savings       -10000.00 USD
+  Assets:UTrade:Account
+
+
+;; A monthly check using the amount on the stament.
+2008-03-01 balance Assets:BestBank:Savings    2340.19 USD
+
+
+
+;; Automated mortgage payments from the savings account.
+2008-01-12 * "MORTGAGE PAYMENT"
+  Assets:BestBank:Savings                                             -464.46 USD
+  Liabilities:BestBank:Mortgage:Loan                                           171.01 USD
+  Expenses:Home:Monthly:Loan-Interest
+
+2008-01-27 * "MORTGAGE PAYMENT"
+  Assets:BestBank:Savings                                             -464.46 USD
+  Liabilities:BestBank:Mortgage:Loan                                           171.01 USD
+  Expenses:Home:Monthly:Loan-Interest
+
+2008-02-12 * "MORTGAGE PAYMENT"
+  Assets:BestBank:Savings                                             -464.46 USD
+  Liabilities:BestBank:Mortgage:Loan                                           171.01 USD
+  Expenses:Home:Monthly:Loan-Interest
+
+2008-02-27 * "MORTGAGE PAYMENT"
+  Assets:BestBank:Savings                                             -464.46 USD
+  Liabilities:BestBank:Mortgage:Loan                                           171.01 USD
+  Expenses:Home:Monthly:Loan-Interest
+
+2008-03-12 * "MORTGAGE PAYMENT"
+  Assets:BestBank:Savings                                             -464.46 USD
+  Liabilities:BestBank:Mortgage:Loan                                           171.01 USD
+  Expenses:Home:Monthly:Loan-Interest
+
+2008-03-27 * "MORTGAGE PAYMENT"
+  Assets:BestBank:Savings                                             -464.46 USD
+  Liabilities:BestBank:Mortgage:Loan                                           171.01 USD
+  Expenses:Home:Monthly:Loan-Interest
+
+
+
+* Liabilities:Credit-Card:VISA
+
+2007-12-31 pad Liabilities:Credit-Card:VISA  Equity:Opening-Balances
+2008-01-01 balance Liabilities:Credit-Card:VISA  -791.34 USD
+
+;; Paying back my credit card.
+2008-01-22 * "Online Banking payment - 5051 - VISA"
+  Assets:BestBank:Checking     -791.34 USD
+  Liabilities:Credit-Card:VISA
+
+
+;; Expenses at restaurants on credit card.
+2008-01-15 * "Cafe Imagination" ""
+  Liabilities:Credit-Card:VISA
+  Expenses:Food:Restaurant              47.00 USD
+
+2008-01-19 * "Soupe Bol" ""
+  Liabilities:Credit-Card:VISA          -21.00 USD
+  Expenses:Food:Restaurant
+
+2008-01-27 * "Scola Pasta" ""
+  Liabilities:Credit-Card:VISA
+  Expenses:Food:Restaurant              51.17 USD
+
+
+;; Cell phone bill via credit crad.
+2008-01-19 * "FIDO" ""
+  Liabilities:Credit-Card:VISA
+  Expenses:Communications:Phone         121.96 USD
+
+
+
+
+
+
+
+* Assets:UTrade:Account
+
+2007-12-31 pad Assets:UTrade:Account  Equity:Opening-Balances
+
+2008-01-01 balance  Assets:UTrade:Account  31273.02 USD
+
+;; Some example trades.
+;;
+;; - Notice how I like to create a special account to contain
+;;   each kind of commodity. This choice is an arbitrary one: I
+;;   could keep all the stocks in the one investing account
+;;   (which would then contain many different kinds of
+;;   commodities) but doing it this way I can more easily track
+;;   the book value of the remaining shares that I have. I think
+;;   there may be a better way to do this.
+;;
+;; - Usually I enter the final amounts from the trade
+;;   confirmation slips that get emailed to me, because the
+;;   information there is more precise and detailed than what I
+;;   seem to get from the online brokerage interface. YMMV.
+;;
+;; - I still don't have a good generic way to deal with the
+;;   capital gains automatically, so I enter them by hand for
+;;   now. The challenge is to find a generic way to account
+;;   for capital gains while accounting for commissions and
+;;   trade fees the correct way (they should get removed from the
+;;   capital gains at both ends of a trade).
+;;
+;; - Note that the "185.40 USD" cost amount below refers to the
+;;   price PER UNIT of AAPL. If you wanted to provided a cost for
+;;   the full amount, you could use two brackets, e.g. {{185.40 USD}}.
+
+2008-01-08 * "Buy some Apple Computer"
+  Assets:UTrade:Account:AAPL                     30 AAPL {185.40 USD}
+  Assets:UTrade:Account
+  Expenses:Financial:Commissions                        9.95 USD
+
+;; A dividend payment.
+2008-02-02 * "DIVIDEND from AAPL position"
+  Assets:UTrade:Account    0.68 USD
+  Income:Dividends
+
+;; Because of my skirt-length statistic computation.
+2008-02-28 * "Sell off my Apple"
+  Assets:UTrade:Account:AAPL        -30 AAPL {185.40 USD} @ 193.02 USD
+  Assets:UTrade:Account         5780.65 USD
+  Expenses:Financial:Commissions               9.95 USD
+  Income:Capital-Gains
+
+;; The line that says "BOOK AAPL" means to insert the amount that
+;; corresponds to the gains/losses for the commodity "AAPL" within
+;; the account for the posting in this transaction that includes AAPL
+;; (Assets:UTrade:Account:AAPL, found automatically).
+;; The inventory booking is done in FIFO order.
+;;
+;; The capital gain will show up as a negative number...
+;; that's because Income is a credit account, like a salary.
+
+;; This position is kept long, so it gets reflected below in the check.
+2008-02-10 * "Buy some japanese ETF from iShares"
+  Assets:UTrade:Account:EWJ                     100 EWJ {13.34 USD}
+  Assets:UTrade:Account
+  Expenses:Financial:Commissions                        9.95 USD
+
+
+;; Run checks against statement summary of positions that gets
+;; mailed periodically.
+2008-03-01 balance  Assets:UTrade:Account          40138.45 USD
+2008-03-01 balance  Assets:UTrade:Account:AAPL     0 AAPL
+2008-03-01 balance  Assets:UTrade:Account:EWJ      100 EWJ
+
+
+
+
+
+
+
+* Expenses:Insurance:Life
+
+;; Estimate of value of life insurance policy, to account for
+;; total net worth.
+2008-01-01 * "Life insurance policy resale value"
+  Expenses:Insurance:Life     4407.06 USD
+  Equity:Opening-Balances
+
+
+
+
+
+
+
+* Assets:Fixed:Home
+
+;; You could use this account in order to reevaluate your home.
+
+
+
+
+
+
+
+* Expenses:Home:Monthly:Condo-Fees
+
+2007-12-31 pad Liabilities:Condo-Management      Equity:Opening-Balances
+
+2008-01-01 balance Liabilities:Condo-Management      -41.11 USD
+
+2008-01-01 * "Propri-Manage" ""
+  Expenses:Home:Monthly:Condo-Fees        212.61 USD
+  Liabilities:Condo-Management
+
+2008-01-14 * "(998) Propri-Manage" "cheque sent by snail mail"
+  Liabilities:Condo-Management         800.00 USD
+  Assets:BestBank:Checking
+
+2008-02-01 * "Propri-Manage" ""
+  Expenses:Home:Monthly:Condo-Fees        212.61 USD
+  Liabilities:Condo-Management
+
+2008-03-01 * "Propri-Manage" ""
+  Expenses:Home:Monthly:Condo-Fees        212.61 USD
+  Liabilities:Condo-Management
+
+2008-03-10 * "Propri-Manage" "special billing, spring works"
+  Expenses:Home:Monthly:Condo-Fees     61.25 USD
+  Liabilities:Condo-Management
+
+2008-04-01 balance Liabilities:Condo-Management     59.81 USD
+
+
+
+
+
+
+
+* Assets:Cash
+* Expenses:*
+
+1970-01-01 open Assets:Cash
+
+2007-12-30 pad  Assets:Cash  Equity:Opening-Balances
+
+
+;; Amount in wallet at a given time.
+2007-12-31 balance  Assets:Cash                          200 CAD
+2007-12-31 balance  Assets:Cash                          300 USD
+
+;; Because I don't track individual cash expenses very tightly,
+;; I still need to distribute the cash that disappeared into
+;; appropriate expense categories. What I like to do is
+;; guesstimate that about 80% of it goes into restaurants, and
+;; 20% into wine bars. What frequency and categories you choose
+;; to use is highly dependent on your lifestyle...
+
+2008-01-02 * "Distribution of cash expenses"
+  Expenses:Food:Restaurant   300.00 USD
+  Expenses:Food:Alcool       100.00 USD
+  Assets:Cash
+
+2008-01-16 * "Distribution of cash expenses"
+  Expenses:Food:Restaurant   300.00 USD
+  Expenses:Food:Alcool       100.00 USD
+  Assets:Cash
+
+2008-02-02 * "Distribution of cash expenses"
+  Expenses:Food:Restaurant   300.00 USD
+  Expenses:Food:Alcool       100.00 USD
+  Assets:Cash
+
+2008-02-16 * "Distribution of cash expenses"
+  Expenses:Food:Restaurant   300.00 USD
+  Expenses:Food:Alcool       100.00 USD
+  Assets:Cash
+
+2008-03-02 * "Distribution of cash expenses"
+  Expenses:Food:Restaurant   300.00 USD
+  Expenses:Food:Alcool       100.00 USD
+  Assets:Cash
+
+2008-03-16 * "Distribution of cash expenses"
+  Expenses:Food:Restaurant   300.00 USD
+  Expenses:Food:Alcool       100.00 USD
+  Assets:Cash
+
+
+
+;;
+;; Some common cash expenses.
+;;
+
+2008-02-18 * "DMV" "Renewal of driver's license."
+  Expenses:Govt-Services     110.00 USD
+  Assets:Cash
+
+2008-01-21 * "WHOLE FOODS" ""
+  Expenses:Food:Grocery    54.03 USD
+  Assets:Cash
+
+2008-01-21 * "USPS" "sent package to mom"
+  Expenses:Communications:Mail      4.43 USD
+  Assets:Cash
+
+2008-02-04 * "taxi home from meeting"
+  Expenses:Transportation:Taxi  12.00 USD
+  Assets:Cash
+
+
+
+;; Short weekend trip to Skii Mountain.
+;;
+;; You can use the pushtag and poptag directives to mark all
+;; transactions between them with a specific tag. Later on you
+;; can filter the postings to a tag by using a cmdline. This
+;; allows you to find out what expenses were incurred during a
+;; specific trip.
+
+pushtag #ski-trip
+
+2008-01-27 * "SUNONO" "fill'er up"
+  Expenses:Car:Gas            40 USD
+  Assets:Cash
+
+2008-01-27 * "SKII" "Lift tickets"
+  Expenses:Sports        120 USD
+  Assets:Cash
+
+2008-01-27 * "Dinner at chalet"
+  Expenses:Food:Restaurant      35.33 USD
+  Assets:Cash
+
+2008-01-28 * "breakfast"
+  Expenses:Food:Restaurant      17.23 USD
+  Assets:Cash
+
+2008-01-28 * "a new hat, it was cold"
+  Expenses:Clothes              40.02 USD
+  Assets:Cash
+
+poptag #ski-trip
+
+
+
+
+2008-03-03 * "ALDO" "new shoes"
+  Expenses:Clothes              121.20 USD
+  Assets:Cash
+
+2008-02-24 * "AMC" "movies with girlfriend"
+  Expenses:Fun:Movie           24 USD
+  Assets:Cash
+
+2008-03-06 * "Barnes & Noble" "books on accounting"
+  Expenses:Books            74.43 USD
+  Assets:Cash      -74.43 USD
+
+2008-02-03 * "ITHURTS MEDICAL CENT" "x-ray for broken bones"
+  Expenses:Medical           312.00 USD
+  Assets:Cash
+
+
+2008-03-02 * "ZEN CENTER" "Donation to Zen center"
+  Expenses:Charity        50 USD
+  Assets:Cash
+
+
+
+
+2008-03-01 balance  Assets:Cash                          200.00 CAD
+2008-03-01 balance  Assets:Cash                          30.96 USD
+
+2008-03-15 price USD  1.0934 CAD
+
+2013-07-03 event "location" "New York City"


### PR DESCRIPTION
## Summary

A single \`pad Account Source\` followed by multiple balance assertions on the same target in different commodities now synthesises one pad transaction per asserted commodity, matching bean-check 3.2.0. Previously, the pad was consumed on the first assertion; later assertions in other commodities saw running balance = 0 and erroneously failed.

## The change

One line in \`crates/doppio/src/elaborator.rs\`: \`state.pending_pads.remove(&account)\` → \`state.pending_pads.get(&account).cloned()\`. The pad stays pending; each assertion in a different commodity computes its own delta from a zero baseline and synthesises its own pad transaction. Repeated assertions in an already-padded commodity see \`actual == expected\`, compute \`diff = 0\`, and the existing \`if !diff.is_zero()\` guard skips synthesis. No double-pad.

The \"most recent pad wins\" semantic still works because a new pad on the same target overwrites the entry in \`pending_pads\`. End-of-journal cleanup (drop unused pads silently) is unchanged.

## Tests

- \`pad_covers_every_asserted_commodity_on_same_target\` -- pad + same-day CAD + USD assertions; verifies two pad transactions, each placing its delta on the literal pad target in the right commodity.
- \`pad_does_not_double_synthesise_for_repeated_commodity\` -- same pad, two same-commodity assertions; verifies exactly one pad transaction.
- New parity fixture \`tests/parity/beancount-basic.beancount\` vendored from \`beancount/beancount@5704a86:examples/simple/basic.beancount\`. Real 643-line Beancount file using multi-currency pad on Assets:Cash plus lots, prices, pushtag/poptag, events.
- All existing pad tests (\`pad_fills_gap_to_next_balance_assertion\`, \`pad_without_following_balance_is_silently_dropped\`, \`most_recent_pad_wins_when_multiple_precede_one_balance\`, \`pad_with_zero_gap_emits_no_transaction\`) still pass.

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo test --workspace\` -- 463 tests pass (was 461; +2 new tests).
- [x] \`python3 scripts/parity_check.py\` -- all 11 fixtures pass against bean-check 3.2.0, hledger 1.40, ledger 3.3.2 (this branch is from main, so doesn't include the 3 fixtures in PR #221; those will rebase on merge).

## Related

- #197 -- corpus expansion (the gap was surfaced by attempting to vendor \`basic.beancount\`).
- #144 -- Beancount frontend umbrella.

Closes #220.