### PR TITLE
fix(ledger,hledger): accept signed numbers in commodity-first amount form (#264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Signed numbers in commodity-first amount form** (#264): both the ledger-cli
+  and hledger frontends now accept amounts where the commodity precedes a signed
+  number, e.g. `"Beaststalker's Belt" -1` or `USD -1`.  Previously, the sign
+  was not part of the commodity-first grammar alternative, causing inputs like
+  `"Item" -1 {cost} @ price` to be mis-parsed as a binary subtraction
+  expression, which the elaborator then rejected with a type error.  The fix
+  extends the `amount` production with an optional `prefix_op?` between the
+  commodity and the number; the Rust handler applies the captured sign to the
+  number value, producing `Amount { value: -1, commodity: "..." }` as expected.
+
 ### Added
 
 - **`C N1 X = N2 Y` commodity-conversion directive** for the ledger-cli frontend (#248 stage 2).

--- a/crates/doppio/src/grammars/hledger/hledger.pest
+++ b/crates/doppio/src/grammars/hledger/hledger.pest
@@ -295,8 +295,14 @@ base_primary = _{
     | commodity
 }
 
+// An amount literal: commodity-prefixed, number-first, or bare number.
+//   "$100"       — symbol before number (no space required)
+//   "100 USD"    — identifier commodity after number (space required)
+//   "100"        — bare number (commodity filled in from context later)
+//   `"Foo" -1`   — quoted commodity before a signed number; `prefix_op?`
+//                  allows both `"Foo" -1` and `"Foo" - 1` (permissive whitespace).
 amount = ${
-    (commodity ~ ws* ~ number)
+    (commodity ~ ws* ~ prefix_op? ~ ws* ~ number)
     | (number ~ ws+ ~ commodity)
     | number
 }

--- a/crates/doppio/src/grammars/hledger/mod.rs
+++ b/crates/doppio/src/grammars/hledger/mod.rs
@@ -676,14 +676,28 @@ fn run_pratt(pairs: Pairs<Rule>) -> ValueExpr {
                 let mut inner = pair.into_inner();
                 let first = inner.next().unwrap();
                 match first.as_rule() {
+                    // Prefix-commodity form: "$100", `"Long Name" 5`, or `"Long Name" -1`
+                    // Inner sequence: commodity, then optional prefix_op, then number.
                     Rule::commodity => {
                         let comm = commodity_text(first);
-                        let val_str = inner.next().unwrap().as_str();
+                        let next = inner.next().unwrap();
+                        // Check whether the next token is a sign or the number directly.
+                        let (sign, val_str) = if next.as_rule() == Rule::prefix_op {
+                            let sign = next.as_str();
+                            let num_str = inner.next().unwrap().as_str();
+                            (sign, num_str)
+                        } else {
+                            // No prefix_op — next must be the number.
+                            ("+", next.as_str())
+                        };
+                        let magnitude = clean_decimal(val_str);
+                        let value = if sign == "-" { -magnitude } else { magnitude };
                         ValueExpr::Amount {
-                            value: clean_decimal(val_str),
+                            value,
                             commodity: Some(comm),
                         }
                     }
+                    // Number-first form: "100 USD", "5 \"Long Name\"", or bare "100"
                     Rule::number => {
                         let val = clean_decimal(first.as_str());
                         let comm = inner.next().map(commodity_text);
@@ -1685,6 +1699,100 @@ account Income          ; type:R
                 } if c == "Plans: Wildthorn Mail"
             ),
             "commodity should be unquoted; got: {value:?}"
+        );
+    }
+
+    // ---
+    // Signed commodity-first amount tests (#264) — hledger frontend
+    // ---
+
+    /// Quoted commodity with negative number: `"Foo" -1`.
+    #[test]
+    fn signed_commodity_first_negative() {
+        let input = r#""Foo" -1"#;
+        let mut pairs = HledgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(-1),
+                commodity: Some("Foo".into()),
+            }
+        );
+    }
+
+    /// Quoted commodity with explicit positive sign: `"Foo" +1`.
+    #[test]
+    fn signed_commodity_first_explicit_positive() {
+        let input = r#""Foo" +1"#;
+        let mut pairs = HledgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(1),
+                commodity: Some("Foo".into()),
+            }
+        );
+    }
+
+    /// Quoted commodity with negative decimal: `"Foo" -1.5`.
+    #[test]
+    fn signed_commodity_first_negative_decimal() {
+        let input = r#""Foo" -1.5"#;
+        let mut pairs = HledgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(-1.5),
+                commodity: Some("Foo".into()),
+            }
+        );
+    }
+
+    /// Bare (unquoted) commodity with negative number: `USD -1`.
+    #[test]
+    fn bare_commodity_first_negative() {
+        let input = "USD -1";
+        let mut pairs = HledgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(-1),
+                commodity: Some("USD".into()),
+            }
+        );
+    }
+
+    /// Regression: `"Foo" 5` (unsigned commodity-first) still parses correctly.
+    #[test]
+    fn signed_commodity_first_unsigned_regression() {
+        let input = r#""Foo" 5"#;
+        let mut pairs = HledgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(5),
+                commodity: Some("Foo".into()),
+            }
+        );
+    }
+
+    /// Regression: `5 USD` (number-first) still parses correctly.
+    #[test]
+    fn signed_number_first_regression() {
+        let input = "5 USD";
+        let mut pairs = HledgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(5),
+                commodity: Some("USD".into()),
+            }
         );
     }
 

