### PR TITLE
test(parity): wow.dat wiring blocked by elaborator gap; standard.dat deferred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,15 @@
 
 ### Test infrastructure
 
+- **Investigate `tests/parity/ledger-wow.dat` for POSITIVE wiring** (refs #261, refs #263, refs #197):
+  attempted to add the already-vendored `ledger-wow.dat` fixture to the parity POSITIVE list now
+  that both `C`-directive (#261) and quoted-commodity (#263) support have landed.  `dop balance`
+  fails with an elaboration error on postings that combine a quoted commodity name containing an
+  apostrophe with a `{cost}` lot annotation under a `C`-directive commodity-conversion chain
+  (`EvaluationError(BinaryOperationTypeError((Str("Beaststalker's Belt"), Amount, Sub)))`).
+  The fixture remains vendored for reproducibility; the elaborator gap is tracked in #264.
+  `standard.dat` evaluation deferred until #264 is resolved.
+
 - **Vendor `tests/parity/ledger-drewr3.dat`** (refs #257, refs #197): the
   ledger-cli upstream `test/input/drewr3.dat` fixture is vendored with a
   provenance comment block (source URL, commit SHA, license, exercises). It is


### PR DESCRIPTION
## Summary

This PR attempts to wire `tests/parity/ledger-wow.dat` into the parity POSITIVE list, following the merge of #261 (C directive) and #263 (quoted commodities), and to evaluate `standard.dat` (#256) as a potential POSITIVE fixture for the upcoming 2.1.0 release.

**Phase 1 result: STOP — elaboration error in wow.dat.**

`dop balance tests/parity/ledger-wow.dat` fails at elaboration time with:

```
Error: EvaluationError(BinaryOperationTypeError((Str("Beaststalker's Belt"), Amount { value: 1, commodity: None }, Sub)))
```

The failing posting (line 246 of the fixture):

```ledger
2006/03/16 Auction House
    Assets:Tajer                1195768c
    Assets:Tajer:Items                  "Beaststalker's Belt" -1 {65G} @ 1195768c
    Income:Brokering            -545768c
```

The combination of:
- a quoted commodity name containing an apostrophe (`"Beaststalker's Belt"`)
- a `{65G}` lot-cost annotation with a negative quantity (sale posting)
- active `C` commodity-conversion directives in scope

causes the elaborator to treat the quoted commodity as a `ValueExpr::Str` and attempt `Sub` on it, instead of treating it as a commodity identifier throughout the lot-cost elaboration pipeline.

**Per the task scope, wow.dat is NOT added to POSITIVE and standard.dat evaluation is deferred until #264 is resolved.**

## What's in this PR

- **CHANGELOG entry** under `[Unreleased] > Test infrastructure`: documents the wow.dat investigation, the elaboration gap, and the deferral of standard.dat.
- **No changes to `scripts/parity_check.py`**: wow.dat is not wired into POSITIVE.
- **No new vendored files**: `tests/parity/ledger-wow.dat` was already in the repo (vendored in #261).

## Follow-up

- **#264** — `[elaborator] Quoted commodity with apostrophe in lot-cost context fails in wow.dat` — tracks the BinaryOperationTypeError root cause. Once fixed, wow.dat can be wired into POSITIVE and standard.dat (#256) can be re-evaluated.
- refs #197 (corpus expansion umbrella) — does NOT close it.
- refs #256 (standard.dat) — does NOT close it.

## Quality gates

- `cargo fmt --check`: passed
- `cargo clippy -- -D warnings`: passed
- `cargo test`: passed (8 unit + 8 doc tests)
- `python3 scripts/parity_check.py --negative`: passed (4/4)
- Positive parity: existing POSITIVE list unchanged; gate continues to pass (wow.dat not added).

## Test plan

- [ ] CI green on this branch
- [ ] Confirm wow.dat still NOT in POSITIVE (no parity regression)
- [ ] Negative parity cases still pass
- [ ] #264 is the actionable follow-up for the actual fix