### PR TITLE
feat(ledger,hledger): accept double-quoted commodity names (#262)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@
 
 ### Added
 
+- **Double-quoted commodity names** (#262): both the ledger-cli and hledger
+  frontends now accept commodity identifiers enclosed in double quotes, e.g.
+  `"Plans: Wildthorn Mail"`.  The surrounding quotes are stripped so the stored
+  commodity name is the bare string without delimiters.  This is useful for
+  commodity names that contain spaces, colons, or other characters that are
+  not allowed in bare identifier form.  Empty quoted names (`""`) are rejected
+  by the grammar.
+
 - **Explicit `*N` multiplier syntax in automated-rule bodies** (#254): both the
   ledger-cli and hledger frontends now accept `*N` (e.g. `*-1`, `* 0.5`,
   `*0.12`) as a posting amount inside an `= QUERY` auto-rule body. The `*N`

--- a/crates/doppio/src/grammars/hledger/hledger.pest
+++ b/crates/doppio/src/grammars/hledger/hledger.pest
@@ -306,8 +306,16 @@ number = @{
     | "." ~ ASCII_DIGIT+
 }
 
+// A commodity is either one or more currency symbols ($, €, £, ¥), a
+// double-quoted opaque name (e.g. "Plans: Wildthorn Mail"), or an
+// identifier-style name (USD, BTC, AAPL, …).  The quoted alternative is
+// listed second so that a leading `"` is always consumed by it rather than
+// by the symbol alternative; the identifier alternative is last so that bare
+// names still work.  Escape sequences are not supported inside quoted names
+// (hledger does not support them either); embedded quotes are disallowed.
 commodity = @{
     symbol+
+    | "\"" ~ (!"\"" ~ ANY)+ ~ "\""
     | (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_" | "." | ":" | "#")*
 }
 symbol = _{ "$" | "€" | "£" | "¥" }

--- a/crates/doppio/src/grammars/hledger/mod.rs
+++ b/crates/doppio/src/grammars/hledger/mod.rs
@@ -450,6 +450,18 @@ fn parse_lot_annotation_into(pair: Pair<Rule>, acc: &mut LotAnnotation) {
     }
 }
 
+/// Strip surrounding double-quotes from a `commodity` pair's text when the
+/// quoted-string alternative matched.  For bare identifiers and symbol-based
+/// commodities the text is returned unchanged.
+fn commodity_text(pair: Pair<'_, Rule>) -> String {
+    let s = pair.as_str();
+    if s.starts_with('"') && s.ends_with('"') && s.len() >= 2 {
+        s[1..s.len() - 1].to_string()
+    } else {
+        s.to_string()
+    }
+}
+
 fn parse_historical_price(pair: Pair<Rule>) -> HistoricalPrice {
     let mut inner = pair.into_inner();
     let date = parse_date(inner.next().unwrap());
@@ -458,7 +470,7 @@ fn parse_historical_price(pair: Pair<Rule>) -> HistoricalPrice {
 
     for p in inner {
         match p.as_rule() {
-            Rule::commodity => commodity = p.as_str().to_string(),
+            Rule::commodity => commodity = commodity_text(p),
             Rule::value_expr => price_pair = Some(p),
             _ => {}
         }
@@ -646,7 +658,7 @@ fn parse_expr(pair: Pair<Rule>) -> ValueExpr {
     if let Some(comm_pair) = inner.next() {
         ast = ValueExpr::Typed {
             expr: Box::new(ast),
-            commodity: comm_pair.as_str().to_string(),
+            commodity: commodity_text(comm_pair),
         };
     }
     ast
@@ -665,7 +677,7 @@ fn run_pratt(pairs: Pairs<Rule>) -> ValueExpr {
                 let first = inner.next().unwrap();
                 match first.as_rule() {
                     Rule::commodity => {
-                        let comm = first.as_str().to_string();
+                        let comm = commodity_text(first);
                         let val_str = inner.next().unwrap().as_str();
                         ValueExpr::Amount {
                             value: clean_decimal(val_str),
@@ -674,7 +686,7 @@ fn run_pratt(pairs: Pairs<Rule>) -> ValueExpr {
                     }
                     Rule::number => {
                         let val = clean_decimal(first.as_str());
-                        let comm = inner.next().map(|c| c.as_str().to_string());
+                        let comm = inner.next().map(commodity_text);
                         ValueExpr::Amount {
                             value: val,
                             commodity: comm,
@@ -683,7 +695,7 @@ fn run_pratt(pairs: Pairs<Rule>) -> ValueExpr {
                     _ => unreachable!(),
                 }
             }
-            Rule::commodity => ValueExpr::Commodity(pair.as_str().to_string()),
+            Rule::commodity => ValueExpr::Commodity(commodity_text(pair)),
             Rule::expr => run_pratt(pair.into_inner()),
             _ => unreachable!("unexpected primary rule: {:?}", pair.as_rule()),
         })
@@ -1553,5 +1565,141 @@ account Income          ; type:R
         let ann = lot_annotation.as_ref().expect("lot annotation present");
         assert!(ann.cost_is_total, "double-brace form sets cost_is_total");
         assert!(ann.cost.is_some(), "cost expression captured");
+    }
+
+    // ---
+    // Quoted-commodity tests (#262) — hledger frontend
+    // ---
+
+    /// Number-first form: `5 "Long Name"` — commodity is stripped of quotes.
+    #[test]
+    fn quoted_commodity_number_first() {
+        let input = r#"5 "Long Name""#;
+        let mut pairs = HledgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(5),
+                commodity: Some("Long Name".into()),
+            }
+        );
+    }
+
+    /// Commodity-first form: `"Long Name" 5` — commodity is stripped of quotes.
+    #[test]
+    fn quoted_commodity_commodity_first() {
+        let input = r#""Long Name" 5"#;
+        let mut pairs = HledgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(5),
+                commodity: Some("Long Name".into()),
+            }
+        );
+    }
+
+    /// Quoted commodity with colon inside (the motivating example from #262).
+    #[test]
+    fn quoted_commodity_with_colon() {
+        let input = r#"1 "Plans: Wildthorn Mail""#;
+        let mut pairs = HledgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(1),
+                commodity: Some("Plans: Wildthorn Mail".into()),
+            }
+        );
+    }
+
+    /// Quoted commodity with an apostrophe inside.
+    #[test]
+    fn quoted_commodity_with_apostrophe() {
+        let input = r#"1 "It's""#;
+        let mut pairs = HledgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(1),
+                commodity: Some("It's".into()),
+            }
+        );
+    }
+
+    /// Quoted commodity with a slash inside.
+    #[test]
+    fn quoted_commodity_with_slash() {
+        let input = r#"1 "a/b""#;
+        let mut pairs = HledgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(1),
+                commodity: Some("a/b".into()),
+            }
+        );
+    }
+
+    /// Empty double quotes cannot produce an empty commodity name.
+    ///
+    /// The grammar requires at least one non-quote character inside a quoted
+    /// commodity; there is no string-literal fallback in `base_primary` for
+    /// the hledger frontend, so `"" 5` is a parse error outright.
+    #[test]
+    fn quoted_commodity_empty_rejected() {
+        let input = r#""" 5"#;
+        assert!(
+            HledgerParser::parse(Rule::value_expr, input).is_err(),
+            "empty-quoted commodity form must be rejected by the grammar"
+        );
+    }
+
+    /// Full transaction with a quoted commodity parses correctly.
+    #[test]
+    fn quoted_commodity_in_full_transaction() {
+        let input = concat!(
+            "2024-01-01 * Test\n",
+            "    assets:items   1 \"Plans: Wildthorn Mail\" @ $125\n",
+            "    equity\n",
+        );
+        let journal = parse_hledger(input).expect("quoted commodity transaction should parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!("expected transaction");
+        };
+        let details = tx.postings[0].amount.as_ref().expect("amount present");
+        let AmountDetails::Amount { value, .. } = details else {
+            panic!("expected Amount variant");
+        };
+        assert!(
+            matches!(
+                value,
+                ValueExpr::Amount {
+                    commodity: Some(c),
+                    ..
+                } if c == "Plans: Wildthorn Mail"
+            ),
+            "commodity should be unquoted; got: {value:?}"
+        );
+    }
+
+    /// Bare identifier commodities (regression: must still work).
+    #[test]
+    fn bare_commodity_regression() {
+        let input = "100 USD";
+        let mut pairs = HledgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(100),
+                commodity: Some("USD".into()),
+            }
+        );
     }
 }

