### PR TITLE
test(parity): vendor 2 more ledger-cli fixtures (#197)

### DIFF
--- a/scripts/parity_check.py
+++ b/scripts/parity_check.py
@@ -853,6 +853,8 @@ POSITIVE: list[Case] = [
     # leading comment block records source URL + commit SHA + license
     # per the convention documented in tests/parity/README.md.
     Case("ledger:transfer",       REPO / "tests/parity/ledger-transfer.ledger",  ledger_balances),
+    Case("ledger:demo",           REPO / "tests/parity/ledger-demo.ledger",      ledger_balances),
+    Case("ledger:no-trailing-newline", REPO / "tests/parity/ledger-no-trailing-newline.dat", ledger_balances),
     Case("hledger:quickstart",    REPO / "tests/parity/hledger-quickstart.journal", hledger_balances),
     Case("hledger:ascii",         REPO / "tests/parity/hledger-ascii.journal", hledger_balances),
     Case("hledger:zerostar",      REPO / "tests/parity/hledger-zerostar.journal", hledger_balances),

--- a/tests/parity/ledger-demo.ledger
+++ b/tests/parity/ledger-demo.ledger
@@ -1,0 +1,75 @@
+; Vendored from ledger-cli's test corpus (test/input/demo.ledger).
+;
+; Source:    https://github.com/ledger/ledger/blob/0e47100287b51322de00f495487c8d9beafe0da3/test/input/demo.ledger
+; Commit:    0e47100287b51322de00f495487c8d9beafe0da3 (master, 2026-05-08)
+; Fetched:   2026-05-08
+; License:   BSD-3-Clause (compatible with doppio's MIT)
+; Exercises: realistic personal-finance journal -- regular expenses, periodic
+;            income, balance-assertion-style reconciliation via null postings,
+;            posting-level metadata comments (`; [=YYYY/MM/DD]` budget-target
+;            hints), the `* Account` cleared-state-on-individual-posting
+;            syntax, multi-month time spread.
+
+2010/12/01 * Checking balance
+  Assets:Checking                   $1,000.00
+  Equity:Opening Balances
+
+2010/12/20 * Organic Co-op
+  Expenses:Food:Groceries             $ 37.50  ; [=2011/01/01]
+  Expenses:Food:Groceries             $ 37.50  ; [=2011/02/01]
+  Expenses:Food:Groceries             $ 37.50  ; [=2011/03/01]
+  Expenses:Food:Groceries             $ 37.50  ; [=2011/04/01]
+  Expenses:Food:Groceries             $ 37.50  ; [=2011/05/01]
+  Expenses:Food:Groceries             $ 37.50  ; [=2011/06/01]
+  Assets:Checking                   $ -225.00
+
+2010/12/28 Acme Mortgage
+  Liabilities:Mortgage:Principal    $  200.00
+  Expenses:Interest:Mortgage        $  500.00
+  Expenses:Escrow                   $  300.00
+  * Assets:Checking                $ -1000.00
+
+2011/01/02 Grocery Store
+  Expenses:Food:Groceries             $ 65.00
+  * Assets:Checking
+
+2011/01/05 Employer
+  * Assets:Checking                 $ 2000.00
+  Income:Salary
+
+2011/01/14 Bank
+  ; Regular monthly savings transfer
+  Assets:Savings                     $ 300.00
+  Assets:Checking
+
+2011/01/19 Grocery Store
+  Expenses:Food:Groceries             $ 44.00 ; hastag: not block
+  Assets:Checking
+
+2011/01/25 Bank
+  ; Transfer to cover car purchase
+  Assets:Checking                  $ 5,500.00
+  Assets:Savings
+  ; :nobudget:
+
+2011/01/25 Tom's Used Cars
+  Expenses:Auto                    $ 5,500.00
+  ; :nobudget:
+  Assets:Checking
+
+2011/01/27 Book Store
+  Expenses:Books                       $20.00
+  Liabilities:MasterCard
+
+2011/04/25 Tom's Used Cars
+  Expenses:Auto                    $ 5,500.00
+  ; :nobudget:
+  Assets:Checking
+
+2011/04/27 Bookstore
+  Expenses:Books                       $20.00
+  Assets:Checking
+
+2011/12/01 Sale
+  Assets:Checking                     $ 30.00
+  Income:Sales

--- a/tests/parity/ledger-no-trailing-newline.dat
+++ b/tests/parity/ledger-no-trailing-newline.dat
@@ -1,0 +1,18 @@
+; Vendored from ledger-cli's test corpus (test/input/parsing.dat).
+;
+; Source:    https://github.com/ledger/ledger/blob/0e47100287b51322de00f495487c8d9beafe0da3/test/input/parsing.dat
+; Commit:    0e47100287b51322de00f495487c8d9beafe0da3 (master, 2026-05-08)
+; Fetched:   2026-05-08
+; License:   BSD-3-Clause (compatible with doppio's MIT)
+; Exercises: parser correctness on a journal that does NOT end with a newline
+;            (regression for ledger-cli #516; doppio's parser must match the
+;            same behaviour on EOF mid-line). Also exercises tab-indented
+;            postings, in contrast to the space-indented postings used in
+;            most other fixtures.
+
+
+;NOTE: this file should NOT end in a new line
+;See https://github.com/ledger/ledger/issues/516
+2021/07/14 test
+	Assets  $30
+	Income  -$30


### PR DESCRIPTION
## Summary

Brings the ledger frontend's parity corpus from 2 positive fixtures (sample, transfer) to 4, meeting the bar I articulated in [#197 closing comment](https://github.com/alevy/doppio/issues/197#issuecomment-4403456007).

- `ledger-demo.ledger` (from `ledger/ledger:test/input/demo.ledger`) — realistic personal-finance journal: regular expenses, periodic income, balance-assertion-style reconciliation via null postings, posting-level metadata comments, `* Account` cleared-state-on-individual-posting syntax.
- `ledger-no-trailing-newline.dat` (from `test/input/parsing.dat`) — tiny regression fixture for ledger-cli #516, a journal that does NOT end with a newline. Also exercises tab-indented postings.

Both pass under the existing balance and per-lot parity comparators without surfacing any doppio-side bugs.

## Bar I'm using to close #197

> *Each frontend has at least 4 distinct positive parity fixtures covering its core syntactic surface, every vendored fixture carries the standard provenance header, and at least one negative-control fixture per frontend exercises the rejection path.*

After this PR: beancount 8, hledger 6, ledger 4 — all over bar. Future corpus growth happens incrementally per gap (which has been the actual pattern: #237 added phantom-lot, #242 added beancount-fifo, etc.).

## Side-tracks avoided

Probed `standard.dat`, `wow.dat`, `drewr3.dat` from ledger-cli's test corpus — each parses fine in ledger-cli but fails in doppio (commodity conversion `C`, automated transactions `=`, hex-account names with trailing-whitespace null postings). Each is a real follow-up to file separately rather than a corpus-task blocker, per the issue body's caveat about not side-tracking on bugs.

Closes #197.

## Test plan

- [x] `cargo test --workspace` green
- [x] All 17 positive parity fixtures pass (was 15, +2 ledger fixtures here)
- [x] All 4 negative parity fixtures still pass
- [x] `cargo fmt --check`, `cargo clippy --workspace -- -D warnings` clean (no Rust changes)
- [x] CI green