### PR TITLE
fix(elaborator): apply C-directive transitive chain via fixpoint (#266)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ### Fixed
 
+- **`C`-directive transitive chain (fixpoint) applied during balance verification** (#266):
+  PR #261 (#248 stage 2) implemented `C` commodity-conversion directives but omitted the
+  transitive-chain pass.  When `C 1.00s = 100c` and `C 1.00G = 100s` are both in scope,
+  a posting in `c` now elaborates all the way to `G` (divisor 10000), enabling
+  mixed-commodity transactions like `1G / -10000c` to balance correctly.  The fix adds an
+  eager fixpoint pass (`Context::resolve_commodity_conversion_chains`) that runs once per
+  `CommodityConversion` directive after it is inserted into the context: every entry is
+  rewritten to point directly at its chain root with the accumulated product divisor.
+  Cycles (`C 1X = 1Y; C 1Y = 1X`) are detected and surfaced as a new
+  `ResolutionError::CommodityConversionCycle` variant.  The #261 test that asserted
+  "no chaining" has been replaced with tests that assert correct chaining (2-hop, 3-hop)
+  and cycle detection.  `tests/parity/ledger-wow.dat` now elaborates without the
+  previous `TransactionDoesNotBalance({"G": -65, "s": 6500.00})` error; display-time
+  parity with ledger-cli's `bal` command is tracked separately.
+
 - **Signed numbers in commodity-first amount form** (#264): both the ledger-cli
   and hledger frontends now accept amounts where the commodity precedes a signed
   number, e.g. `"Beaststalker's Belt" -1` or `USD -1`.  Previously, the sign
@@ -23,8 +38,9 @@
   applied at elaboration time via the existing `commodity_conversions` map; aliases declared with
   `commodity X / alias Y` continue to use `divisor = Decimal::ONE` (a 1:1 rename, unchanged).
   The directive is context-versioned: transactions that precede a `C` directive in source order
-  are not retroactively affected.  **No chaining**: `C 1G = 100s` + `C 1s = 100c` converts
-  `c`-postings to `s` only (one hop), matching ledger-cli's observed behaviour.
+  are not retroactively affected.  Transitive chains (e.g. `c → s → G`) are resolved to the
+  chain root via an eager fixpoint pass; see #266 for the correction of #261's incomplete
+  single-hop implementation.
   Grammar addition: `number ~ commodity` (no-space number-first form, e.g. `1428c`) is now
   accepted in posting amounts, enabling wow.dat-style postings.
 

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -6345,15 +6345,125 @@ C 1.00s = 100c
         );
     }
 
-    /// Two-step chain: `C 1G = 100s` + `C 1s = 100c`.
+    /// 2-hop balance verification: `C 1G = 100s` + `C 1s = 100c`.
     ///
-    /// ledger-cli does NOT chain C directives transitively: 250c converts to
-    /// 2.50s (one hop) but NOT all the way to 0.025G.
-    /// Verified empirically.
+    /// A mixed-commodity transaction with one posting in G and one in c must
+    /// balance after the full transitive chain is applied.  Both postings in the
+    /// elaborated Journal are expressed in the chain root G.
+    ///
+    /// Chain: c → s → G (total divisor = 10000).
+    /// 10000c / 10000 = 1G.  The G posting is already at root.
     #[test]
-    fn test_c_directive_no_chaining() {
+    fn test_c_directive_chain_applied_for_balance_verification() {
         let input = "\
+C 1.00s = 100c
 C 1.00G = 100s
+
+2024-01-01 mixed
+  Assets:A   1G
+  Assets:B  -10000c
+";
+        let journal = elaborate(input);
+        assert_eq!(journal.transactions.len(), 1);
+        let tx = &journal.transactions[0];
+        let asset_a = tx
+            .postings
+            .iter()
+            .find(|p| p.account == "Assets:A")
+            .unwrap();
+        let asset_b = tx
+            .postings
+            .iter()
+            .find(|p| p.account == "Assets:B")
+            .unwrap();
+        // Assets:A is 1G (already at chain root).
+        assert_eq!(
+            asset_a.amount_in("G"),
+            Some(dec!(1)),
+            "Assets:A should be 1G"
+        );
+        // Assets:B: -10000c → -10000 / 10000 = -1G via the c→s→G chain.
+        assert_eq!(
+            asset_b.amount_in("G"),
+            Some(dec!(-1)),
+            "Assets:B should be -1G after 2-hop c→s→G conversion"
+        );
+    }
+
+    /// 3-hop balance verification: `C 1P = 10G` + `C 1G = 100s` + `C 1s = 100c`.
+    ///
+    /// Chain: c → s → G → P (total divisor = 100000).
+    /// 100000c / 100000 = 1P.
+    #[test]
+    fn test_c_directive_three_hop_chain() {
+        let input = "\
+C 1.00s = 100c
+C 1.00G = 100s
+C 1.00P = 10G
+
+2024-01-01 mixed
+  Assets:A   1P
+  Assets:B  -100000c
+";
+        let journal = elaborate(input);
+        assert_eq!(journal.transactions.len(), 1);
+        let tx = &journal.transactions[0];
+        let asset_a = tx
+            .postings
+            .iter()
+            .find(|p| p.account == "Assets:A")
+            .unwrap();
+        let asset_b = tx
+            .postings
+            .iter()
+            .find(|p| p.account == "Assets:B")
+            .unwrap();
+        // Assets:A is 1P (already at chain root).
+        assert_eq!(
+            asset_a.amount_in("P"),
+            Some(dec!(1)),
+            "Assets:A should be 1P"
+        );
+        // Assets:B: -100000c resolves via c→s→G→P (divisor = 100000) = -1P.
+        assert_eq!(
+            asset_b.amount_in("P"),
+            Some(dec!(-1)),
+            "Assets:B should be -1P after 3-hop c→s→G→P conversion"
+        );
+    }
+
+    /// Cycle detection: `C 1X = 1Y` + `C 1Y = 1X` must produce a
+    /// `ResolutionError::CommodityConversionCycle`.
+    #[test]
+    fn test_c_directive_cycle_detection() {
+        use crate::{grammars::ledger::parse_ledger, resolution::HIR};
+        let input = "\
+C 1.00X = 1Y
+C 1.00Y = 1X
+
+2024-01-01 t
+  Assets:A  1X
+  Equity
+";
+        let ast = parse_ledger(input).expect("parse should succeed");
+        let err = HIR::try_from(ast).expect_err("cycle should be detected at resolution time");
+        assert!(
+            matches!(
+                err,
+                crate::resolution::ResolutionError::CommodityConversionCycle(_)
+            ),
+            "expected CommodityConversionCycle, got: {err:?}"
+        );
+    }
+
+    /// Single-hop happy path (regression of #261's basic case).
+    ///
+    /// `C 1.00s = 100c` with a posting of 250c resolves to 2.50s.
+    /// (Already covered by `test_c_directive_c_to_s`; this is an explicit
+    /// guard that the fixpoint does not break the 1-hop case.)
+    #[test]
+    fn test_c_directive_single_hop_regression() {
+        let input = "\
 C 1.00s = 100c
 
 2024-01-01 Test
@@ -6367,17 +6477,10 @@ C 1.00s = 100c
             .iter()
             .find(|p| p.account == "Assets:Cash")
             .unwrap();
-        // ledger-cli: 250c -> 2.50s (stops at first hop; does NOT chain to G).
         assert_eq!(
             cash.amount_in("s"),
             Some(dec!(2.50)),
-            "C directives do not chain: 250c should convert to 2.50s, not 0.025G"
-        );
-        // Must NOT appear as G.
-        assert_eq!(
-            cash.amount_in("G"),
-            None,
-            "no G amount expected when conversion stops at s"
+            "single-hop: 250c / 100 should be 2.50s"
         );
     }
 

--- a/crates/doppio/src/resolution.rs
+++ b/crates/doppio/src/resolution.rs
@@ -153,6 +153,66 @@ pub struct Context {
     pub(crate) defines: BTreeMap<String, Define>,
 }
 
+impl Context {
+    /// Run a fixpoint pass over `commodity_conversions`, transitively resolving
+    /// every entry to its chain root.
+    ///
+    /// After this pass each entry `(Y, (root, total_divisor))` satisfies:
+    /// `root` either is not itself a key in `commodity_conversions` (true chain
+    /// root), or is a self-loop sentinel `root == root` (canonical commodity
+    /// that is already expressed in itself, with a divisor for unit normalisation).
+    /// The divisor accumulates multiplicatively along the chain so that
+    /// `amount_in_Y / total_divisor == amount_in_root`.
+    ///
+    /// Cycles (`C 1X = 1Y; C 1Y = 1X`) are detected via a hop-count limit equal
+    /// to the map's length: if we take more hops than there are entries, we must
+    /// be in a cycle. The commodity that triggered the cycle is returned as an
+    /// error.
+    ///
+    /// This is called once per `CommodityConversion` directive (eager/resolution-time
+    /// fixpoint, as required by #266 design constraint A).
+    pub(crate) fn resolve_commodity_conversion_chains(&mut self) -> Result<(), ResolutionError> {
+        let max_hops = self.commodity_conversions.len();
+        // Collect all commodity keys first to avoid borrow conflicts.
+        let keys: Vec<String> = self.commodity_conversions.keys().cloned().collect();
+        for start in keys {
+            // Walk the chain from `start` until we reach a root.
+            //
+            // A root is either:
+            //   (a) a commodity that is NOT a key in the map (truly external root), or
+            //   (b) a self-loop sentinel: (X, (X, d)) — canonical commodity X maps to
+            //       itself with normalisation divisor d.
+            //
+            // In either case we stop and accumulate the final divisor.
+            let mut hops = 0usize;
+            let mut current = start.clone();
+            let mut total_divisor = rust_decimal::Decimal::ONE;
+
+            // Walk the chain until we hit a root (commodity not in the map)
+            // or a self-loop sentinel (commodity maps to itself).
+            while let Some((next, divisor)) = self.commodity_conversions.get(&current).cloned() {
+                total_divisor *= divisor;
+                if next == current {
+                    // Self-loop sentinel: this is the chain root; stop.
+                    break;
+                }
+                current = next;
+                hops += 1;
+                if hops > max_hops {
+                    return Err(ResolutionError::CommodityConversionCycle(start));
+                }
+            }
+
+            // Rewrite the entry for `start` to point directly at the chain root
+            // with the accumulated total divisor.
+            if let Some(entry) = self.commodity_conversions.get_mut(&start) {
+                *entry = (current, total_divisor);
+            }
+        }
+        Ok(())
+    }
+}
+
 /// A resolved `define` entry, carrying parameter names and the macro body.
 #[derive(Debug, Clone)]
 pub(crate) struct Define {
@@ -777,6 +837,13 @@ pub enum ResolutionError {
     /// An automated transaction rule's query string could not be compiled
     /// as a regex. Carries the raw query and the underlying regex error.
     InvalidAutoRuleQuery(String, String),
+    /// A cycle was detected among `C` commodity-conversion directives.
+    ///
+    /// The carried string names one commodity that participates in the cycle
+    /// (e.g. `"X"` when `C 1X = 1Y` and `C 1Y = 1X` are both in scope).
+    /// Chains like `c → s → G` are valid and are fully resolved to the chain
+    /// root; a cycle has no root and cannot be resolved.
+    CommodityConversionCycle(String),
 }
 
 impl std::fmt::Display for ResolutionError {
@@ -787,6 +854,13 @@ impl std::fmt::Display for ResolutionError {
             }
             ResolutionError::InvalidAutoRuleQuery(query, err) => {
                 write!(f, "Invalid auto-rule query `{query}`: {err}")
+            }
+            ResolutionError::CommodityConversionCycle(commodity) => {
+                write!(
+                    f,
+                    "Cycle detected in C commodity-conversion directives \
+                     involving commodity `{commodity}`"
+                )
             }
         }
     }
@@ -1134,23 +1208,43 @@ impl TryFrom<ast::Journal> for HIR {
                     //     — scales postings already in the canonical commodity by N1
                     //     (empirically: C 100c = 1s, posting 250c -> 2.5c)
                     //
-                    // ledger-cli does NOT chain C directives (c -> s -> G does NOT
-                    // produce a c -> G entry); each entry is a direct single-hop mapping.
+                    // After inserting, we run a fixpoint pass that transitively
+                    // resolves all chains to their root commodity (fix for #266).
+                    // For example, with `C 1s = 100c` and `C 1G = 100s` in scope,
+                    // the `c` entry resolves all the way to G (divisor = 10000),
+                    // so a posting in `c` will elaborate directly to G.
+                    //
+                    // Cycles (C 1X = 1Y; C 1Y = 1X) are detected and surfaced as
+                    // ResolutionError::CommodityConversionCycle.
                     let divisor = lhs.value * rhs.value;
-                    new_context =
-                        Some(new_context.unwrap_or_else(|| context.clone())).map(|mut ctx| {
-                            // RHS commodity -> LHS canonical with product divisor.
-                            ctx.commodity_conversions
-                                .entry(rhs.commodity.clone())
-                                .or_insert_with(|| (lhs.commodity.clone(), divisor));
-                            // LHS commodity -> itself, scaled by N1 only.
-                            // This handles the "posting in canonical" case, e.g.
-                            // `C 100c = 1s` with `250c` posting -> `2.50c`.
-                            ctx.commodity_conversions
-                                .entry(lhs.commodity.clone())
-                                .or_insert_with(|| (lhs.commodity.clone(), lhs.value));
-                            ctx
-                        });
+                    let mut ctx = new_context.unwrap_or_else(|| context.clone());
+                    // RHS commodity -> LHS canonical with product divisor.
+                    //
+                    // Use `insert` (overwrite) so that a later directive like
+                    // `C 1G = 100s` correctly updates s's entry to point at G,
+                    // even if s was previously inserted as a self-loop sentinel
+                    // by an earlier directive (`C 1s = 100c` inserts s→(s,1)).
+                    ctx.commodity_conversions
+                        .insert(rhs.commodity.clone(), (lhs.commodity.clone(), divisor));
+                    // LHS commodity -> itself, scaled by N1 only (self-loop sentinel).
+                    //
+                    // This handles the "posting in canonical" case, e.g.
+                    // `C 100c = 1s` with `250c` posting -> `2.50c`.
+                    //
+                    // Use `entry(...).or_insert_with` so a more specific
+                    // canonical-resolution inserted by an earlier directive is
+                    // not overwritten: if `s` is already resolved (e.g. because
+                    // `C 1s = 100c` ran first and s→(s,1) is set, then
+                    // `C 1G = 100s` runs and updates s→(G,100) via the rhs insert
+                    // above), the lhs self-loop insert here is a no-op for
+                    // entries that already have a non-self-loop target.
+                    ctx.commodity_conversions
+                        .entry(lhs.commodity.clone())
+                        .or_insert_with(|| (lhs.commodity.clone(), lhs.value));
+                    // Run the transitive fixpoint: chain c -> s -> G becomes
+                    // c -> G directly (with product divisor).  Cycles error out.
+                    ctx.resolve_commodity_conversion_chains()?;
+                    new_context = Some(ctx);
                 }
             }
 

--- a/docs/SUPPORTED_FEATURES.md
+++ b/docs/SUPPORTED_FEATURES.md
@@ -89,7 +89,7 @@ Status legend:
 | `~` budget / periodic directive | ~ | Parsed but not elaborated (intentional parse-and-discard). No effect on balances or reports |
 | `= query` automated transaction rules | + | v2.1.0 (#249). Body postings synthesized as `PostingKind::VirtualUnbalanced`. Bare decimal amounts act as multipliers of the matched posting's commodity amount; amounts with an explicit commodity symbol are literal. Query strings: `/pattern/` → regex, bare string → case-insensitive substring match |
 | Explicit `*N` multiplier syntax in rule bodies | + | (#254). `*N`, `*-1`, `* 0.5` etc. in auto-rule body posting amounts are accepted and lower to the same bare-number multiplier as a plain bare decimal |
-| `C N1 X = N2 Y` commodity-conversion directive | + | (#248 stage 2). X (LHS) is the canonical commodity; Y (RHS) postings divide by `N1 * N2` to yield X-equivalent amounts. Divisor is empirically confirmed against ledger-cli. No chaining: `C 1G = 100s` + `C 1s = 100c` converts `c` to `s` (one hop), not all the way to `G`. |
+| `C N1 X = N2 Y` commodity-conversion directive | + | (#248 stage 2, #266). X (LHS) is the canonical commodity; Y (RHS) postings divide by `N1 * N2` to yield X-equivalent amounts. Divisor is empirically confirmed against ledger-cli. Transitive chains are resolved to the chain root via an eager fixpoint pass: `C 1s = 100c` + `C 1G = 100s` converts `c`-postings all the way to `G` (divisor 10000). Cycles (`C 1X = 1Y; C 1Y = 1X`) surface as `ResolutionError::CommodityConversionCycle` at resolution time. |
 
 ## Expression language
 


### PR DESCRIPTION
## Summary

- PR #261 (refs #248 stage 2) shipped `C`-directive support with single-hop resolution only. The `test_c_directive_no_chaining` test asserted "no chaining" based on a display-time observation against ledger-cli's `bal` command — but ledger-cli **does** apply the full transitive chain for balance verification. That test was wrong and is removed.
- This PR adds `Context::resolve_commodity_conversion_chains`: an eager fixpoint pass that runs once per `CommodityConversion` directive. After processing, every entry in `commodity_conversions` maps directly to its chain root with the accumulated product divisor. A posting of `10000c` with `C 1s = 100c; C 1G = 100s` in scope now elaborates to `1G`.
- Cycle detection (`C 1X = 1Y; C 1Y = 1X`) surfaces as the new `ResolutionError::CommodityConversionCycle` variant. `ResolutionError` is already `#[non_exhaustive]` (refs #255), so this is additive.
- `tests/parity/ledger-wow.dat` now elaborates without the previous `TransactionDoesNotBalance({"G": -65, "s": 6500.00})` error. Display-time parity diverges (ledger-cli's `bal` canonicalises one hop at display; doppio canonicalises to chain root at library level — a deliberate design choice). wow.dat is not added to POSITIVE yet; that divergence is tracked separately.

This corrects refs #261's incomplete implementation and closes #266.

## Test plan

- [x] **2-hop balance verification** (`test_c_directive_chain_applied_for_balance_verification`): `1G` and `-10000c` with `C 1s = 100c; C 1G = 100s` both elaborate to G and the transaction balances
- [x] **3-hop balance verification** (`test_c_directive_three_hop_chain`): `1P` and `-100000c` with three `C` directives balance as `P`
- [x] **Cycle detection** (`test_c_directive_cycle_detection`): `C 1X = 1Y; C 1Y = 1X` returns `ResolutionError::CommodityConversionCycle` at resolution time
- [x] **Single-hop regression** (`test_c_directive_single_hop_regression`): `C 1s = 100c` with `250c` still gives `2.50s`
- [x] **Alias regression** (`test_alias_divisor_one_regression`): `commodity BTC / alias Bitcoin` still 1:1 renames with no scaling
- [x] **wow.dat elaboration**: `dop balance tests/parity/ledger-wow.dat` completes without error
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — 388 lib tests pass; 0 failures
- [x] `python3 scripts/parity_check.py --negative` — 4/4 pass

Closes #266