--- a/crates/doppio/src/grammars/ledger/ledger.pest
+++ b/crates/doppio/src/grammars/ledger/ledger.pest
@@ -387,12 +387,18 @@ term = ${ (prefix_op ~ ws*)? ~ primary }
 // base_primary is silent, so the parser sees the child rule directly.
 primary = { base_primary ~ access* }
 
+// Ordering note: `amount` is tried before `string` so that commodity-first
+// quoted amounts like `"Long Name" 5` are consumed by the `amount` rule
+// (commodity ~ ws* ~ number) rather than by `string`.  A quoted string that
+// is *not* followed by a number still falls through to `string` because the
+// `amount` alternatives all require a numeric component.  `function_call` is
+// first because it starts with an identifier, not a quote.
 base_primary = _{
     function_call
+    | amount
     | string
     | "(" ~ bool_expr ~ ")"
     | "(" ~ expr ~ ")"
-    | amount
     | commodity
 }
 
@@ -426,10 +432,16 @@ number = @{
     | "." ~ ASCII_DIGIT+
 }
 
-// A commodity is either one or more currency symbols ($, €, £, ¥) or
-// an identifier-style name (USD, BTC, AAPL, …).
+// A commodity is either one or more currency symbols ($, €, £, ¥), a
+// double-quoted opaque name (e.g. "Plans: Wildthorn Mail"), or an
+// identifier-style name (USD, BTC, AAPL, …).  The quoted alternative is
+// listed second so that a leading `"` is always consumed by it rather than
+// by the symbol alternative; the identifier alternative is last so that bare
+// names still work.  Escape sequences are not supported inside quoted names
+// (ledger-cli does not support them either); embedded quotes are disallowed.
 commodity = @{
     symbol+
+    | "\"" ~ (!"\"" ~ ANY)+ ~ "\""
     | (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_" | "." | ":" | "#")*
 }
 

--- a/crates/doppio/src/grammars/ledger/mod.rs
+++ b/crates/doppio/src/grammars/ledger/mod.rs
@@ -347,6 +347,18 @@ fn parse_assertion_directive(pair: Pair<Rule>) -> AssertionDirective {
     }
 }
 
