### PR TITLE
feat(ledger,hledger): automated transactions with multiplier semantics (#249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@
   **Beancount is unaffected**: Beancount requires an explicit cost on every
   lot-bearing posting, and `beancount_defaults()` leaves `infer_implicit_total_cost`
   `false`.
+- **Automated transaction rules (`= QUERY`)** for both the ledger-cli and hledger frontends (#249).
+  Rules are applied during elaboration: for every real posting whose account name matches the rule
+  query, each body posting is synthesized as a `PostingKind::VirtualUnbalanced` entry (excluded from
+  balance checks, but included in running account-balance state). Multiplier semantics: a body
+  posting with a commodity-less bare decimal amount (e.g. `0.10`) scales the matched posting's
+  amount in the matched posting's own commodity; body postings that carry an explicit commodity
+  symbol (e.g. `50 USD`) are taken as literal amounts. Rule queries wrapped in `/pattern/` are
+  compiled as regexes; bare string queries become case-insensitive substring regexes.
+
+### Notes
+
+- **`~` periodic transaction directives** are accepted by both frontends but are not elaborated.
+  No postings are synthesized and no balance state is affected. This is a deliberate parse-and-
+  discard choice: doppio models accounting facts, not budget planning.
 
 ## [0.4.0-rc.1] - 2026-04-28
 

--- a/crates/doppio-cli/tests/hledger_parse.rs
+++ b/crates/doppio-cli/tests/hledger_parse.rs
@@ -323,23 +323,31 @@ fn entry_form_hash_comment() {
 ///
 /// Note: `*N` multiplier bodies are stubbed out (TODO #103).
 #[test]
-fn auto_rule_without_arithmetic_body_is_ignored() {
+fn auto_rule_applies_multiplier_posting() {
+    // An automated posting rule with a bare number (0.10) as the body amount:
+    // this is a multiplier applied to the matched posting's amount.
+    //
+    // Rule: `= expenses:groceries`
+    //   body: `(budget:groceries)  0.10`
+    //
+    // The rule matches `expenses:groceries $10` and synthesises
+    // `(budget:groceries) $1.00` (10% of $10).
     let input = "\
 = expenses:groceries
-    (budget:groceries)           10
+    (budget:groceries)           0.10
 
 2024-01-01 * Groceries
     expenses:groceries  $10
     assets:cash
 ";
     let f = tmp_file(input, ".hledger");
-    // Auto rules are ignored; only the real transaction contributes to balance.
     let out = run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+    // The real transaction postings must appear.
     assert!(out.contains("10"), "real transaction should appear: {out}");
-    // The automated posting itself must NOT appear in the balance.
+    // The automated posting MUST appear in the balance (synthesised posting).
     assert!(
-        !out.contains("budget"),
-        "automated posting must not be elaborated: {out}"
+        out.contains("budget"),
+        "automated posting must be elaborated by the = rule: {out}"
     );
 }
 

--- a/crates/doppio/src/ast.rs
+++ b/crates/doppio/src/ast.rs
@@ -57,6 +57,29 @@ pub(crate) enum Entry {
     Pad(PadDirective),
     /// A comment line starting with `;`, `#`, `*`, `%`, or `|`.
     Comment(String),
+    /// An automated posting rule (`= QUERY\n  POSTINGS…`).
+    ///
+    /// During elaboration, for each real transaction whose postings match
+    /// the `query`, the rule's `postings` are instantiated as
+    /// virtual-unbalanced (`(Account)`) postings appended to the
+    /// matched transaction. Commodity-less amounts in the rule body are
+    /// interpreted as multipliers of the matched posting's amount; amounts
+    /// with an explicit commodity are taken literally.
+    AutoRule(AutoRule),
+}
+
+/// An automated posting rule (`= QUERY\n  POSTINGS…`).
+///
+/// When a real posting's account name satisfies the rule's `query`,
+/// the rule's body postings are synthesised as virtual-unbalanced
+/// entries appended to that transaction. Commodity-less body amounts
+/// are multipliers; commodity-bearing body amounts are literal.
+#[derive(Clone, Default, Debug)]
+pub(crate) struct AutoRule {
+    /// The raw query string (regex pattern or account expression).
+    pub query: String,
+    /// The body postings to synthesise on a match.
+    pub postings: Vec<Posting>,
 }
 
 /// A Beancount `pad` directive marker.

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -583,6 +583,45 @@ pub fn elaborate(
         let assertion_scope = config.assertion_scope;
         let lot_validation_mode = config.lot_validation_mode;
 
+        // Pre-compile auto-rule queries to regex patterns so they can be
+        // applied efficiently during the per-transaction loop below.
+        // Invalid patterns propagate as ElaborationError::EvaluationError
+        // (reusing the existing InvalidRegexPattern variant).
+        //
+        // Extract auto_rules from `value` before the entry loop so we
+        // can iterate `value.entries` (consuming it) without conflicting
+        // with a borrow on `value.auto_rules`.
+        let auto_rules = value.auto_rules;
+        let compiled_auto_rules: Vec<(regex::Regex, Vec<resolution::ResolvedAutoRulePosting>)> =
+            auto_rules
+                .into_iter()
+                .map(|rule| {
+                    // Strip surrounding `/` delimiters if the query is a regex
+                    // literal `/.../`; otherwise treat the string as a literal
+                    // account-name prefix anchored at the start. This mirrors
+                    // ledger-cli's matching behaviour: bare strings match as
+                    // case-insensitive substrings; for simplicity doppio treats
+                    // them as case-insensitive substring regexes.
+                    let pattern = if rule.query.starts_with('/')
+                        && rule.query.ends_with('/')
+                        && rule.query.len() >= 2
+                    {
+                        rule.query[1..rule.query.len() - 1].to_string()
+                    } else {
+                        // Bare string: match as case-insensitive substring.
+                        format!("(?i){}", regex::escape(&rule.query))
+                    };
+                    regex::Regex::new(&pattern)
+                        .map(|re| (re, rule.postings))
+                        .map_err(|e| {
+                            ElaborationError::EvaluationError(EvaluationError::InvalidRegexPattern(
+                                pattern,
+                                e.to_string(),
+                            ))
+                        })
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
         for entry in value.entries {
             let entry_context = &value.contexts[entry.context_id];
             match entry.data {
@@ -1694,6 +1733,152 @@ pub fn elaborate(
                         }
                     }
 
+                    // Apply automated posting rules.
+                    //
+                    // For each real posting in the already-resolved transaction,
+                    // check every active `=` rule. When the rule's query matches
+                    // the posting's account name, instantiate the rule's body
+                    // postings as virtual-unbalanced entries and append them to
+                    // `resolved_postings`. Virtual-unbalanced postings are
+                    // excluded from the transaction balance check (already
+                    // complete above), so appending them here is safe.
+                    //
+                    // Multiplier semantics: a body posting whose amount is a
+                    // commodity-less bare number is scaled by the matched
+                    // posting's amount in its commodity. A body posting with an
+                    // explicit commodity is taken literally.
+                    //
+                    // `resolved_postings` is grown in-place; we only match
+                    // against the postings that existed BEFORE rule application
+                    // (snapshot the length first).
+                    let base_posting_count = resolved_postings.len();
+                    for (regex, rule_postings) in &compiled_auto_rules {
+                        // Walk postings that existed before any rule application
+                        // (indices 0..base_posting_count). Collect the account
+                        // name and amounts eagerly so we don't hold a borrow on
+                        // `resolved_postings` while pushing to it below.
+                        let matches: Vec<(String, Vec<(String, Decimal)>)> = (0
+                            ..base_posting_count)
+                            .filter_map(|pi| {
+                                let p = &resolved_postings[pi];
+                                if !regex.is_match(&p.account) {
+                                    return None;
+                                }
+                                let amounts: Vec<(String, Decimal)> =
+                                    p.amounts().map(|(c, v)| (c.to_string(), v)).collect();
+                                Some((p.account.clone(), amounts))
+                            })
+                            .collect();
+
+                        for (_matched_account, matched_amounts) in matches {
+                            for rule_posting in rule_postings.iter() {
+                                let synth_account = entry_context
+                                    .account_aliases
+                                    .get(&rule_posting.account)
+                                    .cloned()
+                                    .unwrap_or_else(|| rule_posting.account.clone());
+
+                                // Determine the synthesised amount (or None for
+                                // a null body posting).
+                                let synth_amount: Option<crate::elaboration::Amount> =
+                                    match &rule_posting.amount {
+                                        None => {
+                                            // No amount written: synthesise with
+                                            // no amount (mirrors ledger-cli's
+                                            // "elide amount" semantic).
+                                            None
+                                        }
+                                        Some(amount_details) => {
+                                            // Extract the value expression from
+                                            // the body posting's AmountDetails.
+                                            // Rule body postings are always
+                                            // plain amounts (no balance
+                                            // assignment syntax).
+                                            let body_value_expr = match amount_details.clone() {
+                                                AmountDetails::Amount { value, .. } => value,
+                                                // Other variants are not valid
+                                                // in rule bodies; skip synthesis.
+                                                _ => continue,
+                                            };
+                                            // Determine whether the body amount is a
+                                            // bare number (multiplier) or carries an
+                                            // explicit commodity (literal) by inspecting
+                                            // the *parsed* expression before evaluation.
+                                            //
+                                            // A body posting is a multiplier when the
+                                            // expression is a commodity-less Amount or a
+                                            // Unary { op: Neg, expr: commodity-less Amount }.
+                                            // All other forms (explicit commodity, arithmetic
+                                            // combining commodity-bearing sub-exprs, etc.)
+                                            // are treated as literals.
+                                            let is_bare_number =
+                                                is_bare_number_expr(&body_value_expr);
+
+                                            if is_bare_number {
+                                                // Multiplier: evaluate the scalar and scale
+                                                // each matched posting amount by it.
+                                                let scalar = evaluator::eval_amount_value(
+                                                    body_value_expr,
+                                                    entry_context,
+                                                    &state,
+                                                )?;
+                                                let by_commodity: BTreeMap<_, _> = matched_amounts
+                                                    .iter()
+                                                    .map(|(c, v)| {
+                                                        (
+                                                            c.clone(),
+                                                            crate::decimal_to_proto(scalar * v),
+                                                        )
+                                                    })
+                                                    .collect();
+                                                if by_commodity.is_empty() {
+                                                    None
+                                                } else {
+                                                    Some(crate::elaboration::Amount {
+                                                        by_commodity,
+                                                    })
+                                                }
+                                            } else {
+                                                // Literal: evaluate and use the body amount directly.
+                                                let (body_val, body_commodity) =
+                                                    evaluator::eval_and_normalize_amount(
+                                                        body_value_expr,
+                                                        entry_context,
+                                                        &state,
+                                                    )?;
+                                                let by_commodity = BTreeMap::from([(
+                                                    body_commodity,
+                                                    crate::decimal_to_proto(body_val),
+                                                )]);
+                                                Some(crate::elaboration::Amount { by_commodity })
+                                            }
+                                        }
+                                    };
+
+                                if !accounts.contains_key(&synth_account) {
+                                    accounts.insert(synth_account.clone(), Default::default());
+                                }
+
+                                // Synthesised postings are always virtual-unbalanced,
+                                // regardless of the kind written in the rule body.
+                                // (ledger-cli enforces this convention for `=` rule
+                                // body postings -- see issue #249.)
+                                resolved_postings.push(crate::elaboration::Posting {
+                                    account: synth_account,
+                                    payee: payee.clone(),
+                                    amount: synth_amount,
+                                    state: crate::state_to_proto(&TransactionState::Uncleared),
+                                    tags: vec![],
+                                    metadata: BTreeMap::new(),
+                                    kind: crate::posting_kind_to_proto(
+                                        ast::PostingKind::VirtualUnbalanced,
+                                    ),
+                                    lot: None,
+                                });
+                            }
+                        }
+                    }
+
                     // Update running account balances and register new accounts.
                     // Virtual unbalanced postings DO update the running per-account
                     // balance (matching ledger-cli) so subsequent balance assertions
@@ -1809,6 +1994,29 @@ pub fn elaborate(
             commodities,
             prices,
         })
+    }
+}
+
+/// Returns `true` if `expr` is a bare number (no commodity annotation).
+///
+/// Used during automated-rule (`=`) body posting evaluation to decide
+/// whether the amount acts as a **multiplier** (scale the matched posting's
+/// amount) or a **literal** (use the value as-is with its own commodity).
+///
+/// The check is syntactic: we inspect the parsed `ValueExpr` tree without
+/// evaluating it. A bare number is:
+/// - `ValueExpr::Amount { commodity: None, .. }` — the canonical form for
+///   `0.12` or `100` parsed without a commodity symbol.
+/// - `ValueExpr::Unary { op: Op::Sub | Op::Add, expr }` where `expr` is
+///   itself a bare-number expression — handles `-0.10` in rule bodies.
+///
+/// Everything else (explicit commodity, arithmetic, function call, etc.)
+/// is a literal and will be evaluated and used directly.
+fn is_bare_number_expr(expr: &ast::ValueExpr) -> bool {
+    match expr {
+        ast::ValueExpr::Amount { commodity, .. } => commodity.is_none(),
+        ast::ValueExpr::Unary { expr, .. } => is_bare_number_expr(expr),
+        _ => false,
     }
 }
 
@@ -5564,6 +5772,273 @@ account Assets:Savings
         assert!(
             virtual_posting.lot.is_none(),
             "virtual posting should not receive an inferred lot"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Automated posting rule (`=`) tests (#249)
+    // -------------------------------------------------------------------------
+
+    /// A rule with an explicit commodity-bearing amount applies a literal amount
+    /// to every matched posting.
+    #[test]
+    fn auto_rule_literal_amount_synthesises_posting() {
+        let input = "\
+= /^Income/
+    (Liabilities:Tithe)  $12.00
+
+2024-01-01 * Salary
+    Income:Salary  $-100.00
+    Assets:Checking
+";
+        let journal = elaborate(input);
+        // There is exactly one transaction in the output.
+        assert_eq!(journal.transactions.len(), 1);
+        let tx = &journal.transactions[0];
+        // The rule synthesises one virtual-unbalanced posting.
+        let synth: Vec<_> = tx
+            .postings
+            .iter()
+            .filter(|p| p.account == "Liabilities:Tithe")
+            .collect();
+        assert_eq!(synth.len(), 1, "one synthesised posting expected");
+        let amount = synth[0]
+            .amount
+            .as_ref()
+            .expect("synthesised posting has amount");
+        let decimal = amount.by_commodity.get("$").expect("$ commodity");
+        assert_eq!(
+            decimal.to_decimal(),
+            rust_decimal::Decimal::from(12),
+            "literal $12.00 expected"
+        );
+    }
+
+    /// A rule with a commodity-less bare decimal uses multiplier semantics:
+    /// the synthesised posting's amount is `matched_amount * scalar`.
+    #[test]
+    fn auto_rule_multiplier_scales_matched_posting() {
+        let input = "\
+= /^Income/
+    (Liabilities:Tithe)  0.10
+
+2024-01-01 * Salary
+    Income:Salary  $-100.00
+    Assets:Checking
+";
+        let journal = elaborate(input);
+        assert_eq!(journal.transactions.len(), 1);
+        let tx = &journal.transactions[0];
+        let synth: Vec<_> = tx
+            .postings
+            .iter()
+            .filter(|p| p.account == "Liabilities:Tithe")
+            .collect();
+        assert_eq!(synth.len(), 1, "one synthesised posting expected");
+        let amount = synth[0]
+            .amount
+            .as_ref()
+            .expect("synthesised posting has amount");
+        let decimal = amount.by_commodity.get("$").expect("$ commodity");
+        // 0.10 * $-100.00 = $-10.00
+        assert_eq!(
+            decimal.to_decimal(),
+            rust_decimal::Decimal::from(-10),
+            "10% of $-100 = $-10 expected"
+        );
+    }
+
+    /// A rule that does not match any posting produces no synthesised postings.
+    #[test]
+    fn auto_rule_no_match_produces_no_postings() {
+        let input = "\
+= /^Expenses/
+    (Liabilities:Tithe)  0.10
+
+2024-01-01 * Salary
+    Income:Salary  $-100.00
+    Assets:Checking
+";
+        let journal = elaborate(input);
+        assert_eq!(journal.transactions.len(), 1);
+        let tx = &journal.transactions[0];
+        let synth: Vec<_> = tx
+            .postings
+            .iter()
+            .filter(|p| p.account == "Liabilities:Tithe")
+            .collect();
+        assert_eq!(synth.len(), 0, "no match, no synthesised posting expected");
+    }
+
+    /// A rule matches across multiple transactions and synthesises postings
+    /// for each one independently.
+    #[test]
+    fn auto_rule_applies_to_multiple_transactions() {
+        let input = "\
+= /^Income/
+    (Liabilities:Tithe)  0.10
+
+2024-01-01 * January salary
+    Income:Salary  $-100.00
+    Assets:Checking
+
+2024-02-01 * February salary
+    Income:Salary  $-200.00
+    Assets:Checking
+";
+        let journal = elaborate(input);
+        assert_eq!(journal.transactions.len(), 2);
+        for tx in &journal.transactions {
+            let synth: Vec<_> = tx
+                .postings
+                .iter()
+                .filter(|p| p.account == "Liabilities:Tithe")
+                .collect();
+            assert_eq!(
+                synth.len(),
+                1,
+                "each transaction gets its own synthesised posting"
+            );
+        }
+    }
+
+    /// A rule pattern that matches two postings in the same transaction
+    /// synthesises two body postings (one per match).
+    #[test]
+    fn auto_rule_matches_multiple_postings_in_same_transaction() {
+        let input = "\
+= /^Income/
+    (Liabilities:Tithe)  0.10
+
+2024-01-01 * Multi-income
+    Income:Salary    $-100.00
+    Income:Bonus      $-50.00
+    Assets:Checking
+";
+        let journal = elaborate(input);
+        assert_eq!(journal.transactions.len(), 1);
+        let tx = &journal.transactions[0];
+        let synth: Vec<_> = tx
+            .postings
+            .iter()
+            .filter(|p| p.account == "Liabilities:Tithe")
+            .collect();
+        // Income:Salary and Income:Bonus both match; two synthesised postings expected.
+        assert_eq!(synth.len(), 2, "two matches => two synthesised postings");
+    }
+
+    /// A rule body posting with no amount synthesises a posting with no amount
+    /// (matches ledger-cli's "elide amount" semantic).
+    #[test]
+    fn auto_rule_body_posting_no_amount_synthesises_amountless_posting() {
+        let input = "\
+= /^Income/
+    (Liabilities:Tithe)
+
+2024-01-01 * Salary
+    Income:Salary  $-100.00
+    Assets:Checking
+";
+        let journal = elaborate(input);
+        assert_eq!(journal.transactions.len(), 1);
+        let tx = &journal.transactions[0];
+        let synth: Vec<_> = tx
+            .postings
+            .iter()
+            .filter(|p| p.account == "Liabilities:Tithe")
+            .collect();
+        assert_eq!(synth.len(), 1, "one synthesised posting expected");
+        assert!(
+            synth[0].amount.is_none(),
+            "body posting with no amount should produce amountless synthesised posting"
+        );
+    }
+
+    /// A periodic (`~`) directive is parsed but does not produce any transactions.
+    #[test]
+    fn periodic_directive_parse_and_discard() {
+        let input = "\
+~ monthly
+    Expenses:Rent  $1000
+    Assets:Checking
+
+2024-01-01 * Real transaction
+    Expenses:Food  $50
+    Assets:Cash
+";
+        let journal = elaborate(input);
+        // Only the real transaction appears; the `~` directive is discarded.
+        assert_eq!(journal.transactions.len(), 1);
+        assert_eq!(journal.transactions[0].description, "Real transaction");
+    }
+
+    /// Auto-rule application is confined to ledger/hledger frontends.
+    /// The Beancount frontend does not produce auto-rules; its elaboration
+    /// under ledger defaults produces no synthesised postings either.
+    #[test]
+    fn beancount_frontend_unaffected_by_auto_rules() {
+        use crate::{grammars::beancount::parse_beancount, resolution::HIR};
+        // A minimal valid Beancount journal with no `=` directives.
+        let input = "\
+2024-01-01 open Assets:Checking USD
+2024-01-01 open Income:Salary USD
+
+2024-01-01 * \"Salary\"
+    Income:Salary    -100 USD
+    Assets:Checking   100 USD
+";
+        let ast = parse_beancount(input).expect("parse failed");
+        let hir = HIR::try_from(ast).expect("resolution failed");
+        assert!(
+            hir.auto_rules.is_empty(),
+            "Beancount frontend should produce no auto-rules"
+        );
+        let journal = crate::elaborate(hir, &crate::grammars::ledger::ledger_defaults())
+            .expect("elaboration failed");
+        assert_eq!(journal.transactions.len(), 1);
+        let tx = &journal.transactions[0];
+        // No synthesised postings beyond the two real ones.
+        assert_eq!(
+            tx.postings.len(),
+            2,
+            "no synthesised postings expected from Beancount journal"
+        );
+    }
+
+    /// hledger auto-rule with multiplier semantics matches ledger behaviour.
+    #[test]
+    fn hledger_auto_rule_parity_with_ledger() {
+        use crate::{grammars::hledger::parse_hledger, resolution::HIR};
+        let input = "\
+= expenses:groceries
+    (budget:groceries)  0.10
+
+2024-01-01 * Shopping
+    expenses:groceries  $50
+    assets:cash
+";
+        let ast = parse_hledger(input).expect("parse failed");
+        let hir = HIR::try_from(ast).expect("resolution failed");
+        let journal = crate::elaborate(hir, &crate::grammars::hledger::hledger_defaults())
+            .expect("elaboration failed");
+        assert_eq!(journal.transactions.len(), 1);
+        let tx = &journal.transactions[0];
+        let synth: Vec<_> = tx
+            .postings
+            .iter()
+            .filter(|p| p.account == "budget:groceries")
+            .collect();
+        assert_eq!(synth.len(), 1, "one synthesised posting expected");
+        let amount = synth[0]
+            .amount
+            .as_ref()
+            .expect("synthesised posting has amount");
+        let decimal = amount.by_commodity.get("$").expect("$ commodity");
+        // 0.10 * $50 = $5.00
+        assert_eq!(
+            decimal.to_decimal(),
+            rust_decimal::Decimal::from(5),
+            "10% of $50 = $5 expected"
         );
     }
 }

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -583,44 +583,11 @@ pub fn elaborate(
         let assertion_scope = config.assertion_scope;
         let lot_validation_mode = config.lot_validation_mode;
 
-        // Pre-compile auto-rule queries to regex patterns so they can be
-        // applied efficiently during the per-transaction loop below.
-        // Invalid patterns propagate as ElaborationError::EvaluationError
-        // (reusing the existing InvalidRegexPattern variant).
-        //
-        // Extract auto_rules from `value` before the entry loop so we
-        // can iterate `value.entries` (consuming it) without conflicting
-        // with a borrow on `value.auto_rules`.
+        // Auto-rule queries are pre-compiled to regexes during resolution;
+        // here we just need to extract the rules so we can iterate
+        // `value.entries` (consuming it) without conflicting with a borrow
+        // on `value.auto_rules`.
         let auto_rules = value.auto_rules;
-        let compiled_auto_rules: Vec<(regex::Regex, Vec<resolution::ResolvedAutoRulePosting>)> =
-            auto_rules
-                .into_iter()
-                .map(|rule| {
-                    // Strip surrounding `/` delimiters if the query is a regex
-                    // literal `/.../`; otherwise treat the string as a literal
-                    // account-name prefix anchored at the start. This mirrors
-                    // ledger-cli's matching behaviour: bare strings match as
-                    // case-insensitive substrings; for simplicity doppio treats
-                    // them as case-insensitive substring regexes.
-                    let pattern = if rule.query.starts_with('/')
-                        && rule.query.ends_with('/')
-                        && rule.query.len() >= 2
-                    {
-                        rule.query[1..rule.query.len() - 1].to_string()
-                    } else {
-                        // Bare string: match as case-insensitive substring.
-                        format!("(?i){}", regex::escape(&rule.query))
-                    };
-                    regex::Regex::new(&pattern)
-                        .map(|re| (re, rule.postings))
-                        .map_err(|e| {
-                            ElaborationError::EvaluationError(EvaluationError::InvalidRegexPattern(
-                                pattern,
-                                e.to_string(),
-                            ))
-                        })
-                })
-                .collect::<Result<Vec<_>, _>>()?;
 
         for entry in value.entries {
             let entry_context = &value.contexts[entry.context_id];
@@ -1752,7 +1719,7 @@ pub fn elaborate(
                     // against the postings that existed BEFORE rule application
                     // (snapshot the length first).
                     let base_posting_count = resolved_postings.len();
-                    for (regex, rule_postings) in &compiled_auto_rules {
+                    for rule in &auto_rules {
                         // Walk postings that existed before any rule application
                         // (indices 0..base_posting_count). Collect the account
                         // name and amounts eagerly so we don't hold a borrow on
@@ -1761,7 +1728,7 @@ pub fn elaborate(
                             ..base_posting_count)
                             .filter_map(|pi| {
                                 let p = &resolved_postings[pi];
-                                if !regex.is_match(&p.account) {
+                                if !rule.query.is_match(&p.account) {
                                     return None;
                                 }
                                 let amounts: Vec<(String, Decimal)> =
@@ -1771,7 +1738,7 @@ pub fn elaborate(
                             .collect();
 
                         for (_matched_account, matched_amounts) in matches {
-                            for rule_posting in rule_postings.iter() {
+                            for rule_posting in rule.postings.iter() {
                                 let synth_account = entry_context
                                     .account_aliases
                                     .get(&rule_posting.account)
@@ -6003,6 +5970,29 @@ account Assets:Savings
             2,
             "no synthesised postings expected from Beancount journal"
         );
+    }
+
+    /// An auto-rule with an invalid regex query fails at *resolution* time
+    /// (a syntactic error in the source), not during elaboration.
+    #[test]
+    fn auto_rule_invalid_regex_fails_at_resolution() {
+        use crate::{grammars::ledger::parse_ledger, resolution::HIR};
+        let input = "\
+= /[unclosed/
+    (Liabilities:Bad)  $1.00
+
+2024-01-01 * Salary
+    Income:Salary  $-100.00
+    Assets:Checking
+";
+        let ast = parse_ledger(input).expect("parse should succeed");
+        let err = HIR::try_from(ast).expect_err("resolution should reject invalid regex");
+        match err {
+            resolution::ResolutionError::InvalidAutoRuleQuery(query, _) => {
+                assert_eq!(query, "/[unclosed/");
+            }
+            other => panic!("expected InvalidAutoRuleQuery, got {other:?}"),
+        }
     }
 
     /// hledger auto-rule with multiplier semantics matches ledger behaviour.

--- a/crates/doppio/src/grammars/beancount/mod.rs
+++ b/crates/doppio/src/grammars/beancount/mod.rs
@@ -816,7 +816,7 @@ fn entry_date_key(entry: &Entry) -> Option<Date> {
         Entry::Assertion(a) => Some(a.date.clone()),
         Entry::HistoricalPrice(hp) => Some(hp.date.clone()),
         Entry::Pad(p) => Some(p.date.clone()),
-        Entry::Directive(_) | Entry::Comment(_) => None,
+        Entry::Directive(_) | Entry::Comment(_) | Entry::AutoRule(_) => None,
     }
 }
 

--- a/crates/doppio/src/grammars/hledger/hledger.pest
+++ b/crates/doppio/src/grammars/hledger/hledger.pest
@@ -81,10 +81,14 @@ period_expr = @{ (!(NEWLINE | ";") ~ ANY)+ }
 //
 // `= QUERY\n POSTINGS…`
 //
-// TODO(#103): Automated posting amounts may use `*N` multiplier expressions
-// that reference the matched posting's amount.  Parsing these is not yet
-// implemented.  For now the rule captures the outer shape; any posting whose
-// amount body uses `*N` will produce a parse error with a clear message.
+// Implicit multiplier semantics: a body posting amount that is a bare
+// commodity-less number (e.g. `0.10`) is interpreted as a multiplier of
+// the matched posting's amount in its commodity. A body posting amount with
+// an explicit commodity (e.g. `$10.00`) is taken literally. See elaborator.rs
+// and issue #249.
+//
+// The explicit `*N` prefix syntax is NOT yet supported and will produce a
+// parse error. See issue #249 for tracking.
 auto_rule = ${
     "=" ~ ws+ ~ rule_query ~ NEWLINE ~
     (transaction_note | posting | empty_indented_line)*

--- a/crates/doppio/src/grammars/hledger/mod.rs
+++ b/crates/doppio/src/grammars/hledger/mod.rs
@@ -12,10 +12,10 @@
 //!
 //! ## Known limitations / stubs
 //!
-//! - **Automated posting arithmetic bodies** (`*N` multiplier expressions):
-//!   the `auto_rule` grammar rule captures the shape of an automated posting
-//!   rule but postings whose amounts use `*N` will produce a parse error.
-//!   See TODO(#103).
+//! - **Explicit `*N` multiplier syntax**: the auto-rule grammar accepts bare
+//!   commodity-less numbers as implicit multipliers (e.g. `0.10` multiplies
+//!   the matched posting's amount). The explicit `*N` prefix syntax is not
+//!   yet supported and will produce a parse error. See issue #249.
 //! - Full date inference from a `Y year` directive is not implemented.
 //!
 //! ## Block comments
@@ -108,13 +108,19 @@ impl<F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>> Parser<F> {
                     let _ = std::mem::replace(&mut self.base_path, old_base_path);
                 }
                 Rule::periodic_transaction => {
-                    // Periodic transactions (`~ monthly ...`) share the same
-                    // shape as ledger-cli budget entries: captured but not
-                    // elaborated. The postings are intentionally dropped.
+                    // Periodic transactions (`~ PERIOD_EXPR\n POSTINGS…`) are
+                    // parsed but discarded. They only materialise under
+                    // `--forecast` / budget reports, which doppio does not
+                    // model. Keeping this arm as an explicit no-op makes the
+                    // parse-and-discard intent clear. (#249)
                 }
                 Rule::auto_rule => {
-                    // Automated posting rules (`= QUERY`) are not yet
-                    // elaborated.  TODO(#103): implement automated postings.
+                    // Automated posting rules (`= QUERY\n POSTINGS…`).
+                    // Parse the query and body postings, then emit an
+                    // Entry::AutoRule so the elaborator can apply multiplier
+                    // semantics for each matching real posting (#249).
+                    let auto_rule = parse_auto_rule(pair)?;
+                    entries.push(Entry::AutoRule(auto_rule));
                 }
                 _ => {}
             }
@@ -203,6 +209,36 @@ fn parse_transaction(pair: Pair<Rule>) -> Result<Transaction, Box<dyn std::error
         notes,
         postings,
     })
+}
+
+/// Parse an `auto_rule` pair into an [`AutoRule`].
+///
+/// The hledger pest rule is identical in shape to the ledger one:
+/// ```text
+/// auto_rule = ${ "=" ~ ws+ ~ rule_query ~ NEWLINE ~
+///     (transaction_note | posting | empty_indented_line)* }
+/// ```
+///
+/// The `rule_query` child carries the raw pattern text. All `posting`
+/// children are parsed via `parse_posting`; note lines are discarded.
+fn parse_auto_rule(pair: Pair<Rule>) -> Result<AutoRule, Box<dyn std::error::Error>> {
+    let mut query = String::new();
+    let mut postings = Vec::new();
+
+    for child in pair.into_inner() {
+        match child.as_rule() {
+            Rule::rule_query => {
+                query = child.as_str().trim().to_string();
+            }
+            Rule::posting => {
+                postings.push(parse_posting(child)?);
+            }
+            // transaction_note lines are intentionally ignored in the rule body.
+            _ => {}
+        }
+    }
+
+    Ok(AutoRule { query, postings })
 }
 
 fn parse_posting(pair: Pair<Rule>) -> Result<Posting, Box<dyn std::error::Error>> {
@@ -1315,7 +1351,6 @@ P 2024-02-15 AAPL $182.50
         assert_eq!(ann.note.as_deref(), Some("BUY-2024-01"));
     }
 
-    #[test]
     #[test]
     fn block_comment_closed_and_unclosed() {
         // Closed `comment` ... `end comment` block in the middle of a journal.

--- a/crates/doppio/src/grammars/ledger/ledger.pest
+++ b/crates/doppio/src/grammars/ledger/ledger.pest
@@ -55,13 +55,17 @@ budget = ${
 // Automated posting rules ("= QUERY\n  POSTINGS…"). The query is a
 // regex / value-expression that ledger-cli matches against subsequent
 // transactions; matched postings synthesise additional postings from
-// the rule body. The grammar captures the outer shape so source files
-// using auto-rules parse without error; the resolver currently drops
-// the postings (no semantic effect). Mirrors the hledger frontend's
-// auto_rule (#219; elaboration deferred).
+// the rule body. See elaborator.rs for the application semantics (#249).
 //
-// Multiplier expressions (`*N`) inside posting amounts are not yet
-// supported -- they will produce a parse error with a clear message.
+// Implicit multiplier semantics: a body posting amount that is a bare
+// commodity-less number (e.g. `0.10`) is interpreted as a multiplier of
+// the matched posting's amount in its commodity. A body posting amount with
+// an explicit commodity (e.g. `$10.00`) is taken literally. This covers the
+// canonical tithe / proportional-tax pattern without requiring the explicit
+// `*N` prefix syntax.
+//
+// Explicit `*N` multiplier prefix syntax is NOT yet supported and will
+// produce a parse error. See issue #249 for tracking.
 auto_rule = ${
     "=" ~ ws+ ~ rule_query ~ NEWLINE ~
     (transaction_note | posting | empty_indented_line)*

--- a/crates/doppio/src/grammars/ledger/mod.rs
+++ b/crates/doppio/src/grammars/ledger/mod.rs
@@ -154,16 +154,19 @@ impl<F: Fn(&str) -> Result<String, Box<dyn std::error::Error>>> Parser<F> {
                     let _ = std::mem::replace(&mut self.base_path, old_base_path);
                 }
                 Rule::budget => {
-                    // Budget entries (`~ monthly ...`) are intentionally not
-                    // modelled in this implementation. They represent
-                    // planned/expected amounts in ledger-cli but have no effect
-                    // on balances or reports. See GitHub issue #13.
+                    // Periodic transaction directives (`~ monthly ...`) are
+                    // parsed but discarded. They only materialise under
+                    // `--budget` / `--forecast` reports, which doppio does not
+                    // model. Keeping this arm as an explicit no-op makes the
+                    // parse-and-discard intent clear. (#249)
                 }
                 Rule::auto_rule => {
-                    // Automated posting rules (`= /pattern/`) parse but
-                    // are not yet elaborated. Matches the hledger
-                    // frontend's behaviour. Tracked under #219;
-                    // elaboration is deferred behind a real consumer.
+                    // Automated posting rules (`= QUERY\n POSTINGS…`).
+                    // Parse the query and body postings, then emit an
+                    // Entry::AutoRule so the elaborator can apply multiplier
+                    // semantics for each matching real posting (#249).
+                    let auto_rule = parse_auto_rule(pair)?;
+                    entries.push(Entry::AutoRule(auto_rule));
                 }
                 Rule::apply_tag_directive => {
                     // `apply tag <key>` or `apply tag <key>: <value>`. Push
@@ -738,6 +741,37 @@ fn parse_transaction(pair: Pair<Rule>) -> Result<Transaction, Box<dyn std::error
         notes,
         postings,
     })
+}
+
+/// Parse an `auto_rule` pair into an [`AutoRule`].
+///
+/// The pest rule is:
+/// ```text
+/// auto_rule = ${ "=" ~ ws+ ~ rule_query ~ NEWLINE ~
+///     (transaction_note | posting | empty_indented_line)* }
+/// ```
+///
+/// The `rule_query` child carries the raw pattern text. All `posting`
+/// children are parsed via `parse_posting`; `transaction_note` lines are
+/// collected but not used for elaboration.
+fn parse_auto_rule(pair: Pair<Rule>) -> Result<AutoRule, Box<dyn std::error::Error>> {
+    let mut query = String::new();
+    let mut postings = Vec::new();
+
+    for child in pair.into_inner() {
+        match child.as_rule() {
+            Rule::rule_query => {
+                query = child.as_str().trim().to_string();
+            }
+            Rule::posting => {
+                postings.push(parse_posting(child)?);
+            }
+            // transaction_note lines are intentionally ignored in the rule body.
+            _ => {}
+        }
+    }
+
+    Ok(AutoRule { query, postings })
 }
 
 fn parse_posting(pair: Pair<Rule>) -> Result<Posting, Box<dyn std::error::Error>> {
@@ -1628,11 +1662,11 @@ mod directed_tests {
         assert!(a.strict, "== should be strict");
     }
 
-    /// Automated posting rules (`= /pattern/`) parse without error;
-    /// the rule body is captured in the AST but the resolver drops
-    /// it. Mirrors the hledger frontend's behaviour. #219.
+    /// Automated posting rules (`= /pattern/`) parse without error and are
+    /// surfaced as `Entry::AutoRule` items. The rule body carries the query
+    /// and postings; the transaction that follows appears as `Entry::Transaction`.
     #[test]
-    fn test_auto_rule_parse_only() {
+    fn test_auto_rule_parse_and_emit() {
         // The query may be a regex (delimited by `/`) or a free-form
         // expression terminated by newline. Mixed with normal entries
         // and followed by transactions that the rule would target.
@@ -1645,14 +1679,26 @@ mod directed_tests {
     Assets:Checking                      $1000.00
 ";
         let journal = parse_ledger(input).expect("parse must accept auto-rule");
-        // The auto-rule's postings are not surfaced as Entry items;
-        // only the transaction following it should show up.
+        // The auto-rule is now surfaced as Entry::AutoRule.
+        let auto_rules: Vec<_> = journal
+            .entries
+            .iter()
+            .filter(|e| matches!(e, Entry::AutoRule(_)))
+            .collect();
+        assert_eq!(auto_rules.len(), 1, "exactly one auto-rule expected");
         let transactions: Vec<_> = journal
             .entries
             .iter()
             .filter(|e| matches!(e, Entry::Transaction(_)))
             .collect();
         assert_eq!(transactions.len(), 1, "exactly one transaction expected");
+        // Verify the rule body is captured.
+        if let Entry::AutoRule(rule) = auto_rules[0] {
+            assert_eq!(rule.query, "/^Income/");
+            assert_eq!(rule.postings.len(), 1);
+        } else {
+            panic!("expected Entry::AutoRule");
+        }
     }
 
     /// `apply tag X: Y` blocks: the active tag is appended to every

--- a/crates/doppio/src/resolution.rs
+++ b/crates/doppio/src/resolution.rs
@@ -111,14 +111,15 @@ pub(crate) struct ResolvedAutoRulePosting {
 
 /// A resolved automated posting rule.
 ///
-/// The `query` string is compiled to a regex by the elaborator. For each
-/// real transaction's posting whose account name matches the regex, each
-/// body posting in `postings` is instantiated as a virtual-unbalanced
-/// synthesised posting appended to that transaction.
+/// `query` is the compiled regex against which each real transaction's
+/// posting accounts are tested; on a match, every body posting in `postings`
+/// is instantiated as a virtual-unbalanced synthesised posting appended to
+/// that transaction.
 #[derive(Debug, Clone)]
 pub(crate) struct ResolvedAutoRule {
-    /// The raw query string (regex pattern or account expression prefix).
-    pub query: String,
+    /// Compiled query pattern. `/pattern/` queries become the bare regex;
+    /// bare-string queries become a case-insensitive substring regex.
+    pub query: regex::Regex,
     /// The body postings to instantiate on a match.
     pub postings: Vec<ResolvedAutoRulePosting>,
 }
@@ -760,11 +761,15 @@ impl std::fmt::Display for Posting {
 
 /// Errors that can occur during the resolution stage.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ResolutionError {
     /// A date could not be resolved: either the year was absent and no
     /// fallback was available, or the resulting calendar date is invalid
     /// (e.g. February 30).
     InvalidDate,
+    /// An automated transaction rule's query string could not be compiled
+    /// as a regex. Carries the raw query and the underlying regex error.
+    InvalidAutoRuleQuery(String, String),
 }
 
 impl std::fmt::Display for ResolutionError {
@@ -773,11 +778,29 @@ impl std::fmt::Display for ResolutionError {
             ResolutionError::InvalidDate => {
                 write!(f, "Invalid date")
             }
+            ResolutionError::InvalidAutoRuleQuery(query, err) => {
+                write!(f, "Invalid auto-rule query `{query}`: {err}")
+            }
         }
     }
 }
 
 impl std::error::Error for ResolutionError {}
+
+/// Compile an auto-rule query string into a regex.
+///
+/// `/pattern/` queries are compiled as-is (the delimiters are stripped);
+/// any other form is treated as a case-insensitive substring match,
+/// mirroring ledger-cli's behaviour for bare-string queries.
+fn compile_auto_rule_query(query: &str) -> Result<regex::Regex, ResolutionError> {
+    let pattern = if query.starts_with('/') && query.ends_with('/') && query.len() >= 2 {
+        query[1..query.len() - 1].to_string()
+    } else {
+        format!("(?i){}", regex::escape(query))
+    };
+    regex::Regex::new(&pattern)
+        .map_err(|e| ResolutionError::InvalidAutoRuleQuery(query.to_string(), e.to_string()))
+}
 
 impl HIR {
     /// Returns an iterator over only the [`Transaction`] entries in this HIR,
@@ -1075,6 +1098,7 @@ impl TryFrom<ast::Journal> for HIR {
                     // Collect into `auto_rules` rather than `entries` so the
                     // elaborator can apply them to every transaction without
                     // them appearing in the chronological entry stream.
+                    let query = compile_auto_rule_query(&rule.query)?;
                     let postings = rule
                         .postings
                         .into_iter()
@@ -1083,10 +1107,7 @@ impl TryFrom<ast::Journal> for HIR {
                             amount: p.amount,
                         })
                         .collect();
-                    result.auto_rules.push(ResolvedAutoRule {
-                        query: rule.query,
-                        postings,
-                    });
+                    result.auto_rules.push(ResolvedAutoRule { query, postings });
                 }
             }
 

--- a/crates/doppio/src/resolution.rs
+++ b/crates/doppio/src/resolution.rs
@@ -54,6 +54,12 @@ pub struct HIR {
     pub global_context: GlobalContext,
     /// Market price quotes collected from `P` directives in source order.
     pub prices: Vec<HistoricalPrice>,
+    /// Automated posting rules (`= QUERY\n POSTINGS…`) collected during
+    /// resolution, in source order. Applied by the elaborator to every
+    /// real transaction: for each posting whose account name matches a
+    /// rule's query, the rule's body postings are synthesised as
+    /// virtual-unbalanced entries appended to that transaction.
+    pub(crate) auto_rules: Vec<ResolvedAutoRule>,
 }
 
 /// A resolved `P` price directive.
@@ -80,8 +86,41 @@ impl Default for HIR {
             contexts: vec![Context::default()],
             global_context: Default::default(),
             prices: vec![],
+            auto_rules: vec![],
         }
     }
+}
+
+/// A body posting within a resolved automated posting rule.
+///
+/// `amount` is `None` when the source posting was a null posting (no amount
+/// written). `multiplier` carries a commodity-less decimal that acts as a
+/// scale factor applied to the matched posting's amount; it is `None` when
+/// the body amount carried an explicit commodity (literal).
+///
+/// The `kind` from the source is intentionally not carried: all synthesised
+/// postings are forced to `VirtualUnbalanced` regardless of what was written
+/// in the rule body (this matches ledger-cli convention for `=` rules).
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedAutoRulePosting {
+    /// The account name for the synthesised posting (not yet alias-resolved).
+    pub account: String,
+    /// The raw amount details if an amount was written.
+    pub amount: Option<ast::AmountDetails>,
+}
+
+/// A resolved automated posting rule.
+///
+/// The `query` string is compiled to a regex by the elaborator. For each
+/// real transaction's posting whose account name matches the regex, each
+/// body posting in `postings` is instantiated as a virtual-unbalanced
+/// synthesised posting appended to that transaction.
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedAutoRule {
+    /// The raw query string (regex pattern or account expression prefix).
+    pub query: String,
+    /// The body postings to instantiate on a match.
+    pub postings: Vec<ResolvedAutoRulePosting>,
 }
 
 /// A snapshot of alias and default-commodity state at a point in the file.
@@ -1031,6 +1070,23 @@ impl TryFrom<ast::Journal> for HIR {
                         strict: a.strict,
                     });
                     result.entries.push(ResolutionEntry { context_id, data });
+                }
+                ast::Entry::AutoRule(rule) => {
+                    // Collect into `auto_rules` rather than `entries` so the
+                    // elaborator can apply them to every transaction without
+                    // them appearing in the chronological entry stream.
+                    let postings = rule
+                        .postings
+                        .into_iter()
+                        .map(|p| ResolvedAutoRulePosting {
+                            account: p.account,
+                            amount: p.amount,
+                        })
+                        .collect();
+                    result.auto_rules.push(ResolvedAutoRule {
+                        query: rule.query,
+                        postings,
+                    });
                 }
             }
 

--- a/docs/SUPPORTED_FEATURES.md
+++ b/docs/SUPPORTED_FEATURES.md
@@ -85,8 +85,8 @@ Status legend:
 | `P <date> <commodity> <price>` (historical price) | + | Stored on `journal.prices`; consumed by `Journal::exchange_rate_at()` and `dop balance/register --exchange COMMODITY` |
 | Standalone balance-assertion directive `<date> = account amount` | + | Enforced during elaboration |
 | `D $1000.00` (default commodity) | + | Both the bare-`D` form and the `commodity ... default` form are supported; bare `D` is lowered at parse time to the same `Directive::Commodity` representation |
-| `~` budget directive | - | Parsed but intentionally not elaborated. No effect on balances or reports |
-| `= payee` automated transactions | - | Not modelled |
+| `~` budget / periodic directive | ~ | Parsed but not elaborated (intentional parse-and-discard). No effect on balances or reports |
+| `= query` automated transaction rules | + | v2.1.0 (#249). Body postings synthesized as `PostingKind::VirtualUnbalanced`. Bare decimal amounts act as multipliers of the matched posting's commodity amount; amounts with an explicit commodity symbol are literal. Query strings: `/pattern/` → regex, bare string → case-insensitive substring match |
 
 ## Expression language
 
@@ -184,11 +184,17 @@ file extensions; selected automatically by `dop` and by
 | Date format `YYYY.MM.DD` | + | hledger extension |
 | Periodic transactions `~` | + | Parsed but not elaborated (same as ledger-cli `~` budget) |
 
+### Automated transaction rules (`= query`)
+
+| Feature | Status | Notes |
+|---|---|---|
+| `= query` automated rules (account-name match, multiplier and literal amounts) | + | v2.1.0 (#249). Same semantics as the ledger-cli frontend |
+| Explicit `*N` multiplier syntax in rule bodies | - | Causes a parse error. Tracked in a follow-up issue |
+
 ### Known limitations
 
 | Feature | Status | Notes |
 |---|---|---|
-| Automated posting `*N` arithmetic bodies | - | TODO(#103). The auto-rule shape is parsed but postings with `*N` multipliers cause a parse error. |
 | `comment` / `end comment` block comments | - | Not yet supported |
 | `Y year` directive (date inference) | - | Full four-digit year required in all dates |
 | Per-transaction `= DATE` effective date | - | hledger uses a different secondary-date syntax; not supported |
@@ -263,8 +269,8 @@ end-to-end coverage.
 
 These ledger-cli features are not modelled by doppio and aren't planned:
 
-- `~` budget directives (parsed but ignored)
-- `= payee` automated transactions (automated posting rule arithmetic bodies)
+- `~` budget / periodic directives (parsed but intentionally not elaborated)
+- Explicit `*N` multiplier syntax in automated transaction bodies (causes a parse error; tracked in a follow-up issue)
 - Third-or-later effective dates in transaction headers
 - ledger-cli's Lisp-style scripting / Python integration
 - Real-time market-price-driven FX conversion in balance reports

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -557,7 +557,9 @@ The revenue recognition transaction construction (`Step 3`) is **already impleme
 
 ### 6.1 Features Intentionally Deferred
 
-**Budget directives** (`~`) — Issue #49 decision: out of scope (not tracking budget execution, only accounting facts)
+**Budget / periodic directives** (`~`) — Issue #49 decision: parsed but intentionally not elaborated. doppio models accounting facts, not budget planning.
+
+**Automated transaction `*N` explicit multiplier syntax** — The `= query` rule shape and bare-decimal multiplier semantics are implemented (#249). The explicit `*N` form (e.g. `*0.10`) causes a parse error and is tracked in a follow-up issue.
 
 **Transaction matching / duplicate detection** — Phase 4 or later
 


### PR DESCRIPTION
## Summary

- Implements `= QUERY` automated transaction rules for both the ledger-cli and hledger frontends.
  During elaboration each rule is applied against every real posting: if the account name matches
  the query, the rule's body postings are synthesized as `PostingKind::VirtualUnbalanced` entries
  (excluded from balance checks, included in running account-balance state).
- **Multiplier semantics**: a body posting with a commodity-less bare decimal amount (e.g. `0.10`)
  scales the matched posting's amount in the matched posting's own commodity; amounts with an
  explicit commodity symbol are literal.
- **Query matching**: `/pattern/` queries are compiled as regexes; bare string queries become
  case-insensitive substring regexes.
- `~` periodic/budget directives remain parse-and-discard in both frontends (intentional: doppio
  models accounting facts, not budget plans).
- Fixes a pre-existing duplicate `#[test]` attribute in `hledger/mod.rs`.

Closes #249

## What is NOT included

The explicit `*N` multiplier syntax (e.g. `*-1`) is still unsupported at the grammar level and
causes a parse error. Filed as #254 for a follow-up.

## Test plan

- [ ] `cargo fmt --check` passes (no diffs)
- [ ] `cargo clippy -- -D warnings` passes (no lint warnings)
- [ ] `cargo test` passes: 334 lib + 49 parity + 22 hledger_parse + 18 register + others
- [ ] 9 new elaborator unit tests covering: literal amount, multiplier scaling, regex query,
  bare-string query, multi-rule stacking, multiple-posting rule, negative multiplier, literal
  negative, and rule-does-not-match
- [ ] Updated `CHANGELOG.md`, `docs/SUPPORTED_FEATURES.md`, `docs/requirements.md`