### PR TITLE
feat(ledger,hledger): explicit *N multiplier syntax + vendor drewr3.dat parity fixture (#254, #257)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 ### Added
 
+- **Explicit `*N` multiplier syntax in automated-rule bodies** (#254): both the
+  ledger-cli and hledger frontends now accept `*N` (e.g. `*-1`, `* 0.5`,
+  `*0.12`) as a posting amount inside an `= QUERY` auto-rule body. The `*N`
+  form is lowered to the same bare-number multiplier representation as a plain
+  bare decimal — no new semantic path in the elaborator. `*-1` negates the
+  matched posting's amount; `*0.10` takes 10%, etc.
+
+### Test infrastructure
+
+- **Vendor `tests/parity/ledger-drewr3.dat`** (refs #257, refs #197): the
+  ledger-cli upstream `test/input/drewr3.dat` fixture is vendored with a
+  provenance comment block (source URL, commit SHA, license, exercises). It is
+  NOT yet wired into the positive parity harness: `drewr3.dat` exposed a
+  gap in how `dop balance --flat` reports the balance of intermediate accounts
+  that carry both direct postings and child-account postings (ledger-cli
+  aggregates the subtree; doppio reports only the direct balance). The fixture
+  is tracked in the repo so the gap is reproducible; the harness entry will be
+  added once the gap is resolved.
+
 - **Implicit cost-basis inference for ledger-cli and hledger** (#251): a
   two-real-posting multi-commodity transaction where neither posting carries an
   explicit `@`/`@@` price or `{cost}` lot annotation is now accepted by the

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -6031,4 +6031,173 @@ account Assets:Savings
             "10% of $50 = $5 expected"
         );
     }
+
+    // -------------------------------------------------------------------------
+    // Explicit `*N` multiplier syntax tests (#254)
+    // -------------------------------------------------------------------------
+
+    /// The explicit `*N` prefix form in a ledger auto-rule body is parsed
+    /// and lowers to the same bare-number multiplier as a plain bare decimal.
+    /// `*0.10` against `$-100.00` should produce `$-10.00` (10% tithe).
+    #[test]
+    fn ledger_star_n_multiplier_equals_bare_decimal() {
+        let input = "\
+= /^Income/
+    (Liabilities:Tithe)  *0.10
+
+2024-01-01 * Salary
+    Income:Salary  $-100.00
+    Assets:Checking
+";
+        let journal = elaborate(input);
+        assert_eq!(journal.transactions.len(), 1);
+        let tx = &journal.transactions[0];
+        let synth: Vec<_> = tx
+            .postings
+            .iter()
+            .filter(|p| p.account == "Liabilities:Tithe")
+            .collect();
+        assert_eq!(synth.len(), 1, "one synthesised posting expected");
+        let amount = synth[0]
+            .amount
+            .as_ref()
+            .expect("synthesised posting has amount");
+        let decimal = amount.by_commodity.get("$").expect("$ commodity");
+        // *0.10 * $-100.00 = $-10.00 (same as bare 0.10)
+        assert_eq!(
+            decimal.to_decimal(),
+            rust_decimal::Decimal::from(-10),
+            "*0.10 of $-100 should yield $-10"
+        );
+    }
+
+    /// `*-1` negates the matched posting's amount — the canonical mirror-entry
+    /// pattern used to reflect income into a budget equity account.
+    #[test]
+    fn ledger_star_negative_one_negates_matched_amount() {
+        let input = "\
+= /^Income/
+    Equity:Budget  *-1
+
+2024-01-01 * Salary
+    Income:Salary  $-100.00
+    Assets:Checking
+";
+        let journal = elaborate(input);
+        assert_eq!(journal.transactions.len(), 1);
+        let tx = &journal.transactions[0];
+        let synth: Vec<_> = tx
+            .postings
+            .iter()
+            .filter(|p| p.account == "Equity:Budget")
+            .collect();
+        assert_eq!(synth.len(), 1, "one synthesised posting expected");
+        let amount = synth[0]
+            .amount
+            .as_ref()
+            .expect("synthesised posting has amount");
+        let decimal = amount.by_commodity.get("$").expect("$ commodity");
+        // *-1 * $-100.00 = $100.00 (sign flip)
+        assert_eq!(
+            decimal.to_decimal(),
+            rust_decimal::Decimal::from(100),
+            "*-1 of $-100 should yield $100"
+        );
+    }
+
+    /// `* 0.5` with whitespace between `*` and the number is accepted.
+    #[test]
+    fn ledger_star_n_with_whitespace_is_accepted() {
+        let input = "\
+= /^Income/
+    (Split:Half)  * 0.5
+
+2024-01-01 * Salary
+    Income:Salary  $-200.00
+    Assets:Checking
+";
+        let journal = elaborate(input);
+        let tx = &journal.transactions[0];
+        let synth: Vec<_> = tx
+            .postings
+            .iter()
+            .filter(|p| p.account == "Split:Half")
+            .collect();
+        assert_eq!(synth.len(), 1);
+        let amount = synth[0].amount.as_ref().expect("has amount");
+        let decimal = amount.by_commodity.get("$").expect("$ commodity");
+        // * 0.5 * $-200.00 = $-100.00
+        assert_eq!(
+            decimal.to_decimal(),
+            rust_decimal::Decimal::from(-100),
+            "* 0.5 of $-200 should yield $-100"
+        );
+    }
+
+    /// hledger frontend: `*N` explicit multiplier is accepted and produces the
+    /// same result as the bare decimal form.
+    #[test]
+    fn hledger_star_n_multiplier_equals_bare_decimal() {
+        use crate::{grammars::hledger::parse_hledger, resolution::HIR};
+        let input = "\
+= expenses:groceries
+    (budget:groceries)  *0.10
+
+2024-01-01 * Shopping
+    expenses:groceries  $50
+    assets:cash
+";
+        let ast = parse_hledger(input).expect("parse failed");
+        let hir = HIR::try_from(ast).expect("resolution failed");
+        let journal = crate::elaborate(hir, &crate::grammars::hledger::hledger_defaults())
+            .expect("elaboration failed");
+        let tx = &journal.transactions[0];
+        let synth: Vec<_> = tx
+            .postings
+            .iter()
+            .filter(|p| p.account == "budget:groceries")
+            .collect();
+        assert_eq!(synth.len(), 1, "one synthesised posting expected");
+        let amount = synth[0].amount.as_ref().expect("has amount");
+        let decimal = amount.by_commodity.get("$").expect("$ commodity");
+        // *0.10 * $50 = $5.00
+        assert_eq!(
+            decimal.to_decimal(),
+            rust_decimal::Decimal::from(5),
+            "*0.10 of $50 should yield $5"
+        );
+    }
+
+    /// hledger frontend: `*-1` (negative multiplier) negates the matched amount.
+    #[test]
+    fn hledger_star_negative_one_negates_matched_amount() {
+        use crate::{grammars::hledger::parse_hledger, resolution::HIR};
+        let input = "\
+= expenses:groceries
+    (budget:groceries)  *-1
+
+2024-01-01 * Shopping
+    expenses:groceries  $50
+    assets:cash
+";
+        let ast = parse_hledger(input).expect("parse failed");
+        let hir = HIR::try_from(ast).expect("resolution failed");
+        let journal = crate::elaborate(hir, &crate::grammars::hledger::hledger_defaults())
+            .expect("elaboration failed");
+        let tx = &journal.transactions[0];
+        let synth: Vec<_> = tx
+            .postings
+            .iter()
+            .filter(|p| p.account == "budget:groceries")
+            .collect();
+        assert_eq!(synth.len(), 1, "one synthesised posting expected");
+        let amount = synth[0].amount.as_ref().expect("has amount");
+        let decimal = amount.by_commodity.get("$").expect("$ commodity");
+        // *-1 * $50 = $-50
+        assert_eq!(
+            decimal.to_decimal(),
+            rust_decimal::Decimal::from(-50),
+            "*-1 of $50 should yield $-50"
+        );
+    }
 }

--- a/crates/doppio/src/grammars/hledger/hledger.pest
+++ b/crates/doppio/src/grammars/hledger/hledger.pest
@@ -15,13 +15,11 @@
 //   - `account` directives may have a type comment on the header line
 //   - `commodity` directive accepts a commodity-format string, not just
 //     a bare commodity name
-//   - Automated posting rule bodies may reference `*N` multipliers;
-//     parsing of the multiplier expression is STUBBED out (see TODO below)
+//   - Automated posting rule bodies accept both bare decimal multipliers
+//     (e.g. `0.10`) and explicit `*N` prefix multipliers (e.g. `*-1`,
+//     `* 0.5`); see `auto_multiplier` rule below (#254)
 //
 // NOT YET SUPPORTED (stubbed / ignored):
-//   - Automated posting arithmetic bodies (`= query\n    account  *1.1`):
-//     the auto_rule rule captures the shape but the posting amounts inside
-//     automated rules that use `*N` will fail to parse.  See TODO(#103).
 //   - Full hledger date inference from a preceding `Y year` directive.
 //   - Directive-attached tags (metadata on the same line as a directive).
 // ============================================================
@@ -81,14 +79,13 @@ period_expr = @{ (!(NEWLINE | ";") ~ ANY)+ }
 //
 // `= QUERY\n POSTINGS…`
 //
-// Implicit multiplier semantics: a body posting amount that is a bare
-// commodity-less number (e.g. `0.10`) is interpreted as a multiplier of
-// the matched posting's amount in its commodity. A body posting amount with
-// an explicit commodity (e.g. `$10.00`) is taken literally. See elaborator.rs
-// and issue #249.
-//
-// The explicit `*N` prefix syntax is NOT yet supported and will produce a
-// parse error. See issue #249 for tracking.
+// Multiplier semantics: a body posting amount that is a bare commodity-less
+// number (e.g. `0.10`) is interpreted as a multiplier of the matched
+// posting's amount in its commodity. The explicit `*N` prefix form
+// (e.g. `*-1`, `* 0.5`) is also accepted and lowers to the same bare-number
+// multiplier representation — no new semantic path is required in the
+// elaborator. Body postings with an explicit commodity symbol (e.g. `$10.00`)
+// are taken as literal amounts. See `auto_multiplier` below and #254.
 auto_rule = ${
     "=" ~ ws+ ~ rule_query ~ NEWLINE ~
     (transaction_note | posting | empty_indented_line)*
@@ -128,12 +125,25 @@ virtual_account_inner = @{ (!("  " | ";" | "\t" | "=" | NEWLINE | ")" | "]") ~ A
 // Two or more spaces (or a tab) separate the account from the amount —
 // identical to the ledger-cli convention so that account names containing a
 // single space are parsed correctly.
+//
+// `auto_multiplier` is tried first so that the `*` prefix in automated-rule
+// body postings (e.g. `*-1`, `* 0.5`) is consumed before `value_logic`'s
+// expression parser. Outside auto-rule bodies this is harmless: regular
+// postings don't start with `*`.
 amount_logic = ${
     (ws{2,} | "\t") ~ (
-        value_logic
+        auto_multiplier
+        | value_logic
         | assertion
     )
 }
+
+// Explicit `*N` multiplier form used in automated-rule body postings.
+// Matches `*<number>` or `* <number>` with an optional leading sign on the
+// number (e.g. `*-1`, `*0.5`, `* 0.12`). Lowers to the same bare-number
+// `ValueExpr::Amount` as a plain bare decimal — the elaborator's
+// `is_bare_number_expr` treats both forms identically (#254).
+auto_multiplier = ${ "*" ~ ws* ~ (prefix_op ~ ws*)? ~ number }
 
 // A value expression, optionally followed by lot annotations and/or lot pricing
 // and/or a balance assertion check. Mirrors the ledger-cli grammar.

--- a/crates/doppio/src/grammars/hledger/mod.rs
+++ b/crates/doppio/src/grammars/hledger/mod.rs
@@ -12,10 +12,6 @@
 //!
 //! ## Known limitations / stubs
 //!
-//! - **Explicit `*N` multiplier syntax**: the auto-rule grammar accepts bare
-//!   commodity-less numbers as implicit multipliers (e.g. `0.10` multiplies
-//!   the matched posting's amount). The explicit `*N` prefix syntax is not
-//!   yet supported and will produce a parse error. See issue #249.
 //! - Full date inference from a `Y year` directive is not implemented.
 //!
 //! ## Block comments
@@ -307,6 +303,38 @@ fn parse_posting(pair: Pair<Rule>) -> Result<Posting, Box<dyn std::error::Error>
 fn parse_amount_logic(pair: Pair<Rule>) -> Result<AmountDetails, Box<dyn std::error::Error>> {
     let p = pair.into_inner().next().unwrap();
     match p.as_rule() {
+        Rule::auto_multiplier => {
+            // `*N` multiplier form: `"*" ws* (prefix_op ws*)? number`.
+            // Lower to a bare-number ValueExpr identical to what a plain
+            // bare decimal produces, so the elaborator's `is_bare_number_expr`
+            // check identifies it as a multiplier without any new semantic path
+            // (#254).
+            let mut inner = p.into_inner();
+            // Optional prefix_op, then number.
+            let first = inner
+                .next()
+                .expect("auto_multiplier must have at least a number");
+            let (sign, number_str) = if first.as_rule() == Rule::prefix_op {
+                let s = first.as_str();
+                let n = inner
+                    .next()
+                    .expect("auto_multiplier prefix_op must be followed by number");
+                (s, n.as_str())
+            } else {
+                ("", first.as_str())
+            };
+            let cleaned = format!("{sign}{}", number_str.replace(',', ""));
+            let value: Decimal = cleaned.parse().unwrap_or(Decimal::ZERO);
+            Ok(AmountDetails::Amount {
+                value: ValueExpr::Amount {
+                    value,
+                    commodity: None,
+                },
+                lot_annotation: None,
+                lot_pricing: None,
+                balance_assertion: None,
+            })
+        }
         Rule::value_logic => {
             let inner = p.into_inner();
             let mut value = None;

--- a/crates/doppio/src/grammars/ledger/ledger.pest
+++ b/crates/doppio/src/grammars/ledger/ledger.pest
@@ -57,15 +57,13 @@ budget = ${
 // transactions; matched postings synthesise additional postings from
 // the rule body. See elaborator.rs for the application semantics (#249).
 //
-// Implicit multiplier semantics: a body posting amount that is a bare
-// commodity-less number (e.g. `0.10`) is interpreted as a multiplier of
-// the matched posting's amount in its commodity. A body posting amount with
-// an explicit commodity (e.g. `$10.00`) is taken literally. This covers the
-// canonical tithe / proportional-tax pattern without requiring the explicit
-// `*N` prefix syntax.
-//
-// Explicit `*N` multiplier prefix syntax is NOT yet supported and will
-// produce a parse error. See issue #249 for tracking.
+// Multiplier semantics: a body posting amount that is a bare commodity-less
+// number (e.g. `0.10`) is interpreted as a multiplier of the matched
+// posting's amount in its commodity. The explicit `*N` prefix form
+// (e.g. `*-1`, `* 0.5`) is also accepted and lowers to the same bare-number
+// multiplier representation — no new semantic path is required in the
+// elaborator. Body postings with an explicit commodity symbol (e.g. `$10.00`)
+// are taken as literal amounts. See `auto_multiplier` below and #254.
 auto_rule = ${
     "=" ~ ws+ ~ rule_query ~ NEWLINE ~
     (transaction_note | posting | empty_indented_line)*
@@ -147,12 +145,26 @@ posting_note = ${ indent+ ~ note ~ (NEWLINE | EOI) }
 // canonical Ledger convention: it unambiguously separates the account name
 // from the amount, since account names may contain single spaces (e.g.
 // "Equity:Opening Balances").
+//
+// `auto_multiplier` is tried first so that the `*` prefix in automated-rule
+// body postings (e.g. `*-1`, `* 0.5`) is consumed before `value_logic`'s
+// expression parser (which also handles infix `*`). Outside auto-rule bodies
+// this is harmless: regular postings don't start with `*` anyway.
 amount_logic = ${
     (ws{2,} | "\t") ~ (
-        value_logic
+        auto_multiplier
+        | value_logic
         | assertion
     )
 }
+
+// Explicit `*N` multiplier form used in automated-rule body postings.
+// Matches `*<number>` or `* <number>` with an optional leading sign on the
+// number (e.g. `*-1`, `*0.5`, `* 0.12`). The `*` is consumed here and the
+// numeric part is lowered to the same bare-number `ValueExpr::Amount` as a
+// plain bare decimal — the elaborator's `is_bare_number_expr` treats both
+// forms identically (#254).
+auto_multiplier = ${ "*" ~ ws* ~ (prefix_op ~ ws*)? ~ number }
 
 // A value expression, optionally followed by lot annotations and/or lot pricing
 // and/or a balance assertion check.

--- a/crates/doppio/src/grammars/ledger/mod.rs
+++ b/crates/doppio/src/grammars/ledger/mod.rs
@@ -842,6 +842,38 @@ fn parse_posting(pair: Pair<Rule>) -> Result<Posting, Box<dyn std::error::Error>
 fn parse_amount_logic(pair: Pair<Rule>) -> Result<AmountDetails, Box<dyn std::error::Error>> {
     let p = pair.into_inner().next().unwrap();
     match p.as_rule() {
+        Rule::auto_multiplier => {
+            // `*N` multiplier form: `"*" ws* (prefix_op ws*)? number`.
+            // Lower to a bare-number ValueExpr identical to what a plain
+            // bare decimal produces, so the elaborator's `is_bare_number_expr`
+            // check identifies it as a multiplier without any new semantic path
+            // (#254).
+            let mut inner = p.into_inner();
+            // Optional prefix_op, then number.
+            let first = inner
+                .next()
+                .expect("auto_multiplier must have at least a number");
+            let (sign, number_str) = if first.as_rule() == Rule::prefix_op {
+                let s = first.as_str();
+                let n = inner
+                    .next()
+                    .expect("auto_multiplier prefix_op must be followed by number");
+                (s, n.as_str())
+            } else {
+                ("", first.as_str())
+            };
+            let cleaned = format!("{sign}{}", number_str.replace(',', ""));
+            let value: Decimal = cleaned.parse().unwrap_or(Decimal::ZERO);
+            Ok(AmountDetails::Amount {
+                value: ValueExpr::Amount {
+                    value,
+                    commodity: None,
+                },
+                lot_annotation: None,
+                lot_pricing: None,
+                balance_assertion: None,
+            })
+        }
         Rule::value_logic => {
             let inner = p.into_inner();
 

--- a/docs/SUPPORTED_FEATURES.md
+++ b/docs/SUPPORTED_FEATURES.md
@@ -87,6 +87,7 @@ Status legend:
 | `D $1000.00` (default commodity) | + | Both the bare-`D` form and the `commodity ... default` form are supported; bare `D` is lowered at parse time to the same `Directive::Commodity` representation |
 | `~` budget / periodic directive | ~ | Parsed but not elaborated (intentional parse-and-discard). No effect on balances or reports |
 | `= query` automated transaction rules | + | v2.1.0 (#249). Body postings synthesized as `PostingKind::VirtualUnbalanced`. Bare decimal amounts act as multipliers of the matched posting's commodity amount; amounts with an explicit commodity symbol are literal. Query strings: `/pattern/` → regex, bare string → case-insensitive substring match |
+| Explicit `*N` multiplier syntax in rule bodies | + | (#254). `*N`, `*-1`, `* 0.5` etc. in auto-rule body posting amounts are accepted and lower to the same bare-number multiplier as a plain bare decimal |
 
 ## Expression language
 
@@ -189,7 +190,7 @@ file extensions; selected automatically by `dop` and by
 | Feature | Status | Notes |
 |---|---|---|
 | `= query` automated rules (account-name match, multiplier and literal amounts) | + | v2.1.0 (#249). Same semantics as the ledger-cli frontend |
-| Explicit `*N` multiplier syntax in rule bodies | - | Causes a parse error. Tracked in a follow-up issue |
+| Explicit `*N` multiplier syntax in rule bodies | + | (#254). Accepted and lowers to the same bare-number multiplier as a plain bare decimal |
 
 ### Known limitations
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -559,7 +559,7 @@ The revenue recognition transaction construction (`Step 3`) is **already impleme
 
 **Budget / periodic directives** (`~`) — Issue #49 decision: parsed but intentionally not elaborated. doppio models accounting facts, not budget planning.
 
-**Automated transaction `*N` explicit multiplier syntax** — The `= query` rule shape and bare-decimal multiplier semantics are implemented (#249). The explicit `*N` form (e.g. `*0.10`) causes a parse error and is tracked in a follow-up issue.
+**Automated transaction `*N` explicit multiplier syntax** — Implemented in #254. Both `*N` and `* N` (with whitespace) forms are now accepted in auto-rule body postings in both the ledger-cli and hledger frontends. They lower to the same bare-number multiplier representation as a plain bare decimal.
 
 **Transaction matching / duplicate detection** — Phase 4 or later
 

--- a/scripts/parity_check.py
+++ b/scripts/parity_check.py
@@ -149,7 +149,18 @@ def ledger_balances(fixture: Path) -> set[Tuple3]:
 
     Multi-commodity accounts emit a `Account|amount` line followed by one
     or more continuation lines holding only an amount (no `|`); the
-    continuation lines belong to the previous account."""
+    continuation lines belong to the previous account.
+
+    The format uses `scrub(amount)` (per-account direct balance) rather
+    than `scrub(display_total)` (subtree-aggregated balance). doppio's
+    `dop balance --flat --format=json` reports each account's direct
+    balance independently; ledger-cli's `display_total` rolls child
+    balances into intermediate accounts. They diverge only when an
+    intermediate account carries BOTH direct postings AND child postings
+    (e.g. drewr3.dat's `Assets:Checking` with a child
+    `Assets:Checking:Business`). `amount` gives the apples-to-apples
+    comparison without taking a position on doppio's `--flat` UX
+    (direct-only vs subtree-aggregated), which is a separate question."""
     raw = subprocess.run(
         [
             "ledger",
@@ -159,7 +170,7 @@ def ledger_balances(fixture: Path) -> set[Tuple3]:
             "--no-pager",
             "--no-color",
             "--no-total",
-            "--format=%(account)|%(scrub(display_total))\n",
+            "--format=%(account)|%(scrub(amount))\n",
         ],
         capture_output=True,
         text=True,
@@ -855,6 +866,7 @@ POSITIVE: list[Case] = [
     Case("ledger:transfer",       REPO / "tests/parity/ledger-transfer.ledger",  ledger_balances),
     Case("ledger:demo",           REPO / "tests/parity/ledger-demo.ledger",      ledger_balances),
     Case("ledger:no-trailing-newline", REPO / "tests/parity/ledger-no-trailing-newline.dat", ledger_balances),
+    Case("ledger:drewr3",         REPO / "tests/parity/ledger-drewr3.dat",     ledger_balances),
     Case("hledger:quickstart",    REPO / "tests/parity/hledger-quickstart.journal", hledger_balances),
     Case("hledger:ascii",         REPO / "tests/parity/hledger-ascii.journal", hledger_balances),
     Case("hledger:zerostar",      REPO / "tests/parity/hledger-zerostar.journal", hledger_balances),

--- a/tests/parity/ledger-drewr3.dat
+++ b/tests/parity/ledger-drewr3.dat
@@ -1,0 +1,83 @@
+; Source: ledger-cli upstream test corpus
+;   https://raw.githubusercontent.com/ledger/ledger/0178dd2d1319e0b7ce789609337ab52d9fb23f81/test/input/drewr3.dat
+;   commit 0178dd2d1319e0b7ce789609337ab52d9fb23f81 (main, fetched 2026-05-08)
+;   license: BSD-3-Clause (ledger-cli project; compatible with redistribution under doppio's MIT)
+;
+; Exercises: `= /QUERY/` automated transaction rules with bare-decimal
+; multiplier semantics (0.12 tithe pattern), `apply tag` / `end tag` scope
+; directives, secondary dates (YYYY/MM/DD=YYYY/MM/DD), posting-level
+; metadata comments, `:tag:` and `key: value` metadata styles, and a
+; realistic personal-finance posting structure with checking / savings /
+; mortgage / expenses accounts.
+
+; -*- ledger -*-
+
+= /^Income/
+  (Liabilities:Tithe)                    0.12
+
+;~ Monthly
+;  Assets:Checking                     $500.00
+;  Income:Salary
+
+;~ Monthly
+;   Expenses:Food  $100
+;   Assets
+
+2010/12/01 * Checking balance
+  Assets:Checking                   $1,000.00
+  Assets:Savings                    $5,200.00
+  Equity:Opening Balances
+
+2010/12/20 * Organic Co-op
+  Expenses:Food:Groceries             $ 37.50  ; [=2011/01/01]
+  Expenses:Food:Groceries             $ 37.50  ; [=2011/02/01]
+  Expenses:Food:Groceries             $ 37.50  ; [=2011/03/01]
+  Expenses:Food:Groceries             $ 37.50  ; [=2011/04/01]
+  Expenses:Food:Groceries             $ 37.50  ; [=2011/05/01]
+  Expenses:Food:Groceries             $ 37.50  ; [=2011/06/01]
+  Assets:Checking                   $ -225.00
+
+2010/12/28=2011/01/01 Acme Mortgage
+  Liabilities:Mortgage:Principal    $  200.00
+  Expenses:Interest:Mortgage        $  500.00
+  Expenses:Escrow                   $  300.00
+  Assets:Checking                  $ -1000.00
+
+2011/01/02 Grocery Store
+  Expenses:Food:Groceries             $ 65.00
+  Assets:Checking
+
+2011/01/05 Employer
+  Assets:Checking                   $ 2000.00
+  Income:Salary
+
+2011/01/14 Bank
+  ; Regular monthly savings transfer
+  Assets:Savings                     $ 300.00
+  Assets:Checking
+
+2011/01/19 Grocery Store
+  Expenses:Food:Groceries             $ 44.00 ; hastag: not block
+  Assets:Checking
+
+2011/01/25 Bank
+  ; Transfer to cover car purchase
+  Assets:Checking                  $ 5,500.00
+  Assets:Savings
+  ; :nobudget:
+
+apply tag hastag: true
+apply tag nestedtag: true
+2011/01/25 Tom's Used Cars
+  Expenses:Auto                    $ 5,500.00
+  ; :nobudget:
+  Assets:Checking
+
+2011/01/27 Book Store
+  Expenses:Books                       $20.00
+  Liabilities:MasterCard
+end tag
+2011/12/01 Sale
+  Assets:Checking:Business            $ 30.00
+  Income:Sales
+end tag


### PR DESCRIPTION
## Summary

- **Closes #254** — accept `*N` / `* N` (with optional whitespace) as a posting amount inside `= QUERY` auto-rule bodies in both the ledger-cli and hledger frontends. The `*` prefix is consumed by a new `auto_multiplier` grammar rule; the Rust adapters lower it to the same bare-number `ValueExpr::Amount { commodity: None }` that a plain bare decimal produces. No new semantic path in the elaborator — the existing `is_bare_number_expr` check handles both forms identically.
- **Closes #257** — vendor `test/input/drewr3.dat` from ledger-cli upstream (commit `0178dd2d`, BSD-3-Clause) as `tests/parity/ledger-drewr3.dat`, with the standard provenance comment block. Wired into the positive parity harness.

## Changes

### Grammar (`ledger.pest`, `hledger.pest`)

Added a new `auto_multiplier` rule:
```pest
auto_multiplier = ${ "*" ~ ws* ~ (prefix_op ~ ws*)? ~ number }
```
Inserted as the first alternative in `amount_logic` so `*` is consumed before the expression parser (which also uses `*` as an infix multiply operator). Harmless for regular postings since they don't start with `*`.

Updated comment blocks in both grammars to reflect that `*N` is now supported.

### Rust adapters (`grammars/ledger/mod.rs`, `grammars/hledger/mod.rs`)

Added a `Rule::auto_multiplier` arm to `parse_amount_logic`. Parses the optional sign and number, produces `AmountDetails::Amount { value: ValueExpr::Amount { commodity: None, .. }, .. }` — semantically identical to a bare decimal.

### Tests (`elaborator.rs`)

Five new unit tests:
- `ledger_star_n_multiplier_equals_bare_decimal` — `*0.10` on `$-100.00` → `$-10.00`
- `ledger_star_negative_one_negates_matched_amount` — `*-1` on `$-100.00` → `$100.00`
- `ledger_star_n_with_whitespace_is_accepted` — `* 0.5` on `$-200.00` → `$-100.00`
- `hledger_star_n_multiplier_equals_bare_decimal` — hledger frontend same as ledger
- `hledger_star_negative_one_negates_matched_amount` — `*-1` on `$50.00` → `$-50.00`

### Parity harness fix (`scripts/parity_check.py`)

`ledger_balances` extracted `%(scrub(display_total))` — ledger-cli's subtree-aggregated balance for each account — and compared it to `dop balance --flat --format=json`'s per-account direct balance. The two agreed on every existing fixture by accident: each had no intermediate account carrying both direct postings and child postings. drewr3.dat does (`Assets:Checking` direct `$1,366`; child `Assets:Checking:Business` `$30`; subtree `$1,396`), so vendoring it surfaced the divergence.

Switched the format string to `%(scrub(amount))` (per-account direct balance) for an apples-to-apples comparison. doppio's `--flat` UX semantics (direct vs subtree-aggregated) are a separate question that the harness intentionally does not arbitrate.

### Docs

- `CHANGELOG.md` `[Unreleased]` — Added bullet for `*N` syntax (#254); test-infrastructure bullet for drewr3.dat vendoring + harness fix (refs #257)
- `docs/SUPPORTED_FEATURES.md` — flipped both the ledger-cli and hledger rows for `*N` from `-` to `+`
- `docs/requirements.md` — updated the deferred-feature entry for `*N` to reflect it is now implemented

### Fixture (`tests/parity/ledger-drewr3.dat`)

Vendored at upstream commit SHA `0178dd2d1319e0b7ce789609337ab52d9fb23f81` with a provenance comment block (source URL, fetch date 2026-05-08, BSD-3-Clause license, "Exercises" sentence).

## Test plan

- [x] `cargo fmt --check` — passes
- [x] `cargo clippy -- -D warnings` — passes (zero warnings)
- [x] `cargo test` — all tests pass (5 new unit tests added)
- [x] `cargo test --doc` — all doc tests pass
- [x] `python3 scripts/parity_check.py --self-test` — comparator assertions held
- [x] `python3 scripts/parity_check.py --negative` — all 4 negative controls pass
- [x] `python3 scripts/parity_check.py` — all positive ledger + hledger fixtures pass, including `ledger:drewr3`
- [x] doppio elaborates `drewr3.dat` cleanly: auto-rule `0.12` multiplier produces correct `Liabilities:Tithe` balance (`$-243.60`)