+/// Strip surrounding double-quotes from a `commodity` pair's text when the
+/// quoted-string alternative matched.  For bare identifiers and symbol-based
+/// commodities the text is returned unchanged.
+fn commodity_text(pair: Pair<'_, Rule>) -> String {
+    let s = pair.as_str();
+    if s.starts_with('"') && s.ends_with('"') && s.len() >= 2 {
+        s[1..s.len() - 1].to_string()
+    } else {
+        s.to_string()
+    }
+}
+
 fn parse_historical_price(pair: Pair<Rule>) -> HistoricalPrice {
     let mut inner = pair.into_inner();
     let date = parse_date(&mut inner.next().unwrap().into_inner());
@@ -357,7 +369,7 @@ fn parse_historical_price(pair: Pair<Rule>) -> HistoricalPrice {
     for p in inner {
         match p.as_rule() {
             Rule::time => time = Some(p.as_str().to_string()),
-            Rule::commodity => commodity = p.as_str().to_string(),
+            Rule::commodity => commodity = commodity_text(p),
             Rule::value_expr => price_pair = Some(p),
             _ => {}
         }
@@ -1024,11 +1036,11 @@ pub(crate) fn parse_expr(pair: Pair<Rule>) -> ValueExpr {
     let expr_pair = inner.next().expect("Empty value_expr");
     let mut ast = run_pratt(expr_pair.into_inner());
 
-    // Check for trailing commodity (e.g., '(1+2) USD')
+    // Check for trailing commodity (e.g., '(1+2) USD' or '(1+2) "Long Name"')
     if let Some(comm_pair) = inner.next() {
         ast = ValueExpr::Typed {
             expr: Box::new(ast),
-            commodity: comm_pair.as_str().to_string(),
+            commodity: commodity_text(comm_pair),
         };
     }
     ast
@@ -1067,19 +1079,19 @@ fn run_pratt(pairs: pest::iterators::Pairs<Rule>) -> ValueExpr {
                 let mut inner = pair.into_inner();
                 let first = inner.next().unwrap();
                 match first.as_rule() {
-                    // Prefix-commodity form: "$100" -- commodity comes first
+                    // Prefix-commodity form: "$100" or `"Long Name" 5` -- commodity comes first
                     Rule::commodity => {
-                        let comm = first.as_str().to_string();
+                        let comm = commodity_text(first);
                         let val_str = inner.next().unwrap().as_str();
                         ValueExpr::Amount {
                             value: clean_parse_decimal(val_str),
                             commodity: Some(comm),
                         }
                     }
-                    // Number-first form: "100 USD" or bare "100"
+                    // Number-first form: "100 USD", "5 \"Long Name\"", or bare "100"
                     Rule::number => {
                         let val = clean_parse_decimal(first.as_str());
-                        let comm = inner.next().map(|c| c.as_str().to_string());
+                        let comm = inner.next().map(commodity_text);
                         ValueExpr::Amount {
                             value: val,
                             commodity: comm,
@@ -1088,7 +1100,7 @@ fn run_pratt(pairs: pest::iterators::Pairs<Rule>) -> ValueExpr {
                     _ => unreachable!(),
                 }
             }
-            Rule::commodity => ValueExpr::Commodity(pair.as_str().to_string()),
+            Rule::commodity => ValueExpr::Commodity(commodity_text(pair)),
             Rule::function_call => {
                 let mut inner = pair.into_inner();
                 let name = inner.next().unwrap().as_str().to_string();
@@ -2038,5 +2050,172 @@ account Assets:Savings
             "    Equity:Opening         $-100.00\n",
         );
         parse_ledger(input).expect("trailing whitespace on amount posting should parse");
+    }
+
+    // ---
+    // Quoted-commodity tests (#262)
+    // ---
+
+    /// Number-first form: `5 "Long Name"` — commodity is stripped of quotes.
+    #[test]
+    fn test_quoted_commodity_number_first() {
+        let input = r#"5 "Long Name""#;
+        let mut pairs = LedgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(5),
+                commodity: Some("Long Name".into()),
+            }
+        );
+    }
+
+    /// Commodity-first form: `"Long Name" 5` — commodity is stripped of quotes.
+    #[test]
+    fn test_quoted_commodity_commodity_first() {
+        let input = r#""Long Name" 5"#;
+        let mut pairs = LedgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(5),
+                commodity: Some("Long Name".into()),
+            }
+        );
+    }
+
+    /// Quoted commodity with colon inside (the motivating example from #262).
+    #[test]
+    fn test_quoted_commodity_with_colon() {
+        let input = r#"1 "Plans: Wildthorn Mail""#;
+        let mut pairs = LedgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(1),
+                commodity: Some("Plans: Wildthorn Mail".into()),
+            }
+        );
+    }
+
+    /// Quoted commodity with an apostrophe inside.
+    #[test]
+    fn test_quoted_commodity_with_apostrophe() {
+        let input = r#"1 "It's""#;
+        let mut pairs = LedgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(1),
+                commodity: Some("It's".into()),
+            }
+        );
+    }
+
+    /// Quoted commodity with a leading dollar sign (verifies the symbol
+    /// alternative doesn't shadow the quoted form).
+    #[test]
+    fn test_quoted_commodity_leading_dollar() {
+        let input = r#"1 "$pecial""#;
+        let mut pairs = LedgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(1),
+                commodity: Some("$pecial".into()),
+            }
+        );
+    }
+
+    /// Quoted commodity with a slash inside.
+    #[test]
+    fn test_quoted_commodity_with_slash() {
+        let input = r#"1 "a/b""#;
+        let mut pairs = LedgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(1),
+                commodity: Some("a/b".into()),
+            }
+        );
+    }
+
+    /// Empty double quotes cannot produce an empty commodity name.
+    ///
+    /// The grammar requires at least one non-quote character inside a quoted
+    /// commodity, so `""` is never parsed as a commodity.  Instead it is
+    /// parsed as a string literal (`ValueExpr::Str`), which means an amount
+    /// with an empty commodity name is structurally impossible.
+    #[test]
+    fn test_quoted_commodity_empty_not_treated_as_commodity() {
+        // `"" 5` — the empty-quoted form fails to match the `commodity` rule
+        // (which requires `(!"\"" ~ ANY)+`).  The parser therefore treats `""`
+        // as a string literal and ` 5` as unconsumed input.  The result is
+        // NOT an Amount with an empty commodity name.
+        let input = r#""" 5"#;
+        let mut pairs = LedgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert!(
+            !matches!(
+                &expr,
+                ValueExpr::Amount {
+                    commodity: Some(c),
+                    ..
+                } if c.is_empty()
+            ),
+            "empty commodity name must never appear in an Amount; got: {expr:?}"
+        );
+    }
+
+    /// Full transaction with a quoted commodity parses correctly, and the
+    /// commodity name is accessible without surrounding quotes.
+    #[test]
+    fn test_quoted_commodity_in_full_transaction() {
+        let input = concat!(
+            "2024-01-01 * Test\n",
+            "    Assets:Items   1 \"Plans: Wildthorn Mail\" @ $125\n",
+            "    Equity\n",
+        );
+        let journal = parse_ledger(input).expect("quoted commodity transaction should parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!("expected transaction");
+        };
+        let details = tx.postings[0].amount.as_ref().expect("amount present");
+        let AmountDetails::Amount { value, .. } = details else {
+            panic!("expected Amount variant");
+        };
+        assert!(
+            matches!(
+                value,
+                ValueExpr::Amount {
+                    commodity: Some(c),
+                    ..
+                } if c == "Plans: Wildthorn Mail"
+            ),
+            "commodity should be unquoted; got: {value:?}"
+        );
+    }
+
+    /// Bare identifier commodities (regression: must still work after the
+    /// quoted-commodity alternative was added to the grammar).
+    #[test]
+    fn test_bare_commodity_regression() {
+        let input = "100 USD";
+        let mut pairs = LedgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(100),
+                commodity: Some("USD".into()),
+            }
+        );
     }
 }

