### PR TITLE
feat(parity): per-lot inventory comparator + partial-spec resolution (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,22 @@ surface.
   with the realized gain (cash − sum of matched lot costs) rather
   than zero, matching bean-check. New parity fixture
   `tests/parity/beancount-fifo.beancount` exercises this end-to-end.
+- **Per-lot inventory parity comparator** (#227). The parity-test
+  harness now diffs per-`(account, commodity, cost, date, label)`
+  positions in addition to the existing aggregated-by-commodity
+  balance check. Catches lot-dimension regressions that the previous
+  comparator silently aggregated away (e.g. two augmentations at
+  different cost bases collapsed into one bucket).
+  `dop register --format=json` rows now carry an optional `lot`
+  object with `cost_amount` / `cost_commodity` / `date` / `note`
+  fields when present.
+- **Partial-spec lot resolution for reducing postings.** A reduction
+  like `-30 AAPL {185.40 USD}` (cost specified, date inherited as
+  None) now matches against the concrete dated inventory lot via the
+  same booking pass that handles `{}` — bean-check's strict booking
+  rewrites partial-spec reductions to the full lot key, and doppio
+  now mirrors that. Phantom-lot reductions (cost matches no inventory
+  lot) error with `OverReductionInBooking`. (#227)
 
 ---
 

--- a/crates/doppio-cli/src/main.rs
+++ b/crates/doppio-cli/src/main.rs
@@ -599,6 +599,37 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     .iter()
                                     .map(|(k, v)| (k.as_str(), v.as_str()))
                                     .collect();
+                                // Lot annotation (cost / date / note),
+                                // emitted only when present so the
+                                // common case keeps a stable shape.
+                                // Per-lot parity comparators (#227)
+                                // accumulate across postings using
+                                // (commodity, lot_*) as the key.
+                                let lot_obj = posting.lot.as_ref().map(|l| {
+                                    let mut o = serde_json::Map::new();
+                                    if let Some(cost) = &l.cost
+                                        && let Some((cc, cv)) = cost.by_commodity.iter().next()
+                                    {
+                                        o.insert(
+                                            "cost_amount".to_string(),
+                                            serde_json::json!(cv.to_decimal().to_string()),
+                                        );
+                                        o.insert(
+                                            "cost_commodity".to_string(),
+                                            serde_json::json!(cc),
+                                        );
+                                    }
+                                    if let Some(d) = posting.lot_date_naive() {
+                                        o.insert(
+                                            "date".to_string(),
+                                            serde_json::json!(d.to_string()),
+                                        );
+                                    }
+                                    if let Some(n) = posting.lot_note() {
+                                        o.insert("note".to_string(), serde_json::json!(n));
+                                    }
+                                    serde_json::Value::Object(o)
+                                });
                                 rows.push(serde_json::json!({
                                     "date": date,
                                     "description": txn.description,
@@ -610,6 +641,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     "txn_metadata": txn_metadata,
                                     "posting_tags": posting_tags,
                                     "posting_metadata": posting_metadata,
+                                    "lot": lot_obj,
                                 }));
                             }
                         }

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -1165,8 +1165,42 @@ pub fn elaborate(
                             // null posting fills against the post-
                             // booking residual and gain inference is
                             // correct.
-                            let needs_booking =
-                                proto_lot.as_ref().is_some_and(|l| l.cost.is_none());
+                            //
+                            // Booking also fires for *partial-spec*
+                            // reductions like `-30 AAPL {185.40 USD}`
+                            // (cost specified, date / label missing):
+                            // bean-check's strict booking matches such
+                            // a partial spec against the concrete
+                            // dated inventory lot and rewrites the
+                            // reduction's lot key to the matched lot's
+                            // full key. doppio mirrors this so per-lot
+                            // running state (#237) tracks the
+                            // reduction against the same bucket as the
+                            // augmentation (#227 parity comparator).
+                            // Cost-MISSING reductions trigger
+                            // unconditionally; partial-spec reductions
+                            // only when the inventory has positions in
+                            // the same `(account, commodity)` to draw
+                            // against -- otherwise the
+                            // "create-labeled-short-position" path
+                            // (matching bean-check's no-prior
+                            // behaviour) takes over.
+                            let needs_booking = proto_lot.as_ref().is_some_and(|l| {
+                                if l.cost.is_none() {
+                                    return true;
+                                }
+                                if !value.is_sign_negative() {
+                                    return false;
+                                }
+                                state
+                                    .account_inventories
+                                    .get(&account_name)
+                                    .is_some_and(|inv| {
+                                        inv.positions
+                                            .iter()
+                                            .any(|((c, _), v)| c == &commodity && !v.is_zero())
+                                    })
+                            });
                             if needs_booking {
                                 let booking_method = value_global_account_property(
                                     &account_name,
@@ -1889,10 +1923,20 @@ fn book_missing_cost_inline(
         });
     }
 
-    // Partial cost-spec hints: a posting like `{2024-01-15}` carries
-    // a date with no cost; the booking pass uses the date to narrow
-    // which inventory lots are eligible before applying the method's
+    // Partial cost-spec hints: every Some field on the partial spec
+    // is a constraint; eligible inventory lots must match it. The
+    // remaining None fields are wildcards. `{1700 USD}` filters by
+    // cost only; `{2024-01-15}` filters by date only;
+    // `{1700 USD, 2024-01-15}` requires both. Lots that pass all
+    // constraints become candidates for the booking method's
     // ordering rule.
+    let cost_hint = partial_lot.cost.as_ref().and_then(|amount| {
+        amount
+            .by_commodity
+            .iter()
+            .next()
+            .map(|(c, v)| (v.to_decimal(), c.clone()))
+    });
     let date_hint = partial_lot.date.and_then(|epoch_days| {
         chrono::NaiveDate::from_ymd_opt(1970, 1, 1)
             .and_then(|epoch| epoch.checked_add_signed(chrono::Duration::days(epoch_days as i64)))
@@ -1909,6 +1953,12 @@ fn book_missing_cost_inline(
                     }
                     let lot_key = lot_key_opt.clone()?;
                     if !bal.is_sign_positive() || bal.is_zero() {
+                        return None;
+                    }
+                    if let Some((cv, cc)) = cost_hint.as_ref()
+                        && (lot_key.cost.as_ref() != Some(cv)
+                            || lot_key.cost_commodity.as_ref() != Some(cc))
+                    {
                         return None;
                     }
                     if let Some(d) = date_hint

--- a/scripts/parity_check.py
+++ b/scripts/parity_check.py
@@ -661,10 +661,177 @@ _register_pad_extractors()
 
 
 # ---------------------------------------------------------------------------
+# Per-lot inventory extractors (#227).
+#
+# `LotPosition` is a 6-tuple keyed at full lot granularity:
+# `(account, commodity, cost_amount, cost_commodity, lot_date, lot_label)`.
+# `cost_amount`/`cost_commodity`/`lot_date`/`lot_label` are `None` when
+# the corresponding annotation was absent. The map's value is the
+# Decimal unit count.
+#
+# This complements `beancount_balances`: where that aggregates per
+# (account, commodity), this preserves the lot dimension. A regression
+# that drops the lot date on every posting (or collapses two lots at
+# different costs into one) is invisible to the aggregated comparator
+# but caught here.
+# ---------------------------------------------------------------------------
+
+LotKey = tuple[str, str, "Decimal | None", "str | None", "str | None", "str | None"]
+LotPositions = dict[LotKey, Decimal]
+
+
+def beancount_lot_positions(fixture: Path) -> LotPositions:
+    """Per-lot inventory positions via the Beancount Python API.
+
+    Unlike `beancount_balances` (which aggregates by `(account,
+    commodity)`), this preserves the cost / date / label dimensions
+    so we can validate that doppio's per-lot accounting (#237 + #238)
+    matches bean-check's at full granularity."""
+    from beancount.loader import load_file
+    from beancount.core.realization import realize, iter_children
+
+    entries, errors, _ = load_file(str(fixture))
+    if errors:
+        raise RuntimeError(f"beancount errors loading {fixture}: {errors}")
+    real_root = realize(entries)
+    out: LotPositions = {}
+    for ra in iter_children(real_root):
+        for pos in ra.balance.get_positions():
+            cost = pos.cost
+            cost_amount = (
+                Decimal(str(cost.number))
+                if cost is not None and cost.number is not None
+                else None
+            )
+            cost_commodity = cost.currency if cost is not None else None
+            lot_date = (
+                cost.date.isoformat()
+                if cost is not None and cost.date is not None
+                else None
+            )
+            lot_label = cost.label if cost is not None else None
+            key: LotKey = (
+                ra.account,
+                pos.units.currency,
+                cost_amount,
+                cost_commodity,
+                lot_date,
+                lot_label,
+            )
+            out[key] = out.get(key, Decimal(0)) + Decimal(str(pos.units.number))
+    return {k: v for k, v in out.items() if v != 0}
+
+
+def doppio_lot_positions(fixture: Path, dop_bin: Path) -> LotPositions:
+    """Reconstruct per-lot positions from `dop register --format=json`.
+
+    Each row carries an optional `lot` object with `cost_amount`,
+    `cost_commodity`, `date`, and `note` fields (all optional within
+    the object). Accumulate by full lot key; postings without a lot
+    annotation key into the all-None bucket.
+
+    Skips postings on doppio's synthesised empty-string `""` account
+    -- the rounding-residual bucket has no canonical analogue
+    (bean-check's `realize` doesn't surface a comparable position)."""
+    raw = subprocess.run(
+        [str(dop_bin), "register", "--format=json", str(fixture)],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    payload = json.loads(raw)
+    out: LotPositions = {}
+    for row in payload:
+        if row["account"] == "":
+            continue
+        lot = row.get("lot")
+        cost_amount = (
+            Decimal(lot["cost_amount"])
+            if lot is not None and "cost_amount" in lot
+            else None
+        )
+        cost_commodity = (
+            lot.get("cost_commodity") if lot is not None else None
+        )
+        lot_date = lot.get("date") if lot is not None else None
+        lot_label = lot.get("note") if lot is not None else None
+        key: LotKey = (
+            row["account"],
+            row["commodity"],
+            cost_amount,
+            cost_commodity,
+            lot_date,
+            lot_label,
+        )
+        amount = Decimal(row["amount"])
+        out[key] = out.get(key, Decimal(0)) + amount
+    return {k: v for k, v in out.items() if v != 0}
+
+
+def diff_lot_positions(
+    canonical: LotPositions,
+    doppio: LotPositions,
+) -> str | None:
+    """Return None if equal; otherwise a multi-line human-readable diff
+    listing per-lot mismatches, missing keys, and extra keys."""
+    if canonical == doppio:
+        return None
+    canon_keys = set(canonical.keys())
+    dop_keys = set(doppio.keys())
+    only_canon = canon_keys - dop_keys
+    only_dop = dop_keys - canon_keys
+    common = canon_keys & dop_keys
+    mismatched = [(k, canonical[k], doppio[k]) for k in common if canonical[k] != doppio[k]]
+
+    def render_key(k: LotKey) -> str:
+        acct, comm, cost_amt, cost_curr, date, label = k
+        parts = [acct, comm]
+        if cost_amt is not None:
+            parts.append(f"cost={cost_amt} {cost_curr}")
+        if date is not None:
+            parts.append(f"date={date}")
+        if label is not None:
+            parts.append(f'label="{label}"')
+        return " | ".join(parts)
+
+    lines: list[str] = []
+    if mismatched:
+        lines.append("  per-lot unit-count mismatches:")
+        for k, cv, dv in sorted(mismatched, key=lambda x: render_key(x[0])):
+            lines.append(f"    {render_key(k)}: canonical={cv}  doppio={dv}")
+    if only_canon:
+        lines.append("  only in canonical:")
+        for k in sorted(only_canon, key=render_key):
+            lines.append(f"    {render_key(k)} = {canonical[k]}")
+    if only_dop:
+        lines.append("  only in doppio:")
+        for k in sorted(only_dop, key=render_key):
+            lines.append(f"    {render_key(k)} = {doppio[k]}")
+    return "\n".join(lines)
+
+
+# Map balance-extractor -> per-lot extractor. ledger-cli and hledger
+# don't expose lot-bearing inventory in a structured JSON output that
+# matches doppio's lot keys (lot annotations on those frontends are
+# carried as posting metadata only); only Beancount has a
+# canonical-API surface for per-lot positions.
+LOT_EXTRACTOR: dict[CanonicalFn, Callable[[Path], LotPositions] | None] = {}
+
+
+def _register_lot_extractors() -> None:
+    LOT_EXTRACTOR[beancount_balances] = beancount_lot_positions
+    LOT_EXTRACTOR[hledger_balances] = None
+    LOT_EXTRACTOR[ledger_balances] = None
+
+
+# Registered after CanonicalFn is defined.
+
+
+# ---------------------------------------------------------------------------
 # Test catalog
 # ---------------------------------------------------------------------------
 
 CanonicalFn = Callable[[Path], set[Tuple3]]
+
+_register_lot_extractors()
 
 
 @dataclass
@@ -777,11 +944,25 @@ def run_positive(case: Case, dop_bin: Path) -> bool:
         doppio_pads = doppio_pad_fingerprints(case.fixture, dop_bin)
         pad_diff = diff_pad_fingerprints(canonical_pads, doppio_pads)
 
+    # Phase 4: per-lot inventory positions (#227). Catches drift the
+    # commodity-aggregate balance comparator misses: lot-key mismatches
+    # (cost / date / label), augmentation drift (two lots collapsed into
+    # one), and lot-dimension regressions in general. Only Beancount has
+    # a canonical-API surface that preserves the lot dimension after
+    # realization.
+    lot_diff: str | None = None
+    lot_extractor = LOT_EXTRACTOR.get(case.canonical)
+    if lot_extractor is not None:
+        canonical_lots = lot_extractor(case.fixture)
+        doppio_lots = doppio_lot_positions(case.fixture, dop_bin)
+        lot_diff = diff_lot_positions(canonical_lots, doppio_lots)
+
     if (
         bal_diff is None
         and tags_meta_diff is None
         and prices_diff is None
         and pad_diff is None
+        and lot_diff is None
     ):
         print("OK")
         return True
@@ -798,6 +979,9 @@ def run_positive(case: Case, dop_bin: Path) -> bool:
     if pad_diff is not None:
         print("  pad synthesis:", file=sys.stderr)
         print(pad_diff, file=sys.stderr)
+    if lot_diff is not None:
+        print("  per-lot positions:", file=sys.stderr)
+        print(lot_diff, file=sys.stderr)
     return False
 
 


### PR DESCRIPTION
## Summary

Adds a fourth phase to the parity harness: a per-lot inventory comparator that diffs `(account, commodity, cost, date, label)` positions, complementing the existing aggregated-by-commodity balance check. Surfaced (and fixed) two real elaborator bugs in the process.

### Wire format / CLI

- `dop register --format=json` rows now carry an optional `lot` object (`cost_amount`, `cost_commodity`, `date`, `note`) when the elaborated posting has lot annotations.

### Parity script

- `beancount_lot_positions` walks `realize()` without aggregating, preserving the lot dimension.
- `doppio_lot_positions` reads the JSON register and accumulates by full lot key. Skips doppio's synthesised empty-account `""` rounding-residual posting (no canonical analogue in `realize()`).
- `diff_lot_positions` reports per-lot mismatches with rendered keys.
- New phase 4 in `run_positive`. Only Beancount has a structured per-lot canonical surface; ledger / hledger register `None` and the phase is a no-op for them.

### Elaborator (bugs fixed while validating)

1. **Partial-spec lot resolution.** A reduction like `-30 AAPL {185.40 USD}` (cost specified, date inherited as None) now matches against the concrete dated inventory lot via the same booking pass that handles `{}`. bean-check's strict booking rewrites partial-spec reductions to the full lot key; doppio now mirrors that. Previously, the reduction's lot key landed in a different inventory bucket from the augmentation, leaving phantom positive/negative pairs that the per-lot comparator caught.

2. **Cost filter on the booking match path.** `book_missing_cost_inline`'s eligible-lot filter now respects the cost field on the partial spec: a posting that names a cost no inventory lot carries hits 0 matches and errors as `OverReductionInBooking`. Catches the variant of phantom-lot writes that doppio previously silently absorbed when the user wrote an offsetting cash posting to make the journal balance.

3. **Booking trigger condition.** The trigger now distinguishes:
   - cost-MISSING reductions (always book — picks per method)
   - partial-cost reductions (only book when the inventory has positions in `(account, commodity)` to draw against; otherwise the create-labeled-short-position path takes over, matching bean-check's no-prior behaviour)

## Test plan

- [x] All 15 positive parity fixtures pass with the new comparator (was 14, +`beancount-fifo` from #242).
- [x] All 4 negative parity fixtures pass (phantom-lot still rejected; OverReductionInBooking + bean-check's ReductionError on the same input).
- [x] 324 lib tests + workspace tests green (no regressions in #237 / #238 / #242 work).
- [x] `cargo fmt --check`, `cargo clippy --workspace -- -D warnings` clean.
- [ ] CI green