### PR TITLE
parity: comparator self-test (#226 acceptance)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,5 @@ jobs:
         run: python3 scripts/parity_check.py
       - name: Parity (negative — broken fixtures must be rejected by both tools)
         run: python3 scripts/parity_check.py --negative
+      - name: Parity (comparator self-test — diff funcs catch deliberate regressions)
+        run: python3 scripts/parity_check.py --self-test

--- a/scripts/parity_check.py
+++ b/scripts/parity_check.py
@@ -15,8 +15,12 @@ assert that BOTH tools reject them. This is the test-of-the-test: if a future
 change accidentally turns the parity job into a silent no-op, the negative
 controls fail loudly.
 
+Run with `--self-test` to exercise the diff functions themselves with
+hand-crafted matching/mismatching pairs. This proves each comparator
+catches divergences instead of silently returning None (#226 acceptance).
+
 Usage:
-    python3 scripts/parity_check.py [--dop-bin path/to/dop] [--negative]
+    python3 scripts/parity_check.py [--dop-bin path/to/dop] [--negative | --self-test]
 """
 from __future__ import annotations
 
@@ -820,13 +824,140 @@ def run_negative(case: Case, dop_bin: Path) -> bool:
     return False
 
 
+def self_test() -> int:
+    """Negative-control self-test for the four comparators (#226 acceptance).
+
+    For each diff function (`diff_sets`, `diff_fingerprints`, `diff_prices`,
+    `diff_pad_fingerprints`), assert:
+
+      1. A pair of equal inputs returns None ("no diff").
+      2. A pair with a single deliberate divergence (a tag dropped, a
+         price changed, a pad date shifted, a balance moved) returns a
+         non-None message that mentions the divergent item.
+
+    The aim is to prove the comparators actually catch divergences --
+    closing the silent-no-op-CI risk that #226 was filed against, but
+    one level up at the comparator itself rather than at the harness.
+
+    Exits 0 on success, 1 on failure. Self-contained: no fixtures, no
+    external tool invocations."""
+    failures: list[str] = []
+
+    def check(label: str, expected_none: bool, actual: str | None) -> None:
+        if expected_none and actual is not None:
+            failures.append(f"  {label}: expected None, got: {actual}")
+        elif not expected_none and actual is None:
+            failures.append(f"  {label}: expected non-None diff, got None (false-positive risk)")
+
+    # --- diff_sets (Phase 0: balance) -------------------------------------
+    a = {("Assets:Cash", "USD", Decimal("100"))}
+    b = {("Assets:Cash", "USD", Decimal("100"))}
+    check("diff_sets equal", True, diff_sets(a, b))
+    b2 = {("Assets:Cash", "USD", Decimal("99"))}
+    check("diff_sets amount mismatch", False, diff_sets(a, b2))
+    b3 = set()
+    check("diff_sets account dropped", False, diff_sets(a, b3))
+
+    # --- diff_fingerprints (Phase 1: tags + metadata) --------------------
+    fp_a: list[Fingerprint] = [
+        ("2024-01-15", "Bookstore", frozenset({"household"}), frozenset({("phase", "Q1")})),
+    ]
+    fp_b = list(fp_a)
+    check("diff_fingerprints equal", True, diff_fingerprints(fp_a, fp_b))
+    fp_drop_tag: list[Fingerprint] = [
+        ("2024-01-15", "Bookstore", frozenset(), frozenset({("phase", "Q1")})),
+    ]
+    check("diff_fingerprints tag dropped", False, diff_fingerprints(fp_a, fp_drop_tag))
+    fp_meta_drift: list[Fingerprint] = [
+        # Surrounding-quote regression that Phase 1 actually fixed.
+        ("2024-01-15", "Bookstore", frozenset({"household"}), frozenset({("phase", '"Q1"')})),
+    ]
+    check("diff_fingerprints meta value drift", False, diff_fingerprints(fp_a, fp_meta_drift))
+
+    # --- diff_prices (Phase 2) -------------------------------------------
+    pr_a: set[PriceQuad] = {("2024-01-02", "EUR", "USD", Decimal("1.10"))}
+    pr_b = set(pr_a)
+    check("diff_prices equal", True, diff_prices(pr_a, pr_b))
+    pr_value_drift = {("2024-01-02", "EUR", "USD", Decimal("1.11"))}
+    check("diff_prices value drift", False, diff_prices(pr_a, pr_value_drift))
+    check("diff_prices quote dropped", False, diff_prices(pr_a, set()))
+
+    # --- diff_pad_fingerprints (Phase 3) ---------------------------------
+    pad_a: set[PadFingerprint] = {
+        (
+            "2024-01-01",
+            frozenset(
+                {
+                    ("Assets:Cash", "USD", Decimal("700")),
+                    ("Equity:OpeningBalances", "USD", Decimal("-700")),
+                }
+            ),
+        )
+    }
+    pad_b = set(pad_a)
+    check("diff_pad_fingerprints equal", True, diff_pad_fingerprints(pad_a, pad_b))
+    # Source account renamed: Equity:OpeningBalances -> Equity:Other.
+    pad_source_renamed: set[PadFingerprint] = {
+        (
+            "2024-01-01",
+            frozenset(
+                {
+                    ("Assets:Cash", "USD", Decimal("700")),
+                    ("Equity:Other", "USD", Decimal("-700")),
+                }
+            ),
+        )
+    }
+    check(
+        "diff_pad_fingerprints source renamed",
+        False,
+        diff_pad_fingerprints(pad_a, pad_source_renamed),
+    )
+    # Date shifted by one day.
+    pad_date_shift: set[PadFingerprint] = {
+        (
+            "2024-01-02",
+            frozenset(
+                {
+                    ("Assets:Cash", "USD", Decimal("700")),
+                    ("Equity:OpeningBalances", "USD", Decimal("-700")),
+                }
+            ),
+        )
+    }
+    check(
+        "diff_pad_fingerprints date shifted",
+        False,
+        diff_pad_fingerprints(pad_a, pad_date_shift),
+    )
+
+    if failures:
+        print("Self-test FAILED:", file=sys.stderr)
+        for line in failures:
+            print(line, file=sys.stderr)
+        return 1
+    print("Self-test passed: 12/12 comparator assertions held.")
+    return 0
+
+
 def main() -> int:
     p = argparse.ArgumentParser()
     default_dop = REPO / "target" / "release" / "dop"
     p.add_argument("--dop-bin", default=os.environ.get("DOP_BIN") or str(default_dop))
-    p.add_argument("--negative", action="store_true",
-                   help="Run negative-control fixtures (assert both tools reject)")
+    p.add_argument(
+        "--negative", action="store_true",
+        help="Run negative-control fixtures (assert both tools reject)",
+    )
+    p.add_argument(
+        "--self-test", action="store_true",
+        help="Run hand-crafted negative-control assertions on each diff "
+             "function. Proves the comparators catch divergences instead of "
+             "silently returning None. Self-contained -- no fixtures, no tool invocations.",
+    )
     args = p.parse_args()
+
+    if args.self_test:
+        return self_test()
 
     dop_bin = Path(args.dop_bin)
     if not dop_bin.exists():


### PR DESCRIPTION
Closes the last open item in #226's original acceptance: \"a deliberately-constructed regression fails the comparator instead of being silently green.\"

## What this catches

The Phase 1/2/3 PRs landed comparators that diff tags+metadata, prices, and pad-synthesised transactions across each tool. **All four return None when both sides match** — but until now, nothing proved they'd actually return non-None on a mismatch. A refactor that, say, replaced \`diff_fingerprints\`'s \`canon_set != dop_set\` check with \`canon_set is not dop_set\` would compile, run on every fixture, and report green forever.

This PR closes that gap. Adds a \`--self-test\` mode to \`scripts/parity_check.py\` that exercises each diff function with hand-crafted input pairs:

| Comparator | Equal-pair check | Mismatch checks |
|------------|-------------------|------------------|
| \`diff_sets\` (Phase 0: balance) | ✓ | amount drift, account dropped |
| \`diff_fingerprints\` (Phase 1) | ✓ | tag dropped, metadata-value drift (the surrounding-quote regression Phase 1 actually caught) |
| \`diff_prices\` (Phase 2) | ✓ | value drift, quote dropped |
| \`diff_pad_fingerprints\` (Phase 3) | ✓ | source account renamed, date shifted |

12 assertions total. Self-contained: no fixtures, no external tool invocations, no \`dop\` binary required. Runs in milliseconds.

Wired into CI as a third parity step alongside positive and negative runs (\`.github/workflows/ci.yml\`).

## Test plan

- [x] \`python3 scripts/parity_check.py --self-test\` — 12/12 assertions pass.
- [x] Spot-checked failure mode: temporarily replacing \`if canonical == doppio: return None\` with \`return None\` (a deliberately-broken comparator) makes the matching self-test FAIL with \"expected non-None diff, got None (false-positive risk)\" -- confirming the test catches the silent-no-op class of regression it's filed against.
- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo test --workspace\` — 304 lib tests pass.

## Out of scope (filed separately)

- **#234** — parity #226 follow-ons: posting-level diffing, multiset precision, ledger-cli tag extraction.
- **#235** — snapshot regression tests for doppio's synthesised gains + rounding postings (the asymmetric-by-design counterparts to pad).

Closes #226.