--- a/docs/SUPPORTED_FEATURES.md
+++ b/docs/SUPPORTED_FEATURES.md
@@ -31,6 +31,7 @@ Status legend:
 | Postings (indented) | + | |
 | Number-first amounts `100 USD` | + | |
 | Symbol-first amounts `$100` | + | |
+| Quoted commodity names `"Long Name"` | + | (#262). Both `"Name" 5` (commodity-first) and `5 "Name"` (number-first) forms. Surrounding quotes are stripped; the stored commodity name is the bare string |
 | Bare amounts `100` | + | Default commodity applied if declared |
 | Negative amounts | + | Both `-$100` and `$-100` |
 | Lot pricing `@ unit` | + | |


### PR DESCRIPTION
## Summary

- Extends the `commodity` production in both `ledger.pest` and `hledger.pest` to accept double-quoted commodity names such as `"Plans: Wildthorn Mail"` — useful for names containing spaces, colons, or other characters not permitted in bare identifier form.
- Adds a `commodity_text` helper in each frontend's `mod.rs` that strips surrounding quotes from the parsed span; all eight commodity-capture sites updated accordingly.
- Moves `amount` before `string` in `ledger.pest`'s `base_primary` so that commodity-first quoted amounts (`"Long Name" 5`) are parsed as amounts rather than string literals.
- Adds 9 ledger + 8 hledger unit tests covering: number-first form, commodity-first form, special characters (colon, apostrophe, dollar, slash), empty-quoted-not-a-commodity property, full-transaction parse, and bare-identifier regression.

## Test plan

- [x] `cargo fmt --check -p doppio` — no changes required
- [x] `cargo clippy -p doppio -- -D warnings` — clean
- [x] `cargo test -p doppio` — 365 lib + 49 integration + 3 proto tests pass
- [x] `cargo test --doc -p doppio` — 8 doc tests pass
- [x] CI green before merge

## Notes

`tests/parity/ledger-wow.dat` parity wiring (adding `wow.dat` to the POSITIVE harness list) is a fast-follow once this PR and #261 (`C` commodity-conversion directive) both land — `wow.dat` exercises quoted commodities heavily and needs both features to pass end-to-end.

Closes #262