### PR TITLE
fix(ledger): tolerate trailing whitespace on posting lines (#247)

### DIFF
--- a/crates/doppio/src/grammars/ledger/ledger.pest
+++ b/crates/doppio/src/grammars/ledger/ledger.pest
@@ -101,8 +101,14 @@ empty_indented_line = _{ indent+ ~ NEWLINE }
 //
 // The !NEWLINE lookahead prevents a truly empty indented line from being
 // matched as a posting with an empty account name.
+//
+// `ws*` immediately before `(NEWLINE | EOI)` tolerates trailing whitespace
+// after the last meaningful token on the line. Real-world journals
+// (e.g. ledger-cli's own `test/input/standard.dat`) pad account names to
+// a fixed column with trailing spaces, including on null postings; the
+// whitespace before EOL is parser-meaningless. See #247.
 posting = ${
-    indent+ ~ !NEWLINE ~ (state ~ ws+)? ~ posting_account ~ (amount_logic)? ~ (ws* ~ note)? ~ (NEWLINE | EOI) ~
+    indent+ ~ !NEWLINE ~ (state ~ ws+)? ~ posting_account ~ (amount_logic)? ~ (ws* ~ note)? ~ ws* ~ (NEWLINE | EOI) ~
     posting_note*
 }
 

--- a/crates/doppio/src/grammars/ledger/mod.rs
+++ b/crates/doppio/src/grammars/ledger/mod.rs
@@ -1931,4 +1931,33 @@ account Assets:Savings
         let input = "define assetChecker(amt) = (amt > -100.00 or (tag(\"TaxImplication\") !~ /^\\s*$/ and tag(\"Entity\") !~ /^\\s*$/))\n";
         parse_ledger(input).expect("issue #89 input should parse");
     }
+
+    #[test]
+    fn test_issue_247_null_posting_with_trailing_whitespace() {
+        // Regression test for issue #247: real-world journals (e.g.
+        // ledger-cli's own test/input/standard.dat) pad account names
+        // to a fixed column with trailing spaces, even on null
+        // postings. The parser must tolerate trailing whitespace
+        // between the last meaningful token on a posting line and the
+        // newline. (Built via concat! so trailing whitespace is
+        // explicit and survives editor trimming.)
+        let input = concat!(
+            "2002/01/01 * Test\n",
+            "    Assets:Checking         $100.00\n",
+            "    Equity:Opening              \n",
+        );
+        parse_ledger(input).expect("trailing whitespace on null posting should parse");
+    }
+
+    #[test]
+    fn test_issue_247_amount_posting_with_trailing_whitespace() {
+        // Same regression but with an explicit amount: trailing
+        // whitespace after the amount must also parse.
+        let input = concat!(
+            "2002/01/01 * Test\n",
+            "    Assets:Checking         $100.00      \n",
+            "    Equity:Opening         $-100.00\n",
+        );
+        parse_ledger(input).expect("trailing whitespace on amount posting should parse");
+    }
 }


### PR DESCRIPTION
## Summary

Real-world ledger journals pad account names to a fixed column with trailing spaces, including on null postings (where the only thing on the line is the account). The pest `posting` rule required the line to end with `NEWLINE | EOI` immediately after the last meaningful token; this PR adds `ws*` right before `(NEWLINE | EOI)` to absorb that padding.

Pure whitespace-tolerance change — every parse that previously succeeded continues to succeed unchanged.

Closes #247.

## Note on vendoring standard.dat

The user's preference was to also vendor `standard.dat` in this PR if the parser fix unblocked it. It doesn't — `standard.dat` surfaces a *second* gap (multi-commodity transactions without explicit cost, which ledger-cli accepts as implicit-cost buys but doppio rejects as `TransactionDoesNotBalance`). Filing that as a separate follow-up; once it lands `standard.dat` becomes a useful corpus addition.

## Test plan

- [x] 2 new regression tests (`test_issue_247_*_with_trailing_whitespace`), both built via `concat!` so the trailing whitespace is explicit in source.
- [x] 326 lib tests + workspace tests green.
- [x] `cargo fmt --check`, `cargo clippy --workspace -- -D warnings` clean.
- [x] CI green