### PR TITLE
feat(elaborator): auto-booking for Beancount {} reductions (#238)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,21 @@ surface.
   commodity under different lot keys is rejected with
   `ElaborationError::PhantomLotReduction`. ledger-cli + hledger
   defaults remain `Permissive`. (#237)
+- **`BookingMethod` and auto-booking for Beancount `{}` reductions.**
+  The Beancount parser now captures the booking method on `open`
+  directives as a structured `AccountItem::Booking(BookingMethod)`
+  (previously stashed as a free-form note). At elaboration time, a
+  reducing posting whose lot annotation is `{}` (or a partial spec
+  like `{2024-01-15}`) is matched against the account's running
+  inventory per the configured method: `FIFO` consumes oldest lots
+  first, `LIFO` newest, `HIFO` highest-cost, `STRICT` errors on
+  ambiguity, `NONE` skips booking entirely. Multi-lot reductions are
+  split into one synthesised posting per matched lot. Lot dates are
+  auto-filled from the transaction date on augmenting postings (so
+  `{1500 USD}` records `[2024-01-15]` when written on a 2024-01-15
+  transaction), matching bean-check. (#238) Known gap: cost-basis-aware
+  gain inference for null `Income:Trading` postings is incorrect when
+  `{}` reductions balance via `@price` — tracked separately as #242.
 
 ---
 

--- a/crates/doppio/src/ast.rs
+++ b/crates/doppio/src/ast.rs
@@ -208,6 +208,11 @@ pub(crate) enum AccountItem {
     /// If the expression evaluates to `false`, a warning is printed to stderr
     /// but elaboration continues.
     Check(BoolExpr),
+    /// The booking method declared on a Beancount `open` directive (e.g.
+    /// `open Assets:Brokerage AAPL "FIFO"`). Governs how an ambiguous
+    /// `{}` reduction is resolved against the account's running
+    /// inventory. See [`crate::resolution::BookingMethod`].
+    Booking(crate::resolution::BookingMethod),
     /// An unrecognised sub-directive with an optional value.
     Unknown(String, Option<String>),
 }

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -252,6 +252,44 @@ pub enum ElaborationError {
         /// The named lot key that was not found in the inventory.
         lot: String,
     },
+    /// A posting carries a MISSING-cost lot spec (`{}` or partial like
+    /// `{2024-01-15}`) under [`crate::resolution::BookingMethod::Strict`],
+    /// but the partial spec matches more than one lot in the account's
+    /// inventory. Beancount's STRICT booking rejects these as
+    /// ambiguous; FIFO/LIFO/HIFO/AVERAGE would resolve them. See #238.
+    AmbiguousLotMatch {
+        /// The account.
+        account: String,
+        /// The commodity being reduced.
+        commodity: String,
+        /// Number of inventory lots that matched the partial spec.
+        match_count: usize,
+    },
+    /// A booking pass tried to consume more units than the account's
+    /// inventory holds in the named commodity (or matching lot subset
+    /// when a partial spec was given). The reduction is over-sized
+    /// for what the inventory can supply.
+    OverReductionInBooking {
+        /// The account being reduced.
+        account: String,
+        /// The commodity being reduced.
+        commodity: String,
+        /// Units the posting tried to consume (positive).
+        requested: Decimal,
+        /// Units actually available across all matching lots.
+        available: Decimal,
+    },
+    /// A posting with a MISSING-cost lot spec (`{}`) carries POSITIVE
+    /// units (i.e. augmentation) under a non-NONE booking method.
+    /// Augmenting with `{}` requires the cost to come from somewhere
+    /// (an `@price` annotation, typically); supporting that is
+    /// out of scope for the initial #238 cut.
+    AugmentingPostingWithMissingCost {
+        /// The account.
+        account: String,
+        /// The commodity.
+        commodity: String,
+    },
 }
 
 /// Error produced when evaluating a value expression (e.g., an amount or
@@ -446,6 +484,39 @@ impl Display for ElaborationError {
                     f,
                     "phantom-lot reduction: account `{account}` has no prior augmentation \
                      of `{commodity}` matching lot `{lot}`"
+                )
+            }
+            ElaborationError::AmbiguousLotMatch {
+                account,
+                commodity,
+                match_count,
+            } => {
+                write!(
+                    f,
+                    "ambiguous booking: account `{account}` has {match_count} \
+                     matching lots of `{commodity}`; STRICT booking requires \
+                     exactly one (use FIFO/LIFO/HIFO/AVERAGE on `open` to disambiguate)"
+                )
+            }
+            ElaborationError::OverReductionInBooking {
+                account,
+                commodity,
+                requested,
+                available,
+            } => {
+                write!(
+                    f,
+                    "over-reduction during booking: account `{account}` has \
+                     {available} {commodity} available across matching lots, \
+                     but the posting tried to reduce {requested}"
+                )
+            }
+            ElaborationError::AugmentingPostingWithMissingCost { account, commodity } => {
+                write!(
+                    f,
+                    "MISSING-cost lot annotation (`{{}}`) on an augmenting posting \
+                     of `{commodity}` to `{account}`: doppio's booking implementation \
+                     handles reductions only; spell out `{{cost}}` explicitly for augmentations"
                 )
             }
         }
