### PR TITLE
parity: pad-synthesised transaction comparator (#226 Phase 3)

### DIFF
--- a/scripts/parity_check.py
+++ b/scripts/parity_check.py
@@ -519,6 +519,144 @@ _register_prices_extractors()
 
 
 # ---------------------------------------------------------------------------
+# Pad-synthesised transaction extractors (#226 Phase 3).
+#
+# Both Beancount and doppio synthesise a transaction backdated to the pad
+# directive's own date that brings the running balance up to the next
+# balance assertion. The two-posting shape is identical -- target gets the
+# corrective amount, source absorbs the offset -- so a per-(date, frozenset
+# of (account, commodity, amount)) comparison catches drift in either the
+# pad date, the chosen source, or the per-commodity amount. The frozenset
+# is intentionally symmetric over the two postings: bean-check doesn't
+# label which posting is target vs source, and we don't need to.
+# ---------------------------------------------------------------------------
+
+# Per-pad-txn fingerprint: (date, frozenset((account, commodity, value))).
+PadFingerprint = tuple[str, frozenset[tuple[str, str, Decimal]]]
+
+
+def beancount_pad_fingerprints(fixture: Path) -> set[PadFingerprint]:
+    from beancount.loader import load_file
+    from beancount.core.data import Transaction
+
+    entries, errors, _ = load_file(str(fixture))
+    if errors:
+        raise RuntimeError(f"beancount errors loading {fixture}: {errors}")
+    out: set[PadFingerprint] = set()
+    for entry in entries:
+        if not isinstance(entry, Transaction):
+            continue
+        if not (entry.narration or "").startswith("(Padding inserted"):
+            continue
+        postings_set: set[tuple[str, str, Decimal]] = set()
+        for posting in entry.postings:
+            if posting.units is None:
+                continue
+            postings_set.add(
+                (
+                    posting.account,
+                    posting.units.currency,
+                    Decimal(posting.units.number),
+                )
+            )
+        out.add((entry.date.isoformat(), frozenset(postings_set)))
+    return out
+
+
+def doppio_pad_fingerprints(fixture: Path, dop_bin: Path) -> set[PadFingerprint]:
+    """Group `dop register --format=json` rows for pad-synthesised
+    transactions into per-(date, target, source) postings sets, then
+    discard the labelling and return per-(date, frozenset(postings))
+    fingerprints to match the canonical shape."""
+    raw = subprocess.run(
+        [str(dop_bin), "register", "--format=json", str(fixture)],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    payload = json.loads(raw)
+    grouped: dict[tuple[str, str, str, str], set[tuple[str, str, Decimal]]] = {}
+    for row in payload:
+        if row["description"] != "(padding inserted for balance assertion)":
+            continue
+        source = row.get("txn_metadata", {}).get("pad")
+        if source is None:
+            continue
+        date = row["date"]
+        account = row["account"]
+        commodity = row["commodity"]
+        amount = Decimal(row["amount"])
+        if account == source:
+            grouped.setdefault((date, "__pending__", source, commodity), set()).add(
+                (account, commodity, amount)
+            )
+        else:
+            grouped.setdefault((date, account, source, commodity), set()).add(
+                (account, commodity, amount)
+            )
+    out: set[PadFingerprint] = set()
+    for key, postings in grouped.items():
+        date, target, source, commodity = key
+        if target == "__pending__":
+            continue
+        pending_key = (date, "__pending__", source, commodity)
+        pending = grouped.get(pending_key, set())
+        target_amount = next(iter(postings))[2]
+        matching_source = next(
+            (
+                p
+                for p in pending
+                if p[0] == source and p[1] == commodity and p[2] == -target_amount
+            ),
+            None,
+        )
+        full = set(postings)
+        if matching_source is not None:
+            full.add(matching_source)
+        out.add((date, frozenset(full)))
+    return out
+
+
+def diff_pad_fingerprints(
+    canonical: set[PadFingerprint], doppio: set[PadFingerprint]
+) -> str | None:
+    if canonical == doppio:
+        return None
+    only_canon = canonical - doppio
+    only_dop = doppio - canonical
+    lines = []
+    if only_canon:
+        lines.append("  pad txns only in canonical:")
+        for fp in sorted(only_canon, key=lambda x: (x[0], sorted(map(str, x[1])))):
+            date, postings = fp
+            posting_strs = ", ".join(
+                f"{a} {v} {c}" for (a, c, v) in sorted(postings)
+            )
+            lines.append(f"    [{date}] {{ {posting_strs} }}")
+    if only_dop:
+        lines.append("  pad txns only in doppio:")
+        for fp in sorted(only_dop, key=lambda x: (x[0], sorted(map(str, x[1])))):
+            date, postings = fp
+            posting_strs = ", ".join(
+                f"{a} {v} {c}" for (a, c, v) in sorted(postings)
+            )
+            lines.append(f"    [{date}] {{ {posting_strs} }}")
+    return "\n".join(lines)
+
+
+PAD_EXTRACTOR: dict[CanonicalFn, Callable[[Path], set[PadFingerprint]] | None] = {}
+
+
+def _register_pad_extractors() -> None:
+    """Only Beancount has a `pad` directive analogue. hledger / ledger-cli
+    have no equivalent; their fixtures return empty sets on both sides."""
+    PAD_EXTRACTOR[beancount_balances] = beancount_pad_fingerprints
+    PAD_EXTRACTOR[hledger_balances] = None
+    PAD_EXTRACTOR[ledger_balances] = None
+
+
+_register_pad_extractors()
+
+
+# ---------------------------------------------------------------------------
 # Test catalog
 # ---------------------------------------------------------------------------
 
@@ -624,7 +762,21 @@ def run_positive(case: Case, dop_bin: Path) -> bool:
         doppio_prices_set = doppio_prices(case.fixture, dop_bin)
         prices_diff = diff_prices(canonical_prices, doppio_prices_set)
 
-    if bal_diff is None and tags_meta_diff is None and prices_diff is None:
+    # Phase 3: pad-synthesised transactions (#226). Only Beancount has a
+    # `pad` directive; other frontends always return empty sets.
+    pad_diff: str | None = None
+    pad_extractor = PAD_EXTRACTOR.get(case.canonical)
+    if pad_extractor is not None:
+        canonical_pads = pad_extractor(case.fixture)
+        doppio_pads = doppio_pad_fingerprints(case.fixture, dop_bin)
+        pad_diff = diff_pad_fingerprints(canonical_pads, doppio_pads)
+
+    if (
+        bal_diff is None
+        and tags_meta_diff is None
+        and prices_diff is None
+        and pad_diff is None
+    ):
         print("OK")
         return True
     print("MISMATCH")
@@ -637,6 +789,9 @@ def run_positive(case: Case, dop_bin: Path) -> bool:
     if prices_diff is not None:
         print("  prices:", file=sys.stderr)
         print(prices_diff, file=sys.stderr)
+    if pad_diff is not None:
+        print("  pad synthesis:", file=sys.stderr)
+        print(pad_diff, file=sys.stderr)
     return False
 
 


### PR DESCRIPTION
Third (and original-plan-final) slice of #226. Adds a fourth comparison phase to \`scripts/parity_check.py\` that diffs **pad-synthesised transactions** per fixture across each frontend, alongside the balance / tags+metadata / prices phases.

## Comparator

Three new functions in \`scripts/parity_check.py\`:

- \`beancount_pad_fingerprints\` — Python API; finds Transaction entries whose narration starts with \`(Padding inserted\` (bean-check's marker for pad synthesis), extracts the per-posting set as a frozenset of \`(account, commodity, amount)\` triples per pad txn date.
- \`doppio_pad_fingerprints\` — groups \`dop register --format=json\` rows whose description == \`(padding inserted for balance assertion)\` by \`(date, target, source, commodity)\`, reconstructs the two-posting shape, emits the same \`(date, frozenset(postings))\` pair.
- \`diff_pad_fingerprints\` — set-based comparison.

The frozenset is intentionally symmetric over the two postings: bean-check doesn't label target vs source in its synthesised txn, and the comparator doesn't need to either. If the unsigned posting set agrees, the synthesised amounts and accounts agree.

Only Beancount has a \`pad\` directive analogue; hledger and ledger-cli no-op skip.

## Coverage

All 14 fixtures pass all four phases. Spot-checked counts to verify the comparator isn't trivially passing on empty sets:

| Fixture | Pad txns (bc / dop) |
|---------|----------------------|
| \`beancount-basic.beancount\` | 7 / 7 ✓ |
| \`beancount-starter.beancount\` | 7 / 7 ✓ |
| \`beancount-subtree-pad.beancount\` | 1 / 1 ✓ |

## What this catches that prior phases don't

A regression where (account, commodity) totals stay correct but the pad mechanism produces the wrong synthesised transactions: wrong source account, wrong date, or different per-commodity amounts when a target should have been padded for several commodities. Today's fixtures all pass; the value is preventing silent regression.

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo test --workspace\` — 304 lib tests pass.
- [x] \`python3 scripts/parity_check.py\` — all 14 fixtures pass all four phases.

## Out of scope (deliberate)

- **Capital-gains synthesis** (#210). doppio synthesises gains for hledger to keep elaborated output cost-basis-balanced regardless of frontend; hledger itself doesn't synthesise these postings, so a parity comparator would always show structural divergence by design. A snapshot test would be more appropriate.
- **Rounding-residual synthesis**. doppio synthesises a posting on the empty-string account; bean-check absorbs residuals differently. Same asymmetry as gains.

With Phases 1, 2, and 3 landed, the original three-phase plan in #226 is complete. Smaller follow-ons remain: posting-level tags + metadata diffing, ledger-cli tag extraction via format string, per-transaction multiset precision (would need a per-transaction id surfaced by \`dop register\`).

Refs #226.