### PR TITLE
refactor: decouple elaboration semantics from frontend syntax (closes #239)

### DIFF
--- a/crates/doppio-categorize/examples/eval_holdout.rs
+++ b/crates/doppio-categorize/examples/eval_holdout.rs
@@ -47,7 +47,7 @@ fn load_journal(path: &Path) -> Result<Journal, Box<dyn std::error::Error>> {
         let mut input = String::new();
         File::open(path)?.read_to_string(&mut input)?;
         let hir = frontend.parse(&input, base_path, &doppio::file_opener)?;
-        Ok(doppio::elaborate(hir, frontend.defaults())?)
+        Ok(doppio::elaborate(hir, &frontend.elaboration_defaults())?)
     }
 }
 

--- a/crates/doppio-categorize/examples/eval_holdout.rs
+++ b/crates/doppio-categorize/examples/eval_holdout.rs
@@ -47,7 +47,7 @@ fn load_journal(path: &Path) -> Result<Journal, Box<dyn std::error::Error>> {
         let mut input = String::new();
         File::open(path)?.read_to_string(&mut input)?;
         let hir = frontend.parse(&input, base_path, &doppio::file_opener)?;
-        Ok(hir.try_into()?)
+        Ok(doppio::elaborate(hir, frontend.defaults())?)
     }
 }
 

--- a/crates/doppio-cli/src/bin/timings.rs
+++ b/crates/doppio-cli/src/bin/timings.rs
@@ -43,7 +43,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --- elaboration ---
     // Expression evaluation, transaction balancing, account registration.
     let t3 = Instant::now();
-    let journal: doppio::elaboration::Journal = doppio::elaborate(hir)?;
+    // The parser is ledger-cli; use the matching default semantics.
+    let journal: doppio::elaboration::Journal =
+        doppio::elaborate(hir, &doppio::grammars::ledger::LEDGER_DEFAULTS)?;
     eprintln!("elaboration: {:>8.3}s", t3.elapsed().as_secs_f64());
 
     // --- serialize ---

--- a/crates/doppio-cli/src/bin/timings.rs
+++ b/crates/doppio-cli/src/bin/timings.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let t3 = Instant::now();
     // The parser is ledger-cli; use the matching default semantics.
     let journal: doppio::elaboration::Journal =
-        doppio::elaborate(hir, &doppio::grammars::ledger::LEDGER_DEFAULTS)?;
+        doppio::elaborate(hir, &doppio::grammars::ledger::ledger_defaults())?;
     eprintln!("elaboration: {:>8.3}s", t3.elapsed().as_secs_f64());
 
     // --- serialize ---

--- a/crates/doppio-cli/src/main.rs
+++ b/crates/doppio-cli/src/main.rs
@@ -232,12 +232,12 @@ fn load_proto_journal_with_tolerance(
         // Start from the matching tool's default semantics; override the
         // tolerance fraction if `--tolerance` was passed on the CLI.
         let config = match tolerance_override {
-            None => frontend.defaults().clone(),
+            None => frontend.elaboration_defaults(),
             Some(fraction) => doppio::resolution::ElaborationConfig {
                 tolerance_mode: doppio::resolution::ToleranceMode::FractionOfSmallestPrecision(
                     fraction,
                 ),
-                ..frontend.defaults().clone()
+                ..frontend.elaboration_defaults()
             },
         };
         Ok(doppio::elaborate(hir, &config)?)
@@ -428,7 +428,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             File::open(&source)?.read_to_string(&mut file)?;
             let hir = frontend.parse(&file, base_path, &doppio::file_opener)?;
             let journal: doppio::elaboration::Journal =
-                doppio::elaborate(hir, frontend.defaults())?;
+                doppio::elaborate(hir, &frontend.elaboration_defaults())?;
             let compression = if no_compression {
                 doppio::Compression::None
             } else {

--- a/crates/doppio-cli/src/main.rs
+++ b/crates/doppio-cli/src/main.rs
@@ -228,12 +228,19 @@ fn load_proto_journal_with_tolerance(
         let base_path = path.parent().unwrap_or(std::path::Path::new(""));
         let mut file = String::new();
         File::open(path)?.read_to_string(&mut file)?;
-        let mut hir = frontend.parse(&file, base_path, &doppio::file_opener)?;
-        if let Some(fraction) = tolerance_override {
-            hir.global_context.tolerance_mode =
-                doppio::resolution::ToleranceMode::FractionOfSmallestPrecision(fraction);
-        }
-        Ok(doppio::elaborate(hir)?)
+        let hir = frontend.parse(&file, base_path, &doppio::file_opener)?;
+        // Start from the matching tool's default semantics; override the
+        // tolerance fraction if `--tolerance` was passed on the CLI.
+        let config = match tolerance_override {
+            None => frontend.defaults().clone(),
+            Some(fraction) => doppio::resolution::ElaborationConfig {
+                tolerance_mode: doppio::resolution::ToleranceMode::FractionOfSmallestPrecision(
+                    fraction,
+                ),
+                ..frontend.defaults().clone()
+            },
+        };
+        Ok(doppio::elaborate(hir, &config)?)
     }
 }
 
@@ -420,7 +427,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let mut file = String::new();
             File::open(&source)?.read_to_string(&mut file)?;
             let hir = frontend.parse(&file, base_path, &doppio::file_opener)?;
-            let journal: doppio::elaboration::Journal = doppio::elaborate(hir)?;
+            let journal: doppio::elaboration::Journal =
+                doppio::elaborate(hir, frontend.defaults())?;
             let compression = if no_compression {
                 doppio::Compression::None
             } else {

--- a/crates/doppio-cli/tests/dop_format.rs
+++ b/crates/doppio-cli/tests/dop_format.rs
@@ -30,7 +30,7 @@ fn compile_to_dop_with_compression(
     let ast = parser.parse(source).expect("parse failed");
     let hir: doppio::resolution::HIR = ast.try_into().expect("resolution failed");
     let journal: doppio::elaboration::Journal =
-        doppio::elaborate(hir, &doppio::grammars::ledger::LEDGER_DEFAULTS)
+        doppio::elaborate(hir, &doppio::grammars::ledger::ledger_defaults())
             .expect("elaboration failed");
 
     // Write to a named temp file so we can pass its path to `read_dop`.

--- a/crates/doppio-cli/tests/dop_format.rs
+++ b/crates/doppio-cli/tests/dop_format.rs
@@ -29,7 +29,9 @@ fn compile_to_dop_with_compression(
     };
     let ast = parser.parse(source).expect("parse failed");
     let hir: doppio::resolution::HIR = ast.try_into().expect("resolution failed");
-    let journal: doppio::elaboration::Journal = doppio::elaborate(hir).expect("elaboration failed");
+    let journal: doppio::elaboration::Journal =
+        doppio::elaborate(hir, &doppio::grammars::ledger::LEDGER_DEFAULTS)
+            .expect("elaboration failed");
 
     // Write to a named temp file so we can pass its path to `read_dop`.
     let mut tmp = NamedTempFile::new().expect("tmp file");

--- a/crates/doppio/benches/pipeline.rs
+++ b/crates/doppio/benches/pipeline.rs
@@ -37,7 +37,9 @@ fn bench_elaboration(c: &mut Criterion) {
                     let hir: doppio::resolution::HIR = ast.try_into().unwrap();
                     hir
                 },
-                |hir| -> doppio::elaboration::Journal { hir.try_into().unwrap() },
+                |hir| -> doppio::elaboration::Journal {
+                    doppio::elaborate(hir, &doppio::grammars::ledger::ledger_defaults()).unwrap()
+                },
                 criterion::BatchSize::PerIteration,
             )
         });

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -354,10 +354,24 @@ impl Display for ElaborationError {
     }
 }
 
-impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
-    type Error = ElaborationError;
-
-    fn try_from(value: resolution::HIR) -> Result<Self, Self::Error> {
+/// Run the elaboration pass on a resolved [`resolution::HIR`], applying
+/// the semantic ruleset in `config`.
+///
+/// This is the single entry point to the elaborator. The
+/// [`resolution::ElaborationConfig`] passed here is the *only* place the
+/// elaborator picks up its semantic choices (tolerance rule, balance
+/// mode, assertion scope, ...) -- the parser/frontend stages do not
+/// inject any. Callers typically pass `frontend.defaults()` for the
+/// matching tool's behaviour, or any other `ElaborationConfig` to
+/// experiment with cross-syntax-semantics combinations. Per-commodity
+/// overrides set by source directives (Beancount's
+/// `option "inferred_tolerance_default"`) layer on top of the config at
+/// elaboration time via [`resolution::GlobalContext::tolerance_overrides`].
+pub fn elaborate(
+    value: resolution::HIR,
+    config: &resolution::ElaborationConfig,
+) -> Result<crate::elaboration::Journal, ElaborationError> {
+    {
         let mut state = RunningState::default();
 
         let mut transactions = vec![];
@@ -380,10 +394,10 @@ impl TryFrom<resolution::HIR> for crate::elaboration::Journal {
             );
         }
 
-        let tolerance_mode = value.global_context.tolerance_mode;
+        let tolerance_mode = config.tolerance_mode;
         let tolerance_overrides = value.global_context.tolerance_overrides.clone();
-        let balance_mode = value.global_context.balance_mode.clone();
-        let assertion_scope = value.global_context.assertion_scope;
+        let balance_mode = config.balance_mode.clone();
+        let assertion_scope = config.assertion_scope;
 
         for entry in value.entries {
             let entry_context = &value.contexts[entry.context_id];
@@ -2452,8 +2466,8 @@ mod tests {
         assert_eq!(hir.prices.len(), 1, "HIR should contain one price");
 
         // Elaboration stage.
-        let journal =
-            crate::elaboration::Journal::try_from(hir).expect("elaboration should succeed");
+        let journal = crate::elaborate(hir, &crate::grammars::ledger::LEDGER_DEFAULTS)
+            .expect("elaboration should succeed");
 
         assert_eq!(journal.prices.len(), 1, "Journal should contain one price");
         let price = &journal.prices[0];
@@ -2478,7 +2492,8 @@ mod tests {
         use crate::{grammars::ledger::parse_ledger, resolution::HIR};
         let ast = parse_ledger(input).expect("parse failed");
         let hir = HIR::try_from(ast).expect("resolution failed");
-        crate::elaboration::Journal::try_from(hir).expect("elaboration failed")
+        crate::elaborate(hir, &crate::grammars::ledger::LEDGER_DEFAULTS)
+            .expect("elaboration failed")
     }
 
     #[test]
@@ -2586,7 +2601,8 @@ define myval = $99.00
         assert!(hir.contexts[1].defines.contains_key("myval"));
 
         // Elaboration should succeed end-to-end.
-        let journal = crate::elaboration::Journal::try_from(hir).expect("elaboration failed");
+        let journal = crate::elaborate(hir, &crate::grammars::ledger::LEDGER_DEFAULTS)
+            .expect("elaboration failed");
         let after_tx = &journal.transactions[1];
         let b_posting = after_tx
             .postings
@@ -2737,7 +2753,7 @@ define myval = $99.00
         use crate::{grammars::ledger::parse_ledger, resolution::HIR};
         let ast = parse_ledger(input).expect("parse failed");
         let hir = HIR::try_from(ast).expect("resolution failed");
-        crate::elaboration::Journal::try_from(hir)
+        crate::elaborate(hir, &crate::grammars::ledger::LEDGER_DEFAULTS)
     }
 
     #[test]
@@ -2916,7 +2932,9 @@ define myval = $99.00
         use crate::{grammars::ledger::parse_ledger, resolution::HIR};
         let ast = parse_ledger(input).expect("parse failed");
         let hir = HIR::try_from(ast).expect("resolution failed");
-        match crate::elaboration::Journal::try_from(hir).expect_err("expected assertion failure") {
+        match crate::elaborate(hir, &crate::grammars::ledger::LEDGER_DEFAULTS)
+            .expect_err("expected assertion failure")
+        {
             ElaborationError::AccountAssertionFailed {
                 account,
                 posting_index,
@@ -3816,7 +3834,7 @@ account Expenses:Food
 ";
         let ast = crate::grammars::ledger::parse_ledger(input).expect("parse failed");
         let hir = crate::resolution::HIR::try_from(ast).expect("resolution failed");
-        let result = crate::elaboration::Journal::try_from(hir);
+        let result = crate::elaborate(hir, &crate::grammars::ledger::LEDGER_DEFAULTS);
         assert!(
             matches!(result, Err(ElaborationError::AccountAssertionFailed { .. })),
             "positive amount should fail isNegative assertion; got: {result:?}"
@@ -3872,7 +3890,7 @@ account Expenses:Food
 ";
         let ast = crate::grammars::ledger::parse_ledger(input).expect("parse failed");
         let hir = crate::resolution::HIR::try_from(ast).expect("resolution failed");
-        let result = crate::elaboration::Journal::try_from(hir);
+        let result = crate::elaborate(hir, &crate::grammars::ledger::LEDGER_DEFAULTS);
         assert!(
             matches!(result, Err(ElaborationError::AccountAssertionFailed { .. })),
             "$50 should fail between(0, 10); got: {result:?}"

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -361,7 +361,7 @@ impl Display for ElaborationError {
 /// [`resolution::ElaborationConfig`] passed here is the *only* place the
 /// elaborator picks up its semantic choices (tolerance rule, balance
 /// mode, assertion scope, ...) -- the parser/frontend stages do not
-/// inject any. Callers typically pass `frontend.defaults()` for the
+/// inject any. Callers typically pass `&frontend.elaboration_defaults()` for the
 /// matching tool's behaviour, or any other `ElaborationConfig` to
 /// experiment with cross-syntax-semantics combinations. Per-commodity
 /// overrides set by source directives (Beancount's
@@ -2466,7 +2466,7 @@ mod tests {
         assert_eq!(hir.prices.len(), 1, "HIR should contain one price");
 
         // Elaboration stage.
-        let journal = crate::elaborate(hir, &crate::grammars::ledger::LEDGER_DEFAULTS)
+        let journal = crate::elaborate(hir, &crate::grammars::ledger::ledger_defaults())
             .expect("elaboration should succeed");
 
         assert_eq!(journal.prices.len(), 1, "Journal should contain one price");
@@ -2492,7 +2492,7 @@ mod tests {
         use crate::{grammars::ledger::parse_ledger, resolution::HIR};
         let ast = parse_ledger(input).expect("parse failed");
         let hir = HIR::try_from(ast).expect("resolution failed");
-        crate::elaborate(hir, &crate::grammars::ledger::LEDGER_DEFAULTS)
+        crate::elaborate(hir, &crate::grammars::ledger::ledger_defaults())
             .expect("elaboration failed")
     }
 
@@ -2601,7 +2601,7 @@ define myval = $99.00
         assert!(hir.contexts[1].defines.contains_key("myval"));
 
         // Elaboration should succeed end-to-end.
-        let journal = crate::elaborate(hir, &crate::grammars::ledger::LEDGER_DEFAULTS)
+        let journal = crate::elaborate(hir, &crate::grammars::ledger::ledger_defaults())
             .expect("elaboration failed");
         let after_tx = &journal.transactions[1];
         let b_posting = after_tx
@@ -2753,7 +2753,7 @@ define myval = $99.00
         use crate::{grammars::ledger::parse_ledger, resolution::HIR};
         let ast = parse_ledger(input).expect("parse failed");
         let hir = HIR::try_from(ast).expect("resolution failed");
-        crate::elaborate(hir, &crate::grammars::ledger::LEDGER_DEFAULTS)
+        crate::elaborate(hir, &crate::grammars::ledger::ledger_defaults())
     }
 
     #[test]
@@ -2932,7 +2932,7 @@ define myval = $99.00
         use crate::{grammars::ledger::parse_ledger, resolution::HIR};
         let ast = parse_ledger(input).expect("parse failed");
         let hir = HIR::try_from(ast).expect("resolution failed");
-        match crate::elaborate(hir, &crate::grammars::ledger::LEDGER_DEFAULTS)
+        match crate::elaborate(hir, &crate::grammars::ledger::ledger_defaults())
             .expect_err("expected assertion failure")
         {
             ElaborationError::AccountAssertionFailed {
@@ -3834,7 +3834,7 @@ account Expenses:Food
 ";
         let ast = crate::grammars::ledger::parse_ledger(input).expect("parse failed");
         let hir = crate::resolution::HIR::try_from(ast).expect("resolution failed");
-        let result = crate::elaborate(hir, &crate::grammars::ledger::LEDGER_DEFAULTS);
+        let result = crate::elaborate(hir, &crate::grammars::ledger::ledger_defaults());
         assert!(
             matches!(result, Err(ElaborationError::AccountAssertionFailed { .. })),
             "positive amount should fail isNegative assertion; got: {result:?}"
@@ -3890,7 +3890,7 @@ account Expenses:Food
 ";
         let ast = crate::grammars::ledger::parse_ledger(input).expect("parse failed");
         let hir = crate::resolution::HIR::try_from(ast).expect("resolution failed");
-        let result = crate::elaborate(hir, &crate::grammars::ledger::LEDGER_DEFAULTS);
+        let result = crate::elaborate(hir, &crate::grammars::ledger::ledger_defaults());
         assert!(
             matches!(result, Err(ElaborationError::AccountAssertionFailed { .. })),
             "$50 should fail between(0, 10); got: {result:?}"

--- a/crates/doppio/src/frontend.rs
+++ b/crates/doppio/src/frontend.rs
@@ -53,7 +53,7 @@ pub trait Frontend {
     /// tool's rules. The associated default is what `dop`-style command
     /// dispatchers use when the user hasn't asked for anything more
     /// specific.
-    fn defaults(&self) -> &'static ElaborationConfig;
+    fn elaboration_defaults(&self) -> ElaborationConfig;
 
     /// Parse source text into an [`HIR`].
     ///

--- a/crates/doppio/src/frontend.rs
+++ b/crates/doppio/src/frontend.rs
@@ -8,7 +8,7 @@
 
 use std::path::Path;
 
-use crate::resolution::HIR;
+use crate::resolution::{ElaborationConfig, HIR};
 
 /// The signature of an `include`-directive file opener.
 ///
@@ -42,6 +42,18 @@ pub trait Frontend {
     /// first one whose extension list contains the source file's
     /// extension.
     fn extensions(&self) -> &'static [&'static str];
+
+    /// The default elaboration semantics for files in this frontend's
+    /// syntax — i.e. the [`ElaborationConfig`] that mirrors what the
+    /// canonical tool's own elaborator would do.
+    ///
+    /// This is a *convenience pairing*, not a forced coupling. The
+    /// elaborator takes any `ElaborationConfig`; a caller can parse a
+    /// file in one frontend's syntax and elaborate it under a different
+    /// tool's rules. The associated default is what `dop`-style command
+    /// dispatchers use when the user hasn't asked for anything more
+    /// specific.
+    fn defaults(&self) -> &'static ElaborationConfig;
 
     /// Parse source text into an [`HIR`].
     ///

--- a/crates/doppio/src/grammars/beancount/mod.rs
+++ b/crates/doppio/src/grammars/beancount/mod.rs
@@ -861,35 +861,39 @@ pub(crate) fn parse_beancount_with_options(
 /// full mapping table and known gaps.
 pub struct BeancountFrontend;
 
-/// Default elaboration semantics for files written in Beancount syntax.
-///
-/// Half-smallest-precision per-transaction balance tolerance (matching
-/// bean-check's `0.5 * 10^(-min_scale)` rule, #198), cost-basis lot
-/// pricing with explicit gain/loss postings (so `{cost}` annotations
-/// drive the cash-equivalent for balance), and subtree-aware top-level
-/// `balance` directives (matching bean-check's account-tree aggregation,
-/// #214).
+/// Construct the default [`crate::resolution::ElaborationConfig`] for
+/// files written in Beancount syntax: half-smallest-precision
+/// per-transaction balance tolerance (matching bean-check's
+/// `0.5 * 10^(-min_scale)` rule, #198), cost-basis lot pricing with
+/// explicit gain/loss postings, and subtree-aware top-level `balance`
+/// directives (matching bean-check's account-tree aggregation, #214).
 ///
 /// Per-commodity tolerance overrides set via Beancount's
 /// `option "inferred_tolerance_default" "COMMODITY:VALUE"` are journal-
-/// level state and live on [`crate::resolution::GlobalContext::tolerance_overrides`];
-/// they layer on top of this default at elaboration time.
-pub static BEANCOUNT_DEFAULTS: std::sync::LazyLock<crate::resolution::ElaborationConfig> =
-    std::sync::LazyLock::new(|| crate::resolution::ElaborationConfig {
+/// level state and live on
+/// [`crate::resolution::GlobalContext::tolerance_overrides`]; they
+/// layer on top of this default at elaboration time.
+///
+/// Available as a free function so test code can construct the config
+/// without instantiating [`BeancountFrontend`]; the trait method
+/// [`crate::frontend::Frontend::elaboration_defaults`] delegates here.
+pub fn beancount_defaults() -> crate::resolution::ElaborationConfig {
+    crate::resolution::ElaborationConfig {
         tolerance_mode: crate::resolution::ToleranceMode::FractionOfSmallestPrecision(
             rust_decimal::Decimal::new(5, 1),
         ),
         balance_mode: crate::resolution::BalanceMode::CostBasis,
         assertion_scope: crate::resolution::AssertionScope::Subtree,
-    });
+    }
+}
 
 impl crate::frontend::Frontend for BeancountFrontend {
     fn extensions(&self) -> &'static [&'static str] {
         &["beancount"]
     }
 
-    fn defaults(&self) -> &'static crate::resolution::ElaborationConfig {
-        &BEANCOUNT_DEFAULTS
+    fn elaboration_defaults(&self) -> crate::resolution::ElaborationConfig {
+        beancount_defaults()
     }
 
     fn parse(
@@ -1546,7 +1550,7 @@ mod tests {
         // passes.
         let journal = parse_beancount(SAMPLE).expect("parse sample.beancount");
         let hir: crate::resolution::HIR = journal.try_into().expect("resolve sample.beancount");
-        let elab: crate::elaboration::Journal = crate::elaborate(hir, &BEANCOUNT_DEFAULTS)
+        let elab: crate::elaboration::Journal = crate::elaborate(hir, &beancount_defaults())
             .expect("elaborate sample.beancount (pad+balance must reconcile)");
         // The synthesized pad transaction is tagged with metadata `pad: <source>`.
         let pad_tx_count = elab
@@ -2021,8 +2025,8 @@ option \"inferred_tolerance_default\" \"USD:0.1\"
         let mut hir: crate::resolution::HIR = journal.try_into()?;
         // Beancount's `option "inferred_tolerance_default"` populates
         // `tolerance_overrides` (per-commodity overrides; layer on top
-        // of `BEANCOUNT_DEFAULTS.tolerance_mode` at elaboration time).
-        // The base semantic config is BEANCOUNT_DEFAULTS itself.
+        // of the config's `tolerance_mode` at elaboration time). The
+        // base semantic config is `beancount_defaults()`.
         for (k, v) in &options {
             if k == "inferred_tolerance_default"
                 && let Some((commodity, decimal)) = v.split_once(':')
@@ -2033,7 +2037,7 @@ option \"inferred_tolerance_default\" \"USD:0.1\"
                     .insert(commodity.trim().to_string(), d);
             }
         }
-        Ok(crate::elaborate(hir, &BEANCOUNT_DEFAULTS)?)
+        Ok(crate::elaborate(hir, &beancount_defaults())?)
     }
 
     #[test]

--- a/crates/doppio/src/grammars/beancount/mod.rs
+++ b/crates/doppio/src/grammars/beancount/mod.rs
@@ -861,9 +861,35 @@ pub(crate) fn parse_beancount_with_options(
 /// full mapping table and known gaps.
 pub struct BeancountFrontend;
 
+/// Default elaboration semantics for files written in Beancount syntax.
+///
+/// Half-smallest-precision per-transaction balance tolerance (matching
+/// bean-check's `0.5 * 10^(-min_scale)` rule, #198), cost-basis lot
+/// pricing with explicit gain/loss postings (so `{cost}` annotations
+/// drive the cash-equivalent for balance), and subtree-aware top-level
+/// `balance` directives (matching bean-check's account-tree aggregation,
+/// #214).
+///
+/// Per-commodity tolerance overrides set via Beancount's
+/// `option "inferred_tolerance_default" "COMMODITY:VALUE"` are journal-
+/// level state and live on [`crate::resolution::GlobalContext::tolerance_overrides`];
+/// they layer on top of this default at elaboration time.
+pub static BEANCOUNT_DEFAULTS: std::sync::LazyLock<crate::resolution::ElaborationConfig> =
+    std::sync::LazyLock::new(|| crate::resolution::ElaborationConfig {
+        tolerance_mode: crate::resolution::ToleranceMode::FractionOfSmallestPrecision(
+            rust_decimal::Decimal::new(5, 1),
+        ),
+        balance_mode: crate::resolution::BalanceMode::CostBasis,
+        assertion_scope: crate::resolution::AssertionScope::Subtree,
+    });
+
 impl crate::frontend::Frontend for BeancountFrontend {
     fn extensions(&self) -> &'static [&'static str] {
         &["beancount"]
+    }
+
+    fn defaults(&self) -> &'static crate::resolution::ElaborationConfig {
+        &BEANCOUNT_DEFAULTS
     }
 
     fn parse(
@@ -886,23 +912,13 @@ impl crate::frontend::Frontend for BeancountFrontend {
         // chronological order.
         sort_entries_by_date(&mut ast_journal.entries);
         let mut hir: crate::resolution::HIR = ast_journal.try_into()?;
-        // Beancount applies a per-transaction balance tolerance by
-        // default (#198). Default fraction is 0.5 -- half the
-        // least-precise posting's decimal place -- matching
-        // bean-check's behaviour.
-        hir.global_context.tolerance_mode =
-            crate::resolution::ToleranceMode::FractionOfSmallestPrecision(
-                rust_decimal::Decimal::new(5, 1),
-            );
-        // Beancount's `balance` directive aggregates the entire
-        // account subtree (#214). A `pad` that targets the same
-        // account synthesizes its corrective amount against the
-        // subtree sum.
-        hir.global_context.assertion_scope = crate::resolution::AssertionScope::Subtree;
         // Honour `option "inferred_tolerance_default" "COMMODITY:VALUE"`
         // directives. Each occurrence overrides any previous value for
         // the same commodity (last write wins). The directive is
-        // file-level; nested includes contribute to the same map.
+        // file-level; nested includes contribute to the same map. This
+        // is journal state derived from the source and stays on
+        // GlobalContext -- the per-commodity override layers on top of
+        // ElaborationConfig::tolerance_mode at elaboration time.
         for (k, v) in &parser.options {
             if k == "inferred_tolerance_default"
                 && let Some((commodity, decimal)) = v.split_once(':')
@@ -1530,8 +1546,7 @@ mod tests {
         // passes.
         let journal = parse_beancount(SAMPLE).expect("parse sample.beancount");
         let hir: crate::resolution::HIR = journal.try_into().expect("resolve sample.beancount");
-        let elab: crate::elaboration::Journal = hir
-            .try_into()
+        let elab: crate::elaboration::Journal = crate::elaborate(hir, &BEANCOUNT_DEFAULTS)
             .expect("elaborate sample.beancount (pad+balance must reconcile)");
         // The synthesized pad transaction is tagged with metadata `pad: <source>`.
         let pad_tx_count = elab
@@ -2004,17 +2019,10 @@ option \"inferred_tolerance_default\" \"USD:0.1\"
     fn elaborate(input: &str) -> Result<crate::elaboration::Journal, Box<dyn std::error::Error>> {
         let (journal, options) = parse_beancount_with_options(input)?;
         let mut hir: crate::resolution::HIR = journal.try_into()?;
-        // Match BeancountFrontend's default (fraction = 0.5) so the
-        // elaborator applies Beancount-style tolerance.
-        hir.global_context.tolerance_mode =
-            crate::resolution::ToleranceMode::FractionOfSmallestPrecision(
-                rust_decimal::Decimal::new(5, 1),
-            );
-        // Match BeancountFrontend's subtree-aware `balance` semantics
-        // (#214). bean-check aggregates the entire account subtree;
-        // pad uses the same scope when computing its corrective
-        // amount.
-        hir.global_context.assertion_scope = crate::resolution::AssertionScope::Subtree;
+        // Beancount's `option "inferred_tolerance_default"` populates
+        // `tolerance_overrides` (per-commodity overrides; layer on top
+        // of `BEANCOUNT_DEFAULTS.tolerance_mode` at elaboration time).
+        // The base semantic config is BEANCOUNT_DEFAULTS itself.
         for (k, v) in &options {
             if k == "inferred_tolerance_default"
                 && let Some((commodity, decimal)) = v.split_once(':')
@@ -2025,7 +2033,7 @@ option \"inferred_tolerance_default\" \"USD:0.1\"
                     .insert(commodity.trim().to_string(), d);
             }
         }
-        Ok(hir.try_into()?)
+        Ok(crate::elaborate(hir, &BEANCOUNT_DEFAULTS)?)
     }
 
     #[test]

--- a/crates/doppio/src/grammars/hledger/mod.rs
+++ b/crates/doppio/src/grammars/hledger/mod.rs
@@ -687,16 +687,19 @@ pub(crate) fn parse_hledger(input: &str) -> Result<Journal, Box<dyn std::error::
 /// that are stubbed out or not yet supported.
 pub struct HledgerFrontend;
 
-/// Default elaboration semantics for files written in hledger syntax.
+/// Construct the default [`crate::resolution::ElaborationConfig`] for
+/// files written in hledger syntax: strict per-transaction balance,
+/// `@price`-driven cost-equivalent for lots with both `{cost}` and
+/// `@price` (with a synthesised posting on `Income:Capital Gains` so
+/// the elaborated form is cost-basis-balanced regardless of frontend),
+/// and direct-account balance assertions. Mirrors hledger's own
+/// elaboration. See #210 for the gains-synthesis design.
 ///
-/// Strict per-transaction balance, `@price`-driven cost-equivalent for
-/// lots with both `{cost}` and `@price` (with a synthesised posting on
-/// `Income:Capital Gains` so the elaborated form is cost-basis-balanced
-/// regardless of frontend), and direct-account balance assertions.
-/// Mirrors hledger's own elaboration. See #210 for the gains-synthesis
-/// design.
-pub static HLEDGER_DEFAULTS: std::sync::LazyLock<crate::resolution::ElaborationConfig> =
-    std::sync::LazyLock::new(|| crate::resolution::ElaborationConfig {
+/// Available as a free function so test code can construct the config
+/// without instantiating [`HledgerFrontend`]; the trait method
+/// [`crate::frontend::Frontend::elaboration_defaults`] delegates here.
+pub fn hledger_defaults() -> crate::resolution::ElaborationConfig {
+    crate::resolution::ElaborationConfig {
         tolerance_mode: crate::resolution::ToleranceMode::FractionOfSmallestPrecision(
             rust_decimal::Decimal::ZERO,
         ),
@@ -704,15 +707,16 @@ pub static HLEDGER_DEFAULTS: std::sync::LazyLock<crate::resolution::ElaborationC
             gains_account: "Income:Capital Gains".to_string(),
         },
         assertion_scope: crate::resolution::AssertionScope::Direct,
-    });
+    }
+}
 
 impl crate::frontend::Frontend for HledgerFrontend {
     fn extensions(&self) -> &'static [&'static str] {
         &["hledger", "journal"]
     }
 
-    fn defaults(&self) -> &'static crate::resolution::ElaborationConfig {
-        &HLEDGER_DEFAULTS
+    fn elaboration_defaults(&self) -> crate::resolution::ElaborationConfig {
+        hledger_defaults()
     }
 
     fn parse(
@@ -1411,7 +1415,7 @@ nothing after this matters
         let ast = parse_hledger(input).expect("parse");
         let hir: crate::resolution::HIR = ast.try_into().expect("resolution");
         let journal: crate::elaboration::Journal =
-            crate::elaborate(hir, &HLEDGER_DEFAULTS).expect("elaboration");
+            crate::elaborate(hir, &hledger_defaults()).expect("elaboration");
         let retain = journal
             .transactions
             .iter()
@@ -1450,7 +1454,7 @@ account Income          ; type:R
         let ast = parse_hledger(input).expect("parse");
         let hir: crate::resolution::HIR = ast.try_into().expect("resolution");
         let journal: crate::elaboration::Journal =
-            crate::elaborate(hir, &HLEDGER_DEFAULTS).expect("elaboration");
+            crate::elaborate(hir, &hledger_defaults()).expect("elaboration");
         let salary = journal
             .accounts
             .get("Income:Salary")

--- a/crates/doppio/src/grammars/hledger/mod.rs
+++ b/crates/doppio/src/grammars/hledger/mod.rs
@@ -687,9 +687,32 @@ pub(crate) fn parse_hledger(input: &str) -> Result<Journal, Box<dyn std::error::
 /// that are stubbed out or not yet supported.
 pub struct HledgerFrontend;
 
+/// Default elaboration semantics for files written in hledger syntax.
+///
+/// Strict per-transaction balance, `@price`-driven cost-equivalent for
+/// lots with both `{cost}` and `@price` (with a synthesised posting on
+/// `Income:Capital Gains` so the elaborated form is cost-basis-balanced
+/// regardless of frontend), and direct-account balance assertions.
+/// Mirrors hledger's own elaboration. See #210 for the gains-synthesis
+/// design.
+pub static HLEDGER_DEFAULTS: std::sync::LazyLock<crate::resolution::ElaborationConfig> =
+    std::sync::LazyLock::new(|| crate::resolution::ElaborationConfig {
+        tolerance_mode: crate::resolution::ToleranceMode::FractionOfSmallestPrecision(
+            rust_decimal::Decimal::ZERO,
+        ),
+        balance_mode: crate::resolution::BalanceMode::AtPriceWithSynthesis {
+            gains_account: "Income:Capital Gains".to_string(),
+        },
+        assertion_scope: crate::resolution::AssertionScope::Direct,
+    });
+
 impl crate::frontend::Frontend for HledgerFrontend {
     fn extensions(&self) -> &'static [&'static str] {
         &["hledger", "journal"]
+    }
+
+    fn defaults(&self) -> &'static crate::resolution::ElaborationConfig {
+        &HLEDGER_DEFAULTS
     }
 
     fn parse(
@@ -703,16 +726,7 @@ impl crate::frontend::Frontend for HledgerFrontend {
             base_path: base_path.to_path_buf(),
         }
         .parse(input)?;
-        let mut hir: crate::resolution::HIR = ast_journal.try_into()?;
-        // hledger uses `@price` for transaction balance when present
-        // and does not require an explicit gain/loss posting. After
-        // the @price-driven balance check, the elaborator synthesizes
-        // a posting on the gains account so the elaborated form is
-        // cost-basis-balanced -- giving `.dop` files a uniform shape
-        // across frontends. See #210.
-        hir.global_context.balance_mode = crate::resolution::BalanceMode::AtPriceWithSynthesis {
-            gains_account: "Income:Capital Gains".to_string(),
-        };
+        let hir: crate::resolution::HIR = ast_journal.try_into()?;
         Ok(hir)
     }
 }
@@ -1396,7 +1410,8 @@ nothing after this matters
 ";
         let ast = parse_hledger(input).expect("parse");
         let hir: crate::resolution::HIR = ast.try_into().expect("resolution");
-        let journal: crate::elaboration::Journal = crate::elaborate(hir).expect("elaboration");
+        let journal: crate::elaboration::Journal =
+            crate::elaborate(hir, &HLEDGER_DEFAULTS).expect("elaboration");
         let retain = journal
             .transactions
             .iter()
@@ -1434,7 +1449,8 @@ account Income          ; type:R
 ";
         let ast = parse_hledger(input).expect("parse");
         let hir: crate::resolution::HIR = ast.try_into().expect("resolution");
-        let journal: crate::elaboration::Journal = crate::elaborate(hir).expect("elaboration");
+        let journal: crate::elaboration::Journal =
+            crate::elaborate(hir, &HLEDGER_DEFAULTS).expect("elaboration");
         let salary = journal
             .accounts
             .get("Income:Salary")

--- a/crates/doppio/src/grammars/ledger/mod.rs
+++ b/crates/doppio/src/grammars/ledger/mod.rs
@@ -280,9 +280,31 @@ pub(crate) fn parse_ledger(input: &str) -> Result<Journal, Box<dyn std::error::E
 /// ```
 pub struct LedgerFrontend;
 
+/// Default elaboration semantics for files written in ledger-cli syntax.
+///
+/// Strict per-transaction balance, cost-basis lot pricing with explicit
+/// gain/loss postings, and direct-account balance assertions -- mirroring
+/// what `ledger`'s own elaborator does. Pass this to [`crate::elaborate`]
+/// to elaborate a ledger-cli journal under ledger-cli rules. Or don't:
+/// the elaborator accepts any [`crate::resolution::ElaborationConfig`],
+/// which is the whole point of the syntax/semantics decoupling
+/// introduced in #239.
+pub static LEDGER_DEFAULTS: std::sync::LazyLock<crate::resolution::ElaborationConfig> =
+    std::sync::LazyLock::new(|| crate::resolution::ElaborationConfig {
+        tolerance_mode: crate::resolution::ToleranceMode::FractionOfSmallestPrecision(
+            rust_decimal::Decimal::ZERO,
+        ),
+        balance_mode: crate::resolution::BalanceMode::CostBasis,
+        assertion_scope: crate::resolution::AssertionScope::Direct,
+    });
+
 impl crate::frontend::Frontend for LedgerFrontend {
     fn extensions(&self) -> &'static [&'static str] {
         &["ledger"]
+    }
+
+    fn defaults(&self) -> &'static crate::resolution::ElaborationConfig {
+        &LEDGER_DEFAULTS
     }
 
     fn parse(

--- a/crates/doppio/src/grammars/ledger/mod.rs
+++ b/crates/doppio/src/grammars/ledger/mod.rs
@@ -280,31 +280,32 @@ pub(crate) fn parse_ledger(input: &str) -> Result<Journal, Box<dyn std::error::E
 /// ```
 pub struct LedgerFrontend;
 
-/// Default elaboration semantics for files written in ledger-cli syntax.
+/// Construct the default [`crate::resolution::ElaborationConfig`] for
+/// files written in ledger-cli syntax: strict per-transaction balance,
+/// cost-basis lot pricing with explicit gain/loss postings, and
+/// direct-account balance assertions. Mirrors what `ledger`'s own
+/// elaborator does.
 ///
-/// Strict per-transaction balance, cost-basis lot pricing with explicit
-/// gain/loss postings, and direct-account balance assertions -- mirroring
-/// what `ledger`'s own elaborator does. Pass this to [`crate::elaborate`]
-/// to elaborate a ledger-cli journal under ledger-cli rules. Or don't:
-/// the elaborator accepts any [`crate::resolution::ElaborationConfig`],
-/// which is the whole point of the syntax/semantics decoupling
-/// introduced in #239.
-pub static LEDGER_DEFAULTS: std::sync::LazyLock<crate::resolution::ElaborationConfig> =
-    std::sync::LazyLock::new(|| crate::resolution::ElaborationConfig {
+/// Available as a free function so test code can construct the config
+/// without instantiating [`LedgerFrontend`]; the trait method
+/// [`crate::frontend::Frontend::elaboration_defaults`] delegates here.
+pub fn ledger_defaults() -> crate::resolution::ElaborationConfig {
+    crate::resolution::ElaborationConfig {
         tolerance_mode: crate::resolution::ToleranceMode::FractionOfSmallestPrecision(
             rust_decimal::Decimal::ZERO,
         ),
         balance_mode: crate::resolution::BalanceMode::CostBasis,
         assertion_scope: crate::resolution::AssertionScope::Direct,
-    });
+    }
+}
 
 impl crate::frontend::Frontend for LedgerFrontend {
     fn extensions(&self) -> &'static [&'static str] {
         &["ledger"]
     }
 
-    fn defaults(&self) -> &'static crate::resolution::ElaborationConfig {
-        &LEDGER_DEFAULTS
+    fn elaboration_defaults(&self) -> crate::resolution::ElaborationConfig {
+        ledger_defaults()
     }
 
     fn parse(

--- a/crates/doppio/src/lib.rs
+++ b/crates/doppio/src/lib.rs
@@ -407,18 +407,45 @@ where
 {
     let output = parser.parse(input)?;
     let hir: resolution::HIR = output.try_into()?;
-    Ok(elaborate(hir)?)
+    // The parser is type-locked to ledger-cli, so the matching defaults
+    // are LEDGER_DEFAULTS. Callers who want a different elaboration
+    // ruleset (e.g. relaxed tolerance, subtree assertions) can call
+    // `frontend.parse()` and `elaborate()` separately and pass an
+    // explicit `ElaborationConfig`.
+    Ok(elaborate(hir, &grammars::ledger::LEDGER_DEFAULTS)?)
 }
 
-/// Run the elaboration stage on a resolved [`resolution::HIR`], producing a
-/// fully-balanced [`elaboration::Journal`]. This is the conversion bridge
-/// inside [`compile`]; expose it as a public function so callers that
-/// dispatch to a [`Frontend`] manually (like the CLI) can hand off to
-/// elaboration without reaching for the crate-private intermediate type.
+/// Run the elaboration stage on a resolved [`resolution::HIR`] under
+/// the given [`resolution::ElaborationConfig`], producing a
+/// fully-balanced [`elaboration::Journal`].
+///
+/// The config is the elaborator's only source of semantic choices
+/// (tolerance rule, balance mode, assertion scope, ...). Callers
+/// typically pass `frontend.defaults()` for the matching tool's
+/// behaviour:
+///
+/// ```rust
+/// use doppio::frontend::Frontend as _;
+/// use doppio::LedgerFrontend;
+///
+/// let hir = LedgerFrontend
+///     .parse(
+///         "2024-01-01 Test\n  Expenses:Food  $10\n  Assets:Cash\n",
+///         std::path::Path::new(""),
+///         &|_| Ok(String::new()),
+///     )
+///     .unwrap();
+/// let journal = doppio::elaborate(hir, LedgerFrontend.defaults()).unwrap();
+/// assert_eq!(journal.transactions.len(), 1);
+/// ```
+///
+/// Or any other config to mix-and-match syntax and semantics
+/// (parse a beancount file under ledger-cli rules, etc.).
 pub fn elaborate(
     hir: resolution::HIR,
+    config: &resolution::ElaborationConfig,
 ) -> Result<elaboration::Journal, elaborator::ElaborationError> {
-    elaboration::Journal::try_from(hir)
+    elaborator::elaborate(hir, config)
 }
 
 /// Evaluate a single [`resolution::Transaction`] through the elaboration stage.
@@ -473,7 +500,14 @@ pub fn eval_transaction(
         contexts: vec![context.clone()],
         ..Default::default()
     };
-    let journal = elaboration::Journal::try_from(hir)?;
+    // No frontend is involved in programmatic transaction construction,
+    // so there's no natural "matching" default. Use the ledger-cli rules
+    // (strict balance, cost-basis lots, direct-account assertions) --
+    // the strictest of the three -- so a programmatically-built
+    // transaction has to balance exactly. Callers that need different
+    // semantics can use [`elaborate`] directly with their own
+    // [`resolution::ElaborationConfig`].
+    let journal = elaborator::elaborate(hir, &grammars::ledger::LEDGER_DEFAULTS)?;
     // The HIR contained exactly one transaction, so the journal has exactly one.
     Ok(journal
         .transactions

--- a/crates/doppio/src/lib.rs
+++ b/crates/doppio/src/lib.rs
@@ -408,11 +408,11 @@ where
     let output = parser.parse(input)?;
     let hir: resolution::HIR = output.try_into()?;
     // The parser is type-locked to ledger-cli, so the matching defaults
-    // are LEDGER_DEFAULTS. Callers who want a different elaboration
+    // are `ledger_defaults()`. Callers who want a different elaboration
     // ruleset (e.g. relaxed tolerance, subtree assertions) can call
     // `frontend.parse()` and `elaborate()` separately and pass an
     // explicit `ElaborationConfig`.
-    Ok(elaborate(hir, &grammars::ledger::LEDGER_DEFAULTS)?)
+    Ok(elaborate(hir, &grammars::ledger::ledger_defaults())?)
 }
 
 /// Run the elaboration stage on a resolved [`resolution::HIR`] under
@@ -421,8 +421,8 @@ where
 ///
 /// The config is the elaborator's only source of semantic choices
 /// (tolerance rule, balance mode, assertion scope, ...). Callers
-/// typically pass `frontend.defaults()` for the matching tool's
-/// behaviour:
+/// typically pass `&frontend.elaboration_defaults()` for the matching
+/// tool's behaviour:
 ///
 /// ```rust
 /// use doppio::frontend::Frontend as _;
@@ -435,7 +435,7 @@ where
 ///         &|_| Ok(String::new()),
 ///     )
 ///     .unwrap();
-/// let journal = doppio::elaborate(hir, LedgerFrontend.defaults()).unwrap();
+/// let journal = doppio::elaborate(hir, &LedgerFrontend.elaboration_defaults()).unwrap();
 /// assert_eq!(journal.transactions.len(), 1);
 /// ```
 ///
@@ -507,7 +507,7 @@ pub fn eval_transaction(
     // transaction has to balance exactly. Callers that need different
     // semantics can use [`elaborate`] directly with their own
     // [`resolution::ElaborationConfig`].
-    let journal = elaborator::elaborate(hir, &grammars::ledger::LEDGER_DEFAULTS)?;
+    let journal = elaborator::elaborate(hir, &grammars::ledger::ledger_defaults())?;
     // The HIR contained exactly one transaction, so the journal has exactly one.
     Ok(journal
         .transactions

--- a/crates/doppio/src/resolution.rs
+++ b/crates/doppio/src/resolution.rs
@@ -115,8 +115,18 @@ pub(crate) struct Define {
     pub body: ast::DefineBody,
 }
 
-/// Global properties of commodities and accounts that are shared across all
-/// contexts (i.e. not invalidated by later directives).
+/// Per-journal state populated during resolution.
+///
+/// Holds journal-derived metadata (commodity / account / tag properties,
+/// per-commodity tolerance overrides set by `option` directives) — i.e.
+/// things the resolver builds from directives in the source file. The
+/// elaborator's *semantic configuration* (default tolerance rule, balance
+/// mode, assertion scope, ...) is **not** here -- that lives in
+/// [`ElaborationConfig`] and is passed explicitly to `elaborate()`. The
+/// two layers are deliberately separate: a frontend's job is to parse a
+/// dialect into the AST, the resolver canonicalises the AST into the
+/// HIR, and the elaborator applies a semantic ruleset that the caller
+/// chooses (typically the matching tool's defaults, but freely mixable).
 #[derive(Default, Debug)]
 pub struct GlobalContext {
     /// Properties declared in `commodity` directives.
@@ -125,16 +135,45 @@ pub struct GlobalContext {
     pub account_properties: BTreeMap<String, AccountProperties>,
     /// Properties declared in `tag` directives.
     pub tag_properties: BTreeMap<String, TagProperties>,
-    /// How the elaborator handles small per-transaction balance
-    /// residuals. See [`ToleranceMode`].
-    pub tolerance_mode: ToleranceMode,
-    /// Per-commodity absolute tolerance overrides, layered on top of
-    /// [`Self::tolerance_mode`]. Populated by Beancount's
-    /// `option "inferred_tolerance_default" "COMMODITY:VALUE"`
-    /// directive. When a commodity is present in this map, the
-    /// elaborator uses the override directly; otherwise it falls back
-    /// to the `tolerance_mode` rule.
+    /// Per-commodity absolute tolerance overrides populated by Beancount's
+    /// `option "inferred_tolerance_default" "COMMODITY:VALUE"` directive.
+    /// When a commodity is present in this map, the elaborator uses the
+    /// override directly; otherwise it falls back to
+    /// [`ElaborationConfig::tolerance_mode`]. This map is journal state
+    /// (mutated by directives during resolution), not config -- and is
+    /// therefore the one tolerance-related field that stays on
+    /// `GlobalContext`.
     pub tolerance_overrides: BTreeMap<String, rust_decimal::Decimal>,
+}
+
+/// The elaborator's semantic configuration.
+///
+/// Passed explicitly to [`crate::elaborate`] alongside the [`HIR`].
+/// Keeps elaboration semantics decoupled from the frontend that parsed
+/// the source: a journal in beancount syntax can be elaborated under
+/// ledger-cli rules, hledger syntax under beancount rules, or any
+/// mix-and-match combination. The expected common case --
+/// "use the same tool's defaults that produced this dialect" -- is
+/// served by the [`crate::frontend::Frontend::defaults`] convenience
+/// per-frontend default constants.
+///
+/// # Layering with journal-injected overrides
+///
+/// Journal directives can override individual fields per commodity /
+/// account: the most prominent example is Beancount's
+/// `option "inferred_tolerance_default" "COMMODITY:VALUE"` which
+/// populates [`GlobalContext::tolerance_overrides`]. The elaborator
+/// reads the override map first and falls back to the config's
+/// [`Self::tolerance_mode`] when no override is present. The config
+/// stays immutable per elaboration call; the override map is
+/// journal-derived and lives on `GlobalContext`.
+#[derive(Debug, Clone, Default)]
+pub struct ElaborationConfig {
+    /// Default per-transaction balance-residual tolerance. Per-commodity
+    /// overrides on [`GlobalContext::tolerance_overrides`] take
+    /// precedence; this rule applies to commodities not present in the
+    /// override map. See [`ToleranceMode`].
+    pub tolerance_mode: ToleranceMode,
     /// How the elaborator computes a posting's cash-equivalent for
     /// transaction balance when the posting carries both `{cost}` and
     /// `@price` annotations. See [`BalanceMode`].


### PR DESCRIPTION
Closes #239. Pure refactor — behaviour identical, all 14 parity fixtures still pass.

## What changes

The compiler pipeline is **parse → resolve → elaborate**. Each stage has its own job: parsers tokenise dialects into ASTs, the resolver canonicalises, the elaborator applies a semantic ruleset. Until now, the frontends muddled the layers by injecting per-tool semantic defaults directly onto \`GlobalContext\`:

\`\`\`rust
hir.global_context.tolerance_mode = FractionOfSmallestPrecision(0.5);
hir.global_context.balance_mode = CostBasis;
hir.global_context.assertion_scope = Subtree;
\`\`\`

That baked \"file in beancount syntax\" → \"beancount-style elaboration semantics\" as a hardcoded coupling. The pairing is conventional but **not fundamental**: a user could legitimately want to parse beancount syntax under ledger-cli rules, hledger syntax under beancount rules, or any mix-and-match.

This PR factors out the syntax → semantics pairing as a separate concern.

## Five changes

1. **New \`ElaborationConfig\`** in \`resolution\` — the three per-tool selectors that used to live on \`GlobalContext\` (\`tolerance_mode\`, \`balance_mode\`, \`assertion_scope\`).
2. **\`pub fn elaborate(hir, &ElaborationConfig)\`** is now the single entry point. The old \`TryFrom<HIR> for Journal\` impl is gone — converting an HIR to a Journal isn't a one-arg operation any more, it requires choosing a semantic ruleset.
3. **\`Frontend::defaults() -> &'static ElaborationConfig\`** is a new trait method. Each frontend returns the matching tool's defaults — a *convenience pairing*, not a forced coupling.
4. **\`static *_DEFAULTS: LazyLock<ElaborationConfig>\`** in each frontend module (\`LEDGER_DEFAULTS\`, \`HLEDGER_DEFAULTS\`, \`BEANCOUNT_DEFAULTS\`).
5. **Frontends no longer mutate semantic-config fields**. \`Frontend::parse\` produces just the parse + resolve output.

\`tolerance_overrides\` on \`GlobalContext\` stays put — it's *journal* state populated from \`option\` directives during resolution, not config. At elaboration time, per-commodity overrides layer on top of the config's \`tolerance_mode\`.

## Composability

\`\`\`rust
let hir = BeancountFrontend.parse(input, base_path, opener)?;
let journal = elaborate(hir, BeancountFrontend.defaults())?;     // canonical pairing
let journal = elaborate(hir, LedgerFrontend.defaults())?;        // mix-and-match
let journal = elaborate(hir, &my_custom_config)?;                // arbitrary
\`\`\`

## API impact (breaking)

- \`pub fn elaborate(hir)\` → \`pub fn elaborate(hir, &ElaborationConfig)\`. Caller passes a config explicitly.
- \`compile()\` is type-locked to ledger-cli (takes a \`grammars::ledger::Parser\`); internally uses \`LEDGER_DEFAULTS\`. Caller-facing signature unchanged.
- \`eval_transaction()\` (programmatic builder API) uses \`LEDGER_DEFAULTS\` internally since no frontend is involved. Caller-facing signature unchanged.
- \`TryFrom<HIR> for Journal\` is gone — there's no automatic conversion any more.

The \`elaborate\` change is the only caller-visible breakage.

## Files touched

\`crates/doppio/src/resolution.rs\`, \`elaborator.rs\`, \`frontend.rs\`, \`grammars/{ledger,hledger,beancount}/mod.rs\`, \`lib.rs\`; \`crates/doppio-cli/src/main.rs\`, \`src/bin/timings.rs\`, \`tests/dop_format.rs\`; \`crates/doppio-categorize/examples/eval_holdout.rs\`.

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo test --workspace\` — 304 lib tests pass.
- [x] \`python3 scripts/parity_check.py\` — all 14 fixtures pass against bean-check 3.2.0, hledger 1.40, ledger 3.3.2.
- [x] \`python3 scripts/parity_check.py --self-test\` — 12/12 comparator assertions hold.

## Why this lands before #237

#237 (per-lot inventory) introduces a fifth selector (\`LotValidationMode\`). With this refactor in first, that selector slots cleanly into \`ElaborationConfig\` from day one — and reviewers of #237 can see the lot work as pure new functionality on top of an already-tidy structure rather than refactor + new field in one PR.

Closes #239.