@@ -760,8 +831,33 @@ pub fn elaborate(
                                         if let Some(ann) = lot_annotation {
                                             let epoch = chrono::NaiveDate::from_ymd_opt(1970, 1, 1)
                                                 .expect("epoch is valid");
+                                            // Auto-fill the lot date from the
+                                            // transaction date for AUGMENTING
+                                            // postings (positive units, explicit
+                                            // cost): matches bean-check, which
+                                            // writes the transaction date as
+                                            // the lot's acquisition date when
+                                            // `{}` carries no `[date]`.
+                                            // Reducing postings (negative
+                                            // units) and MISSING-cost specs are
+                                            // left as the user wrote them: the
+                                            // booking pass walks inventory and
+                                            // re-emits explicit-cost postings
+                                            // with the matched lot's date.
+                                            // Required for FIFO / LIFO to
+                                            // distinguish lots whose only other
+                                            // annotation is cost.
+                                            let is_augmenting =
+                                                !value.is_sign_negative() && !value.is_zero();
+                                            let lot_date = ann.date.or(
+                                                if is_augmenting && ann.cost.is_some() {
+                                                    Some(transaction.date)
+                                                } else {
+                                                    Option::None
+                                                },
+                                            );
                                             let proto_date =
-                                                ann.date.map(|d| (d - epoch).num_days() as i32);
+                                                lot_date.map(|d| (d - epoch).num_days() as i32);
                                             let cost_is_total = ann.cost_is_total;
                                             let (proto_cost, cost_pair) =
                                                 if let Some(cost_expr) = ann.cost {
@@ -1366,6 +1462,21 @@ pub fn elaborate(
                         )?;
                     }
 
+                    // Booking pass (#238): for any posting carrying a
+                    // MISSING-cost lot annotation (`{}` or partial),
+                    // look up the account's booking method and
+                    // synthesise explicit-cost replacement postings
+                    // matched against the running inventory. Must run
+                    // BEFORE the phantom-lot check so the latter sees
+                    // booked (concrete-cost) postings that match the
+                    // inventory by construction.
+                    let resolved_postings = apply_booking(
+                        resolved_postings,
+                        &state.account_inventories,
+                        &value.global_context.account_properties,
+                        config.default_booking_method,
+                    )?;
+
                     // Strict lot-validation: project this transaction's
                     // lot-bearing postings onto the running inventory and
                     // reject any reducing posting whose lot key picks
@@ -1405,15 +1516,43 @@ pub fn elaborate(
                             if !delta.is_sign_negative() {
                                 continue;
                             }
-                            let prior_specific = state
+                            // Per-account opt-out: an EXPLICIT
+                            // `BookingMethod::None` on the `open`
+                            // directive means "this account allows
+                            // mixed inventories; don't validate".
+                            // Doesn't apply to accounts that merely
+                            // *fall back* to the frontend default --
+                            // those still participate in
+                            // `LotValidationMode::Strict` checking.
+                            let booking_method = value
+                                .global_context
+                                .account_properties
+                                .get(account)
+                                .and_then(|p| p.booking_method);
+                            if matches!(booking_method, Some(resolution::BookingMethod::None)) {
+                                continue;
+                            }
+                            // The reducer's LotKey acts as a *partial
+                            // spec*: None fields match any value in the
+                            // inventory. A reducer like `{$150}` (cost
+                            // specified, date inherited as None) matches
+                            // any inventory lot at $150 regardless of
+                            // its (auto-filled) acquisition date. See
+                            // #238 for the rationale.
+                            let any_match = state
                                 .account_inventories
                                 .get(account)
-                                .and_then(|inv| {
-                                    inv.positions.get(&(commodity.clone(), Some(lot.clone())))
+                                .map(|inv| {
+                                    inv.positions.iter().any(|((c, k), v)| {
+                                        c == commodity
+                                            && !v.is_zero()
+                                            && k.as_ref().is_some_and(|inv_lot| {
+                                                lot_matches_pattern(lot, inv_lot)
+                                            })
+                                    })
                                 })
-                                .copied()
-                                .unwrap_or_default();
-                            if !prior_specific.is_zero() {
+                                .unwrap_or(false);
+                            if any_match {
                                 continue;
                             }
                             let any_prior_same_commodity = state
@@ -1597,6 +1736,261 @@ fn for_each_descendant<T>(map: &BTreeMap<String, T>, account: &str, mut f: impl 
 /// commodity), so we read the first entry. If the cost map is empty
 /// (a lot with `[date]` only, for example), `cost` and `cost_commodity`
 /// are `None`.
+/// Does `inventory` satisfy the constraints in `pattern`? Each field
+/// of `pattern` that is `Some(_)` must equal the corresponding
+/// inventory field; `None` fields in `pattern` match any value. Used
+/// by both the phantom-lot validator and the booking pass when a
+/// reducer's lot annotation only partially specifies the lot key.
+fn lot_matches_pattern(pattern: &LotKey, inventory: &LotKey) -> bool {
+    if let Some(c) = &pattern.cost
+        && Some(c) != inventory.cost.as_ref()
+    {
+        return false;
+    }
+    if let Some(c) = &pattern.cost_commodity
+        && Some(c) != inventory.cost_commodity.as_ref()
+    {
+        return false;
+    }
+    if let Some(d) = &pattern.date
+        && Some(d) != inventory.date.as_ref()
+    {
+        return false;
+    }
+    if let Some(n) = &pattern.note
+        && Some(n) != inventory.note.as_ref()
+    {
+        return false;
+    }
+    true
+}
+
+/// Apply per-account booking methods to any posting whose lot
+/// annotation carries a MISSING cost (`{}` or a partial spec like
+/// `{2024-01-15}`). The MISSING-cost marker is the user's request:
+/// "look at the inventory and tell me which lot(s) this reduction
+/// drew from." Each such posting is replaced by one or more booked
+/// postings, each carrying an explicit cost on its lot annotation.
+///
+/// Inputs:
+/// - `postings` — the elaborated postings produced by the main
+///   transaction loop. Already balance-checked.
+/// - `inventories` — the running per-account inventory at the moment
+///   the transaction is being elaborated (from before this
+///   transaction's contributions are folded in).
+/// - `account_properties` — looked up per posting account to find
+///   the configured [`BookingMethod`].
+///
+/// Postings without a lot annotation, or with an explicit cost, are
+/// passed through unchanged. Postings on accounts whose booking
+/// method is [`BookingMethod::None`] are also passed through (NONE
+/// short-circuits booking entirely; the cost stays MISSING).
+///
+/// Augmenting postings with MISSING cost are rejected with
+/// [`ElaborationError::AugmentingPostingWithMissingCost`] — first
+/// cut handles reductions only.
+///
+/// AVERAGE booking is not yet implemented; an account configured
+/// with AVERAGE falls through to FIFO behaviour for now (tracked as
+/// follow-up to #238).
+fn apply_booking(
+    postings: Vec<crate::elaboration::Posting>,
+    inventories: &BTreeMap<String, AccountInventory>,
+    account_properties: &BTreeMap<String, resolution::AccountProperties>,
+    default_booking_method: resolution::BookingMethod,
+) -> Result<Vec<crate::elaboration::Posting>, ElaborationError> {
+    let mut out: Vec<crate::elaboration::Posting> = Vec::with_capacity(postings.len());
+    // Track the per-account, per-commodity reductions we've already
+    // booked from earlier postings in the same transaction so that a
+    // subsequent MISSING-cost posting on the same account doesn't
+    // re-consume an already-booked lot.
+    let mut consumed: BTreeMap<(String, String, LotKey), Decimal> = BTreeMap::new();
+
+    for posting in postings {
+        let Some(lot) = posting.lot.as_ref() else {
+            out.push(posting);
+            continue;
+        };
+        if lot.cost.is_some() {
+            // Explicit cost: not a booking trigger.
+            out.push(posting);
+            continue;
+        }
+        // MISSING-cost lot annotation. Look up the booking method,
+        // falling back to the frontend default (Beancount: STRICT;
+        // ledger / hledger: NONE — i.e. the booking pass is a no-op).
+        let method = account_properties
+            .get(&posting.account)
+            .and_then(|p| p.booking_method)
+            .unwrap_or(default_booking_method);
+        if matches!(method, resolution::BookingMethod::None) {
+            // NONE: skip booking entirely. Posting is recorded as cost=None.
+            out.push(posting);
+            continue;
+        }
+        // We need the units to know how much to consume. Booking only
+        // applies when the posting carries a single commodity; the
+        // amounts() iterator yields one entry per commodity (postings
+        // synthesised by `==*` are multi-commodity but never carry a
+        // lot annotation, so this is unreachable in practice).
+        let amount_pairs: Vec<(String, Decimal)> =
+            posting.amounts().map(|(c, v)| (c.to_string(), v)).collect();
+        if amount_pairs.len() != 1 {
+            // Zero or multi-commodity posting with a lot annotation:
+            // not supported by booking. Pass through.
+            out.push(posting);
+            continue;
+        }
+        let (commodity, units) = amount_pairs.into_iter().next().expect("len == 1");
+        if !units.is_sign_negative() {
+            return Err(ElaborationError::AugmentingPostingWithMissingCost {
+                account: posting.account.clone(),
+                commodity,
+            });
+        }
+        // Partial cost spec hints (date, note) filter eligible lots.
+        let date_hint = lot.date.and_then(|epoch_days| {
+            chrono::NaiveDate::from_ymd_opt(1970, 1, 1).and_then(|epoch| {
+                epoch.checked_add_signed(chrono::Duration::days(epoch_days as i64))
+            })
+        });
+        let note_hint = lot.note.clone();
+
+        let inventory = inventories.get(&posting.account);
+        let mut eligible_lots: Vec<(LotKey, Decimal)> = inventory
+            .map(|inv| {
+                inv.positions
+                    .iter()
+                    .filter_map(|((c, lot_key_opt), bal)| {
+                        if c != &commodity {
+                            return None;
+                        }
+                        let lot_key = lot_key_opt.clone()?;
+                        if !bal.is_sign_positive() || bal.is_zero() {
+                            return None;
+                        }
+                        if let Some(d) = date_hint
+                            && lot_key.date != Some(d)
+                        {
+                            return None;
+                        }
+                        if let Some(n) = note_hint.as_deref()
+                            && lot_key.note.as_deref() != Some(n)
+                        {
+                            return None;
+                        }
+                        // Subtract any already-consumed units in this
+                        // transaction.
+                        let already = consumed
+                            .get(&(posting.account.clone(), commodity.clone(), lot_key.clone()))
+                            .copied()
+                            .unwrap_or_default();
+                        let remaining = *bal - already;
+                        if remaining.is_zero() || !remaining.is_sign_positive() {
+                            return None;
+                        }
+                        Some((lot_key, remaining))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Sort eligible lots per the booking method.
+        match method {
+            resolution::BookingMethod::Fifo
+            | resolution::BookingMethod::Strict
+            | resolution::BookingMethod::StrictWithSize
+            | resolution::BookingMethod::Average => {
+                // FIFO + STRICT both walk in ascending acquisition-date
+                // order; STRICT errors on >1 match below. AVERAGE is
+                // not yet a separate path -- documented as follow-up.
+                eligible_lots.sort_by_key(|(k, _)| k.date);
+            }
+            resolution::BookingMethod::Lifo => {
+                eligible_lots.sort_by_key(|b| std::cmp::Reverse(b.0.date));
+            }
+            resolution::BookingMethod::Hifo => {
+                eligible_lots.sort_by_key(|b| std::cmp::Reverse(b.0.cost));
+            }
+            resolution::BookingMethod::None => unreachable!("handled above"),
+        }
+
+        if matches!(method, resolution::BookingMethod::Strict) && eligible_lots.len() > 1 {
+            return Err(ElaborationError::AmbiguousLotMatch {
+                account: posting.account.clone(),
+                commodity,
+                match_count: eligible_lots.len(),
+            });
+        }
+
+        // Walk eligible lots in order and synthesise booked postings.
+        let mut to_consume = -units; // positive
+        let total_available: Decimal = eligible_lots.iter().map(|(_, b)| *b).sum();
+        if to_consume > total_available {
+            return Err(ElaborationError::OverReductionInBooking {
+                account: posting.account.clone(),
+                commodity,
+                requested: to_consume,
+                available: total_available,
+            });
+        }
+        for (lot_key, balance) in eligible_lots {
+            if to_consume.is_zero() {
+                break;
+            }
+            let take = to_consume.min(balance);
+            // Synthesise a booked posting: same account/payee/state/etc.
+            // but with the explicit lot key and reduced units.
+            let booked = synthesise_booked_posting(&posting, &commodity, -take, &lot_key);
+            *consumed
+                .entry((posting.account.clone(), commodity.clone(), lot_key.clone()))
+                .or_default() += take;
+            out.push(booked);
+            to_consume -= take;
+        }
+    }
+    Ok(out)
+}
+
+/// Build a single booked posting cloned from `original`, with
+/// `units` (negative) of `commodity` and an explicit cost from `lot_key`.
+/// Used by [`apply_booking`] when a MISSING-cost reduction has been
+/// matched against a specific inventory lot.
+fn synthesise_booked_posting(
+    original: &crate::elaboration::Posting,
+    commodity: &str,
+    units: Decimal,
+    lot_key: &LotKey,
+) -> crate::elaboration::Posting {
+    let proto_amount = crate::elaboration::Amount {
+        by_commodity: BTreeMap::from([(commodity.to_string(), crate::decimal_to_proto(units))]),
+    };
+    let lot_cost = lot_key
+        .cost
+        .zip(lot_key.cost_commodity.clone())
+        .map(|(cv, cc)| crate::elaboration::Amount {
+            by_commodity: BTreeMap::from([(cc, crate::decimal_to_proto(cv))]),
+        });
+    let proto_date = lot_key.date.and_then(|d| {
+        chrono::NaiveDate::from_ymd_opt(1970, 1, 1).map(|epoch| (d - epoch).num_days() as i32)
+    });
+    let lot = crate::elaboration::Lot {
+        cost: lot_cost,
+        date: proto_date,
+        note: lot_key.note.clone(),
+    };
+    crate::elaboration::Posting {
+        account: original.account.clone(),
+        payee: original.payee.clone(),
+        amount: Some(proto_amount),
+        state: original.state,
+        tags: original.tags.clone(),
+        metadata: original.metadata.clone(),
+        kind: original.kind,
+        lot: Some(lot),
+    }
+}
+
 /// Render a [`LotKey`] for human-readable diagnostic output (error
 /// messages, primarily). Mirrors the source-syntax order
 /// `{cost} [date] ((note))`, omitting fields that are `None`. Empty

--- a/crates/doppio/src/grammars/beancount/mod.rs
+++ b/crates/doppio/src/grammars/beancount/mod.rs
@@ -573,7 +573,7 @@ fn parse_open_directive(pair: Pair<Rule>) -> Directive {
     let name = inner.next().unwrap().as_str().to_string();
 
     let mut notes = Vec::new();
-    let items = Vec::new();
+    let mut items = Vec::new();
 
     for p in inner {
         match p.as_rule() {
@@ -585,7 +585,13 @@ fn parse_open_directive(pair: Pair<Rule>) -> Directive {
             }
             Rule::booking_method => {
                 let inner_pair = p.into_inner().next().unwrap();
-                notes.push(format!("booking: {}", inner_pair.as_str()));
+                let raw = inner_pair.as_str();
+                if let Some(method) = parse_booking_method(raw) {
+                    items.push(crate::ast::AccountItem::Booking(method));
+                } else {
+                    // Unknown spelling -- preserve as a free-form note for diagnostics.
+                    notes.push(format!("booking: {raw}"));
+                }
             }
             Rule::note => notes.push(p.into_inner().as_str().trim().to_string()),
             Rule::metadata_line => notes.push(metadata_line_to_note(p)),
@@ -594,6 +600,24 @@ fn parse_open_directive(pair: Pair<Rule>) -> Directive {
     }
 
     Directive::Account { name, notes, items }
+}
+
+/// Map Beancount's `Booking` spelling on the `open` directive to the
+/// structured [`crate::resolution::BookingMethod`]. Unknown values
+/// return `None`; callers fall through to a free-form note so the
+/// raw text is still observable.
+fn parse_booking_method(raw: &str) -> Option<crate::resolution::BookingMethod> {
+    use crate::resolution::BookingMethod::*;
+    Some(match raw {
+        "STRICT" => Strict,
+        "STRICT_WITH_SIZE" => StrictWithSize,
+        "NONE" => None,
+        "AVERAGE" => Average,
+        "FIFO" => Fifo,
+        "LIFO" => Lifo,
+        "HIFO" => Hifo,
+        _ => return Option::None,
+    })
 }
 
 fn parse_commodity_directive(pair: Pair<Rule>) -> Directive {
@@ -885,6 +909,7 @@ pub fn beancount_defaults() -> crate::resolution::ElaborationConfig {
         balance_mode: crate::resolution::BalanceMode::CostBasis,
         assertion_scope: crate::resolution::AssertionScope::Subtree,
         lot_validation_mode: crate::resolution::LotValidationMode::Strict,
+        default_booking_method: crate::resolution::BookingMethod::Strict,
     }
 }
 
@@ -1237,12 +1262,36 @@ mod tests {
     fn open_with_booking_method() {
         let input = "2024-01-01 open Assets:Brokerage AAPL,USD \"FIFO\"\n";
         let journal = parse_beancount(input).expect("parse");
-        let Entry::Directive(Directive::Account { name, notes, .. }) = &journal.entries[0] else {
+        let Entry::Directive(Directive::Account {
+            name, notes, items, ..
+        }) = &journal.entries[0]
+        else {
             panic!();
         };
         assert_eq!(name, "Assets:Brokerage");
-        assert!(notes.iter().any(|n| n == "booking: FIFO"));
+        let booking = items.iter().find_map(|i| match i {
+            crate::ast::AccountItem::Booking(b) => Some(*b),
+            _ => Option::None,
+        });
+        assert_eq!(booking, Some(crate::resolution::BookingMethod::Fifo));
         assert!(notes.iter().any(|n| n.contains("AAPL,USD")));
+    }
+
+    #[test]
+    fn open_with_unknown_booking_method_falls_back_to_note() {
+        // Unknown spellings should not panic the parser; preserve as a
+        // free-form note so the raw text is still observable.
+        let input = "2024-01-01 open Assets:Brokerage AAPL \"WACKY_METHOD\"\n";
+        let journal = parse_beancount(input).expect("parse");
+        let Entry::Directive(Directive::Account { notes, items, .. }) = &journal.entries[0] else {
+            panic!();
+        };
+        assert!(
+            !items
+                .iter()
+                .any(|i| matches!(i, crate::ast::AccountItem::Booking(_)))
+        );
+        assert!(notes.iter().any(|n| n == "booking: WACKY_METHOD"));
     }
 
     #[test]
@@ -1329,6 +1378,60 @@ mod tests {
         for e in &journal.entries {
             assert!(matches!(e, Entry::Comment(_)));
         }
+    }
+
+    #[test]
+    fn empty_lot_annotation_parses_as_missing_cost() {
+        // `{}` is Beancount's "MISSING cost" spec: a request to the
+        // elaborator to apply the account's booking method against
+        // the running inventory rather than spelling out a specific
+        // lot key. The parser captures this as
+        // `lot_annotation = Some(ann)` with `ann.cost = None` -- the
+        // top-level `Some` distinguishes "annotation present" from
+        // "no annotation at all", and the inner `cost: None`
+        // distinguishes "MISSING cost" from "explicit cost".
+        let input = "\
+2024-03-15 * \"Sell with empty cost spec\"
+  Assets:Brokerage   -5 AAPL {}
+  Assets:Cash       1000 USD
+";
+        let journal = parse_beancount(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!();
+        };
+        let Some(AmountDetails::Amount { lot_annotation, .. }) = &tx.postings[0].amount else {
+            panic!("expected Amount details");
+        };
+        let ann = lot_annotation.as_ref().expect("lot annotation present");
+        assert!(ann.cost.is_none(), "empty {{}} should leave cost MISSING");
+        assert!(ann.date.is_none());
+        assert!(ann.note.is_none());
+    }
+
+    #[test]
+    fn partial_lot_annotation_date_only_parses_as_missing_cost() {
+        // `{2024-01-15}` is a partial cost spec: cost is MISSING, but
+        // the booking method gets a date hint to narrow which lots
+        // are eligible. Same shape as empty `{}` from the cost-MISSING
+        // standpoint.
+        let input = "\
+2024-03-15 * \"Sell with date-only lot spec\"
+  Assets:Brokerage   -5 AAPL {2024-01-15}
+  Assets:Cash       1000 USD
+";
+        let journal = parse_beancount(input).expect("parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!();
+        };
+        let Some(AmountDetails::Amount { lot_annotation, .. }) = &tx.postings[0].amount else {
+            panic!("expected Amount details");
+        };
+        let ann = lot_annotation.as_ref().expect("lot annotation present");
+        assert!(
+            ann.cost.is_none(),
+            "date-only spec should leave cost MISSING"
+        );
+        assert_eq!(ann.date, chrono::NaiveDate::from_ymd_opt(2024, 1, 15));
     }
 
     #[test]
@@ -2444,5 +2547,337 @@ option \"inferred_tolerance_default\" \"USD:0.1\"
 2024-12-31 balance Income:Salary -100.00 USD
 ";
         elaborate(input).expect("leaf-account assertion must still pass");
+    }
+
+    // ----------------------------------------------------------------------
+    // Auto-booking tests (#238)
+    // ----------------------------------------------------------------------
+
+    /// FIFO booking: a `{}` reduction matches against the oldest lot
+    /// in the inventory. The single MISSING-cost posting is replaced
+    /// by one explicit-cost booked posting carrying the matched lot's
+    /// cost basis.
+    #[test]
+    fn fifo_books_against_oldest_lot() {
+        let input = "\
+2024-01-01 open Assets:Brokerage \"FIFO\"
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Income:Trading
+
+2024-01-15 * \"Buy\"
+  Assets:Brokerage   10 GOLD {1500.00 USD}
+  Assets:Cash       -15000.00 USD
+
+2024-02-15 * \"Buy more\"
+  Assets:Brokerage   10 GOLD {1600.00 USD}
+  Assets:Cash       -16000.00 USD
+
+2024-03-15 * \"Sell with empty cost spec\"
+  Assets:Brokerage   -5 GOLD {} @ 1700.00 USD
+  Assets:Cash       8500.00 USD
+  Income:Trading
+";
+        let elab = elaborate(input).expect("FIFO booking should succeed");
+        let sell_tx = elab
+            .transactions
+            .iter()
+            .find(|t| t.description == "Sell with empty cost spec")
+            .unwrap();
+        let booked = sell_tx
+            .postings
+            .iter()
+            .find(|p| p.account == "Assets:Brokerage")
+            .expect("brokerage posting present");
+        assert_eq!(booked.amount_in("GOLD"), Some(dec!(-5)));
+        assert_eq!(
+            booked.lot_cost_in("USD"),
+            Some(dec!(1500.00)),
+            "FIFO should match the oldest (1500 USD) lot"
+        );
+    }
+
+    /// FIFO booking with a multi-lot reduction: `-15 GOLD {}` against
+    /// 10 + 10 should split into one -10 GOLD {1500} posting and one
+    /// -5 GOLD {1600} posting on the brokerage account.
+    #[test]
+    fn fifo_splits_multi_lot_reduction() {
+        let input = "\
+2024-01-01 open Assets:Brokerage \"FIFO\"
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Income:Trading
+
+2024-01-15 * \"Buy\"
+  Assets:Brokerage   10 GOLD {1500.00 USD}
+  Assets:Cash       -15000.00 USD
+
+2024-02-15 * \"Buy more\"
+  Assets:Brokerage   10 GOLD {1600.00 USD}
+  Assets:Cash       -16000.00 USD
+
+2024-03-15 * \"Sell across two lots\"
+  Assets:Brokerage   -15 GOLD {} @ 1700.00 USD
+  Assets:Cash       25500.00 USD
+  Income:Trading
+";
+        let elab = elaborate(input).expect("FIFO multi-lot booking should succeed");
+        let sell_tx = elab
+            .transactions
+            .iter()
+            .find(|t| t.description == "Sell across two lots")
+            .unwrap();
+        let brokerage_postings: Vec<_> = sell_tx
+            .postings
+            .iter()
+            .filter(|p| p.account == "Assets:Brokerage")
+            .collect();
+        assert_eq!(
+            brokerage_postings.len(),
+            2,
+            "expected two booked postings, one per matched lot"
+        );
+        // Order: oldest lot first.
+        assert_eq!(brokerage_postings[0].amount_in("GOLD"), Some(dec!(-10)));
+        assert_eq!(
+            brokerage_postings[0].lot_cost_in("USD"),
+            Some(dec!(1500.00))
+        );
+        assert_eq!(brokerage_postings[1].amount_in("GOLD"), Some(dec!(-5)));
+        assert_eq!(
+            brokerage_postings[1].lot_cost_in("USD"),
+            Some(dec!(1600.00))
+        );
+    }
+
+    /// LIFO booking: same fixture as FIFO but matches the most-recent
+    /// lot first.
+    #[test]
+    fn lifo_books_against_newest_lot() {
+        let input = "\
+2024-01-01 open Assets:Brokerage \"LIFO\"
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Income:Trading
+
+2024-01-15 * \"Buy\"
+  Assets:Brokerage   10 GOLD {1500.00 USD}
+  Assets:Cash       -15000.00 USD
+
+2024-02-15 * \"Buy more\"
+  Assets:Brokerage   10 GOLD {1600.00 USD}
+  Assets:Cash       -16000.00 USD
+
+2024-03-15 * \"Sell\"
+  Assets:Brokerage   -5 GOLD {} @ 1700.00 USD
+  Assets:Cash       8500.00 USD
+  Income:Trading
+";
+        let elab = elaborate(input).expect("LIFO booking should succeed");
+        let sell_tx = elab
+            .transactions
+            .iter()
+            .find(|t| t.description == "Sell")
+            .unwrap();
+        let booked = sell_tx
+            .postings
+            .iter()
+            .find(|p| p.account == "Assets:Brokerage")
+            .expect("brokerage posting present");
+        assert_eq!(
+            booked.lot_cost_in("USD"),
+            Some(dec!(1600.00)),
+            "LIFO should match the newest (1600 USD) lot"
+        );
+    }
+
+    /// HIFO booking: matches the highest-cost lot first.
+    #[test]
+    fn hifo_books_against_highest_cost_lot() {
+        let input = "\
+2024-01-01 open Assets:Brokerage \"HIFO\"
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Income:Trading
+
+2024-01-15 * \"Buy\"
+  Assets:Brokerage   10 GOLD {1500.00 USD}
+  Assets:Cash       -15000.00 USD
+
+2024-02-15 * \"Buy expensive\"
+  Assets:Brokerage   10 GOLD {1700.00 USD}
+  Assets:Cash       -17000.00 USD
+
+2024-02-20 * \"Buy cheaper\"
+  Assets:Brokerage   10 GOLD {1600.00 USD}
+  Assets:Cash       -16000.00 USD
+
+2024-03-15 * \"Sell\"
+  Assets:Brokerage   -5 GOLD {} @ 1750.00 USD
+  Assets:Cash       8750.00 USD
+  Income:Trading
+";
+        let elab = elaborate(input).expect("HIFO booking should succeed");
+        let sell_tx = elab
+            .transactions
+            .iter()
+            .find(|t| t.description == "Sell")
+            .unwrap();
+        let booked = sell_tx
+            .postings
+            .iter()
+            .find(|p| p.account == "Assets:Brokerage")
+            .expect("brokerage posting present");
+        assert_eq!(
+            booked.lot_cost_in("USD"),
+            Some(dec!(1700.00)),
+            "HIFO should match the most-expensive (1700 USD) lot"
+        );
+    }
+
+    /// STRICT + `{}` against multiple eligible lots is an
+    /// AmbiguousLotMatch error.
+    #[test]
+    fn strict_rejects_ambiguous_empty_lot_spec() {
+        let input = "\
+2024-01-01 open Assets:Brokerage \"STRICT\"
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Income:Trading
+
+2024-01-15 * \"Buy\"
+  Assets:Brokerage   10 GOLD {1500.00 USD}
+  Assets:Cash       -15000.00 USD
+
+2024-02-15 * \"Buy more\"
+  Assets:Brokerage   10 GOLD {1600.00 USD}
+  Assets:Cash       -16000.00 USD
+
+2024-03-15 * \"Ambiguous sell\"
+  Assets:Brokerage   -5 GOLD {} @ 1700.00 USD
+  Assets:Cash       8500.00 USD
+  Income:Trading
+";
+        let err = elaborate(input).expect_err("STRICT should reject ambiguous {} reduction");
+        assert!(
+            format!("{err:?}").contains("AmbiguousLotMatch"),
+            "expected AmbiguousLotMatch, got {err:?}"
+        );
+    }
+
+    /// STRICT + `{2024-01-15}` (date hint narrowing to a single lot)
+    /// resolves unambiguously and books that lot.
+    #[test]
+    fn strict_accepts_partial_spec_that_uniquely_resolves() {
+        let input = "\
+2024-01-01 open Assets:Brokerage \"STRICT\"
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Income:Trading
+
+2024-01-15 * \"Buy\"
+  Assets:Brokerage   10 GOLD {1500.00 USD}
+  Assets:Cash       -15000.00 USD
+
+2024-02-15 * \"Buy more\"
+  Assets:Brokerage   10 GOLD {1600.00 USD}
+  Assets:Cash       -16000.00 USD
+
+2024-03-15 * \"Sell from January lot\"
+  Assets:Brokerage   -5 GOLD {2024-01-15} @ 1700.00 USD
+  Assets:Cash       8500.00 USD
+  Income:Trading
+";
+        let elab = elaborate(input).expect("STRICT + date hint should resolve");
+        let sell_tx = elab
+            .transactions
+            .iter()
+            .find(|t| t.description == "Sell from January lot")
+            .unwrap();
+        let booked = sell_tx
+            .postings
+            .iter()
+            .find(|p| p.account == "Assets:Brokerage")
+            .expect("brokerage posting present");
+        assert_eq!(booked.lot_cost_in("USD"), Some(dec!(1500.00)));
+    }
+
+    /// NONE booking bypasses the booking pass entirely; the posting
+    /// is recorded with cost=None even when other lots exist.
+    #[test]
+    fn none_booking_passes_through_unchanged() {
+        let input = "\
+2024-01-01 open Assets:Brokerage \"NONE\"
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Income:Trading
+
+2024-01-15 * \"Buy\"
+  Assets:Brokerage   10 GOLD {1500.00 USD}
+  Assets:Cash       -15000.00 USD
+
+2024-03-15 * \"Sell with no booking\"
+  Assets:Brokerage   -5 GOLD {} @ 1700.00 USD
+  Assets:Cash       8500.00 USD
+  Income:Trading
+";
+        let elab = elaborate(input).expect("NONE booking accepts the posting");
+        let sell_tx = elab
+            .transactions
+            .iter()
+            .find(|t| t.description == "Sell with no booking")
+            .unwrap();
+        let booked = sell_tx
+            .postings
+            .iter()
+            .find(|p| p.account == "Assets:Brokerage")
+            .expect("brokerage posting present");
+        // Under NONE booking, the user's `{}` is preserved as a
+        // cost-MISSING lot annotation rather than rewritten by the
+        // booking pass. The end result is functionally equivalent to
+        // a bare reduction.
+        assert_eq!(booked.amount_in("GOLD"), Some(dec!(-5)));
+        assert_eq!(
+            booked.lot_cost_in("USD"),
+            None,
+            "NONE should leave cost MISSING"
+        );
+    }
+
+    /// Over-reduction: a `{}` reduction asking for more units than
+    /// the inventory holds.
+    #[test]
+    fn over_reduction_in_booking_errors() {
+        let input = "\
+2024-01-01 open Assets:Brokerage \"FIFO\"
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Income:Trading
+
+2024-01-15 * \"Buy\"
+  Assets:Brokerage   10 GOLD {1500.00 USD}
+  Assets:Cash       -15000.00 USD
+
+2024-03-15 * \"Sell more than we have\"
+  Assets:Brokerage   -25 GOLD {} @ 1700.00 USD
+  Assets:Cash       42500.00 USD
+  Income:Trading
+";
+        let err = elaborate(input).expect_err("over-reduction should error");
+        assert!(
+            format!("{err:?}").contains("OverReductionInBooking"),
+            "expected OverReductionInBooking, got {err:?}"
+        );
+    }
+
+    /// Augmenting posting with `{}` (positive units, MISSING cost)
+    /// is not supported in the first cut.
+    #[test]
+    fn augmenting_posting_with_missing_cost_errors() {
+        let input = "\
+2024-01-01 open Assets:Brokerage \"FIFO\"
+2024-01-01 open Assets:Cash USD
+
+2024-03-15 * \"Buy with empty cost spec\"
+  Assets:Brokerage    5 GOLD {} @ 1700.00 USD
+  Assets:Cash       -8500.00 USD
+";
+        let err = elaborate(input).expect_err("augmenting + MISSING should error");
+        assert!(
+            format!("{err:?}").contains("AugmentingPostingWithMissingCost"),
+            "expected AugmentingPostingWithMissingCost, got {err:?}"
+        );
     }
 }

--- a/crates/doppio/src/grammars/hledger/mod.rs
+++ b/crates/doppio/src/grammars/hledger/mod.rs
@@ -708,6 +708,7 @@ pub fn hledger_defaults() -> crate::resolution::ElaborationConfig {
         },
         assertion_scope: crate::resolution::AssertionScope::Direct,
         lot_validation_mode: crate::resolution::LotValidationMode::Permissive,
+        default_booking_method: crate::resolution::BookingMethod::None,
     }
 }
 

--- a/crates/doppio/src/grammars/ledger/mod.rs
+++ b/crates/doppio/src/grammars/ledger/mod.rs
@@ -297,6 +297,7 @@ pub fn ledger_defaults() -> crate::resolution::ElaborationConfig {
         balance_mode: crate::resolution::BalanceMode::CostBasis,
         assertion_scope: crate::resolution::AssertionScope::Direct,
         lot_validation_mode: crate::resolution::LotValidationMode::Permissive,
+        default_booking_method: crate::resolution::BookingMethod::None,
     }
 }
 

--- a/crates/doppio/src/resolution.rs
+++ b/crates/doppio/src/resolution.rs
@@ -187,6 +187,14 @@ pub struct ElaborationConfig {
     /// the account's running balance for that commodity. See
     /// [`LotValidationMode`].
     pub lot_validation_mode: LotValidationMode,
+    /// Frontend-default booking method, used when an account has no
+    /// explicit `booking_method` of its own. Beancount applies STRICT
+    /// here (matching `option "booking_method" "STRICT"` and the
+    /// implicit default on `open` directives); ledger-cli / hledger
+    /// have no booking concept and use NONE (the booking pass is a
+    /// no-op for those frontends, even when a posting carries a
+    /// cost-MISSING lot annotation like `[date]` only).
+    pub default_booking_method: BookingMethod,
 }
 
 /// Strategy for computing a posting's cash-equivalent during the
@@ -279,6 +287,46 @@ pub enum LotValidationMode {
     Strict,
 }
 
+/// Booking method declared on a Beancount `open` directive — governs
+/// how an ambiguous `{}` (empty cost spec) reduction is resolved
+/// against the account's running inventory.
+///
+/// Booking only fires when the user writes `{}` (or a partial spec
+/// like `{2024-01-15}` that leaves the cost MISSING). A bare
+/// reduction with no `{}` at all is not booked: it is recorded as a
+/// `cost=None` position and the booking method is not consulted
+/// (matching Beancount 3.x — see [`LotValidationMode`] for the
+/// validation orthogonal to this).
+///
+/// The variants mirror Beancount's `Booking` enum (in
+/// `beancount/core/data.py`) modulo casing and naming.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum BookingMethod {
+    /// Reject ambiguous `{}` matches with an error. Default in
+    /// Beancount; the only resolution allowed is when exactly one
+    /// existing lot satisfies the partial spec, or when the reduction
+    /// would empty the account in that commodity.
+    #[default]
+    Strict,
+    /// Like [`Self::Strict`], but if a single lot matches the
+    /// reduction's *size* exactly, that lot wins as if it were
+    /// unambiguous.
+    StrictWithSize,
+    /// No matching at all: the reduction is appended to the inventory
+    /// as a cost=None position even if it would result in a mixed
+    /// inventory.
+    None,
+    /// Collapse all lots in the same commodity into a single
+    /// weighted-average-cost lot before matching.
+    Average,
+    /// First-in first-out: consume oldest lots first.
+    Fifo,
+    /// Last-in first-out: consume most-recent lots first.
+    Lifo,
+    /// Highest-in first-out: consume the most-expensive lot first.
+    Hifo,
+}
+
 /// Per-transaction balance tolerance policy.
 ///
 /// When a transaction's postings sum to a non-zero residual, the
@@ -348,6 +396,11 @@ pub struct AccountProperties {
     /// notes on the directive header and `key: value` sub-items inside
     /// the block. Elaboration denormalises by walking ancestors.
     pub metadata: BTreeMap<String, String>,
+    /// Booking method declared on a Beancount `open` directive
+    /// (e.g. `open Assets:Brokerage AAPL "FIFO"`). `None` when no
+    /// method was specified — the elaborator falls back to the
+    /// active [`ElaborationConfig`]'s default. See [`BookingMethod`].
+    pub booking_method: Option<BookingMethod>,
 }
 
 /// A single entry in the resolved journal, paired with its active context.
@@ -831,6 +884,9 @@ impl TryFrom<ast::Journal> for HIR {
                             }
                             ast::AccountItem::Check(expr) => {
                                 global_context.checks.push(expr);
+                            }
+                            ast::AccountItem::Booking(method) => {
+                                global_context.booking_method = Some(method);
                             }
                             ast::AccountItem::Unknown(key, value) => {
                                 // Sub-items without a value (e.g. a bare


### PR DESCRIPTION
## Summary

- Captures Beancount's `open Account "FIFO"` booking method as a structured `AccountItem::Booking(BookingMethod)` (was previously stashed as a free-form note).
- Adds `ElaborationConfig::default_booking_method` per-frontend fallback. Beancount: `Strict`. ledger/hledger: `None` (booking pass is a no-op there, preserving today's behaviour).
- New `apply_booking()` elaborator pass: for any posting whose lot annotation has `cost = None` (the user wrote `{}` or a partial spec like `{2024-01-15}`), walks the running inventory in the booking method's order (FIFO oldest first, LIFO newest, HIFO highest cost, STRICT errors on ambiguity, NONE skips) and synthesises one or more explicit-cost replacement postings. Multi-lot reductions split into multiple postings.
- Lot dates on augmenting postings are now auto-filled from the transaction date (matches bean-check; required for FIFO/LIFO to distinguish cost-only annotations).
- Phantom-lot validator (#237) updated to use partial-spec matching.

Closes #238.

## Empirical clarification on the issue body

The original issue body framed STRICT booking as "errors on bare reductions." Subsequent investigation (with the docs site at <https://beancount.github.io/docs/how_inventories_work/>) showed that's a third-party-doc claim that doesn't match Beancount 3.x. Bare reductions (no `{}`) take the simple-posting path and aren't booked. Booking only fires on `{}` or partial specs. The issue body was updated; this PR matches that revised framing.

## Known gap (filed as #242)

Cost-basis-aware gain inference for null `Income:Trading` postings is incorrect when `{}` reductions balance via `@price`. The booking pass runs after the transaction-balance check, so cost basis is unknown when the null posting is inferred — it gets filled against `@price`-derived cash rather than the post-booking cost basis. The lot keys on the booked postings are correct; only the gain inference is off. Restructuring to do booking before balance is a separate refactor (#242).

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace` all green
- [x] 11 new tests (8 booking semantics + 3 parser)
- [x] Existing 14-fixture positive parity sweep + 4-fixture negative parity sweep both pass (no regressions in #237 phantom-lot work)
- [ ] CI green