### PR TITLE
refactor(resolution): unify commodity aliases under a (canonical, divisor) map (#248 stage 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Internal
+
+- **`Context::commodity_aliases` renamed to `commodity_conversions`** (pre-stage for #248, no
+  behavioural change): the field type changes from `BTreeMap<String, String>` to
+  `BTreeMap<String, (String, Decimal)>`, where the tuple is `(canonical_symbol, divisor)`.
+  All existing alias insertions use `divisor = Decimal::ONE` (a 1:1 rename), so elaboration
+  output is identical. This unification makes stage 2 of #248 (wiring the divisor through
+  for full `C`-directive semantics) a natural extension rather than a new concept.
+
 ### Added
 
 - **Explicit `*N` multiplier syntax in automated-rule bodies** (#254): both the

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -2582,12 +2582,15 @@ mod evaluator {
         match eval(val, eval_context, running_state, &empty_meta, EVAL_BUDGET)? {
             ast::ValueExpr::Amount { value, commodity } => {
                 let commodity = if let Some(commodity) = commodity {
-                    // Apply commodity alias (e.g. "Bitcoin" -> "BTC")
+                    // Apply commodity alias (e.g. "Bitcoin" -> "BTC").
+                    // The divisor stored in commodity_conversions is ignored in
+                    // stage 1; it will be applied in stage 2 (#248) when full
+                    // `C` conversion semantics are wired through elaboration.
                     eval_context
-                        .commodity_aliases
+                        .commodity_conversions
                         .get(&commodity)
-                        .unwrap_or(&commodity)
-                        .clone()
+                        .map(|(canonical, _divisor)| canonical.clone())
+                        .unwrap_or(commodity)
                 } else {
                     // No commodity in the expression -- try context default, then
                     // the caller-supplied fallback (e.g. inferred from account balance).

--- a/crates/doppio/src/resolution.rs
+++ b/crates/doppio/src/resolution.rs
@@ -135,8 +135,15 @@ pub(crate) struct ResolvedAutoRule {
 pub struct Context {
     /// Maps short account names to their canonical equivalents.
     pub account_aliases: BTreeMap<String, String>,
-    /// Maps alternative commodity symbols to their canonical names.
-    pub commodity_aliases: BTreeMap<String, String>,
+    /// Maps alternative commodity symbols to their canonical names and conversion divisors.
+    ///
+    /// The key is the alias (source) commodity symbol. The value is
+    /// `(canonical_symbol, divisor)` where `divisor` is the amount to divide by
+    /// when converting to the canonical commodity. Aliases populated from
+    /// `commodity X\n  alias Y` directives use `divisor = Decimal::ONE` (a 1:1
+    /// rename). Full `C` conversion directives (stage 2, #248) will populate
+    /// entries with arbitrary divisors.
+    pub commodity_conversions: BTreeMap<String, (String, rust_decimal::Decimal)>,
     /// The commodity assumed when a posting amount has no explicit commodity.
     pub default_commodity: Option<String>,
     /// Named aliases defined with `define name[(params)] = body`.
@@ -920,7 +927,10 @@ impl TryFrom<ast::Journal> for HIR {
                                 // original view of aliases.
                                 new_context = Some(new_context.unwrap_or_else(|| context.clone()))
                                     .map(|mut ctx| {
-                                        ctx.commodity_aliases.insert(alias, name.clone());
+                                        ctx.commodity_conversions.insert(
+                                            alias,
+                                            (name.clone(), rust_decimal::Decimal::ONE),
+                                        );
                                         ctx
                                     });
                             }
@@ -1218,11 +1228,15 @@ mod resolution_tests {
 
         // Verify context 1 has the alias
         assert_eq!(
-            hir.contexts[1].commodity_aliases.get("Bitcoin").unwrap(),
+            hir.contexts[1]
+                .commodity_conversions
+                .get("Bitcoin")
+                .unwrap()
+                .0,
             "BTC"
         );
         // Verify context 0 does not
-        assert!(hir.contexts[0].commodity_aliases.is_empty());
+        assert!(hir.contexts[0].commodity_conversions.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Renames `Context::commodity_aliases: BTreeMap<String, String>` to `Context::commodity_conversions: BTreeMap<String, (String, rust_decimal::Decimal)>`, where the tuple is `(canonical_symbol, divisor)`.
- All existing alias insertions (from `commodity X\n  alias Y` directives) use `divisor = Decimal::ONE`, preserving the 1:1 rename semantics exactly.
- The elaborator's alias-resolution path is updated to extract just the canonical symbol from the tuple; the divisor is deliberately ignored in this stage.
- Two test assertions in `resolution.rs` are updated to navigate the new tuple shape (`.0` to get the canonical); the asserted values are unchanged.

This is a pure data-structure refactor. No new pest rules, no new elaboration paths, no behaviour change.

**API note:** `Context` is a `pub` struct and `commodity_conversions` is a `pub` field, so renaming it from `commodity_aliases` is technically API-breaking. Observable behaviour is identical; this aligns with the project's pragmatic pre-major-bump stance.

Refs #248

## Test plan

- `cargo fmt --check` passes.
- `cargo clippy -- -D warnings` passes with zero warnings.
- `cargo test` passes: all existing test suites (350+ tests across doppio, doppio-cli, doppio-categorize, parity harness) pass without any change to assertion expectations.
- `cargo test --doc` passes: all 8 doc tests pass.