--- a/crates/doppio/src/grammars/ledger/ledger.pest
+++ b/crates/doppio/src/grammars/ledger/ledger.pest
@@ -436,13 +436,15 @@ string = ${ "\"" ~ (!"\"" ~ ANY)* ~ "\"" }
 function_call = ${ identifier ~ ws* ~ "(" ~ ws* ~ (expr ~ (ws* ~ "," ~ ws* ~ expr)*)? ~ ws* ~ ")" }
 
 // An amount literal: commodity-prefixed, number-first, or bare number.
-//   "$100"      — symbol before number (no space required)
-//   "100 USD"   — identifier commodity after number (space required)
-//   "100"       — bare number (commodity filled in from context later)
+//   "$100"        — symbol before number (no space required)
+//   "100 USD"     — identifier commodity after number (space required)
+//   "100"         — bare number (commodity filled in from context later)
+//   `"Foo" -1`    — quoted commodity before a signed number (ledger-cli
+//                   accepts optional whitespace between sign and number)
 // The negative lookahead `!bool_op` in the number-first alternative prevents
 // `and`/`or` from being consumed as a commodity (e.g., `0 and` in `amount > 0 and`).
 amount = ${
-    (commodity ~ ws* ~ number)
+    (commodity ~ ws* ~ prefix_op? ~ ws* ~ number)
     | (number ~ ws+ ~ !bool_op ~ commodity)
     | (number ~ commodity)
     | number

--- a/crates/doppio/src/grammars/ledger/mod.rs
+++ b/crates/doppio/src/grammars/ledger/mod.rs
@@ -1103,12 +1103,24 @@ fn run_pratt(pairs: pest::iterators::Pairs<Rule>) -> ValueExpr {
                 let mut inner = pair.into_inner();
                 let first = inner.next().unwrap();
                 match first.as_rule() {
-                    // Prefix-commodity form: "$100" or `"Long Name" 5` -- commodity comes first
+                    // Prefix-commodity form: "$100", `"Long Name" 5`, or `"Long Name" -1`
+                    // Inner sequence: commodity, then optional prefix_op, then number.
                     Rule::commodity => {
                         let comm = commodity_text(first);
-                        let val_str = inner.next().unwrap().as_str();
+                        let next = inner.next().unwrap();
+                        // Check whether the next token is a sign or the number directly.
+                        let (sign, val_str) = if next.as_rule() == Rule::prefix_op {
+                            let sign = next.as_str();
+                            let num_str = inner.next().unwrap().as_str();
+                            (sign, num_str)
+                        } else {
+                            // No prefix_op — next must be the number.
+                            ("+", next.as_str())
+                        };
+                        let magnitude = clean_parse_decimal(val_str);
+                        let value = if sign == "-" { -magnitude } else { magnitude };
                         ValueExpr::Amount {
-                            value: clean_parse_decimal(val_str),
+                            value,
                             commodity: Some(comm),
                         }
                     }
@@ -1322,13 +1334,14 @@ mod tests {
         // Verify second posting (Negative with Commas)
         let p2 = &tx.postings[1];
         if let Some(details) = &p2.amount {
-            // This is interesting: depending on whether $-1234 or -$1234 is used,
-            // it might be a Unary(Amount) or an Amount with a negative number.
-            // Current grammar for `amount` + `prefix_op` makes this a Unary(Amount).
+            // `$-1,234.56` matches the commodity-first alternative with prefix_op:
+            // `(commodity ~ ws* ~ prefix_op? ~ ws* ~ number)` where `$` is the
+            // commodity, `-` is the prefix_op, and `1,234.56` is the number.
+            // Result: Amount { value: -1234.56, commodity: "$" }.
             assert!(matches!(
                 details,
                 AmountDetails::Amount {
-                    value: ValueExpr::Binary { .. },
+                    value: ValueExpr::Amount { .. },
                     ..
                 }
             ));
@@ -2227,7 +2240,152 @@ account Assets:Savings
         );
     }
 
-    /// Bare identifier commodities (regression: must still work after the
+    // ---
+    // Signed commodity-first amount tests (#264)
+    // ---
+
+    /// Quoted commodity with negative number: `"Foo" -1`.
+    #[test]
+    fn test_signed_commodity_first_negative() {
+        let input = r#""Foo" -1"#;
+        let mut pairs = LedgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(-1),
+                commodity: Some("Foo".into()),
+            }
+        );
+    }
+
+    /// Quoted commodity with explicit positive sign: `"Foo" +1`.
+    #[test]
+    fn test_signed_commodity_first_explicit_positive() {
+        let input = r#""Foo" +1"#;
+        let mut pairs = LedgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(1),
+                commodity: Some("Foo".into()),
+            }
+        );
+    }
+
+    /// Quoted commodity with negative decimal: `"Foo" -1.5`.
+    #[test]
+    fn test_signed_commodity_first_negative_decimal() {
+        let input = r#""Foo" -1.5"#;
+        let mut pairs = LedgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(-1.5),
+                commodity: Some("Foo".into()),
+            }
+        );
+    }
+
+    /// Bare (unquoted) commodity with negative number: `USD -1`.
+    #[test]
+    fn test_bare_commodity_first_negative() {
+        let input = "USD -1";
+        let mut pairs = LedgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(-1),
+                commodity: Some("USD".into()),
+            }
+        );
+    }
+
+    /// Regression: `"Foo" 5` (unsigned commodity-first) still parses correctly.
+    #[test]
+    fn test_signed_commodity_first_unsigned_regression() {
+        let input = r#""Foo" 5"#;
+        let mut pairs = LedgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(5),
+                commodity: Some("Foo".into()),
+            }
+        );
+    }
+
+    /// Regression: `-1 USD` (number-first with sign handled by Pratt) still works.
+    #[test]
+    fn test_signed_number_first_regression() {
+        let input = "-1 USD";
+        let mut pairs = LedgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        // `-1 USD` is parsed as Unary(-, Amount(1, USD)) by the Pratt parser.
+        assert_eq!(
+            expr,
+            ValueExpr::Unary {
+                op: crate::ast::Op::Sub,
+                expr: Box::new(ValueExpr::Amount {
+                    value: rust_decimal::dec!(1),
+                    commodity: Some("USD".into()),
+                }),
+            }
+        );
+    }
+
+    /// `"Foo" -1 {65G}` — quoted commodity with signed number and lot annotation
+    /// parses without error (the lot part is consumed by the posting-level grammar).
+    #[test]
+    fn test_signed_commodity_first_with_lot() {
+        // Parse the amount portion only (lot annotation is a posting-level construct).
+        let input = r#""Beaststalker's Belt" -1"#;
+        let mut pairs = LedgerParser::parse(Rule::value_expr, input).unwrap();
+        let expr = parse_expr(pairs.next().unwrap());
+        assert_eq!(
+            expr,
+            ValueExpr::Amount {
+                value: rust_decimal::dec!(-1),
+                commodity: Some("Beaststalker's Belt".into()),
+            }
+        );
+    }
+
+    /// Full wow.dat posting shape: `"Beaststalker's Belt" -1 {65G} @ 1195768c`
+    /// parses as a well-formed transaction without evaluation error.
+    #[test]
+    fn test_wow_dat_posting_shape() {
+        let input = concat!(
+            "2006/03/16 Auction House\n",
+            "    Assets:Tajer                      1195768c\n",
+            "    Assets:Tajer:Items                \"Beaststalker's Belt\" -1 {65G} @ 1195768c\n",
+            "    Income:Brokering                  -545768c\n",
+        );
+        let journal = parse_ledger(input).expect("wow.dat posting shape should parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!("expected transaction");
+        };
+        let details = tx.postings[1].amount.as_ref().expect("amount present");
+        let AmountDetails::Amount { value, .. } = details else {
+            panic!("expected Amount variant");
+        };
+        assert!(
+            matches!(
+                value,
+                ValueExpr::Amount {
+                    value: v,
+                    commodity: Some(c),
+                } if *v == rust_decimal::dec!(-1) && c == "Beaststalker's Belt"
+            ),
+            "expected Amount(-1, \"Beaststalker's Belt\"); got: {value:?}"
+        );
+    }
+
+    /// Bare (unquoted) identifier commodities (regression: must still work after the
     /// quoted-commodity alternative was added to the grammar).
     #[test]
     fn test_bare_commodity_regression() {


### PR DESCRIPTION
## Summary

- Extends the `amount` production in both `ledger.pest` and `hledger.pest` to accept an optional sign (`prefix_op?`) between the commodity and the number, enabling `"Item" -1`, `"Item" +1`, `USD -1`, and the full wow.dat shape `"Item" -1 {cost} @ price`.
- Updates both frontends' `Rule::amount` handlers to consume the optional `prefix_op` pair and negate the magnitude when the sign is `-`, producing `Amount { value: -1, commodity: "..." }`.
- Fixes a stale assertion in `test_complex_math_and_commas` that expected a `Binary` match for `$-1,234.56` — after this grammar fix it correctly parses as `Amount { value: -1234.56, commodity: "$" }`.

## wow.dat status

The grammar fix unblocks wow.dat parsing, but wow.dat still fails balance elaboration with `TransactionDoesNotBalance({"G": -65, "s": 6500.00})`. This is a second, unrelated gap in lot-cost elaboration via the C-directive chain. Tracked in #266. wow.dat is **not** wired into parity POSITIVE in this PR.

## Test plan

- [x] `"Foo" -1` parses as `Amount { value: -1, commodity: "Foo" }`
- [x] `"Foo" +1` parses as `Amount { value: 1, commodity: "Foo" }`
- [x] `"Foo" -1.5` parses as `Amount { value: -1.5, commodity: "Foo" }`
- [x] `USD -1` (bare commodity first) parses as `Amount { value: -1, commodity: "USD" }`
- [x] `"Beaststalker's Belt" -1 {65G} @ 1195768c` (full wow.dat shape) parses as a well-formed transaction
- [x] Regression: `"Foo" 5` still passes
- [x] Regression: `-1 USD` and `5 USD` (number-first) still pass
- [x] Mirror tests in hledger frontend
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` all pass (385 tests)
- [x] `cargo test --doc` all pass

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)