### PR TITLE
test(parity): canonicalise via ledger -X for chain-root fixtures; wire wow.dat in (#269)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,18 @@
 
 ### Test infrastructure
 
+- **Parity harness canonicalisation via `-X` flag** (refs #269, refs #197):
+  `scripts/parity_check.py` gains a `canonical_commodity` field on `Case` and
+  passes `-X <commodity>` to ledger-cli when that field is set.  This makes
+  ledger-cli report balances in the chain-root commodity so the comparison is
+  semantic (same value, same unit) rather than display-level (same commodity
+  string).  The design follows option A from #269: canonicalise on the
+  harness/ledger-cli side rather than adding a CLI display flag to doppio.
+  `ledger:wow` could not be wired into POSITIVE in this PR because a residual
+  semantic gap between doppio's elaboration and ledger-cli's balance reporting
+  remains after commodity canonicalisation (lot-bearing accounts and cross-rate
+  amounts diverge); the gap is tracked as a follow-up.
+
 - **Vendor `tests/parity/ledger-drewr3.dat`** (refs #257, refs #197): the
   ledger-cli upstream `test/input/drewr3.dat` fixture is vendored with a
   provenance comment block (source URL, commit SHA, license, exercises). It is

--- a/scripts/parity_check.py
+++ b/scripts/parity_check.py
@@ -144,7 +144,7 @@ def _parse_ledger_amount(s: str) -> tuple[str, Decimal]:
     raise ValueError(f"no commodity in {s!r}")
 
 
-def ledger_balances(fixture: Path) -> set[Tuple3]:
+def ledger_balances(fixture: Path, canonical: str | None = None) -> set[Tuple3]:
     """Parse ledger-cli's flat balance output via a `--format` template.
 
     Multi-commodity accounts emit a `Account|amount` line followed by one
@@ -160,18 +160,27 @@ def ledger_balances(fixture: Path) -> set[Tuple3]:
     (e.g. drewr3.dat's `Assets:Checking` with a child
     `Assets:Checking:Business`). `amount` gives the apples-to-apples
     comparison without taking a position on doppio's `--flat` UX
-    (direct-only vs subtree-aggregated), which is a separate question."""
+    (direct-only vs subtree-aggregated), which is a separate question.
+
+    When `canonical` is set to a chain-root commodity symbol (e.g. ``"G"``),
+    ``-X <canonical>`` is passed to ledger-cli so that it converts all
+    balances to that commodity using the active ``C``-directive chain.  This
+    makes ledger-cli's output comparable to doppio's library-level
+    canonicalisation, which always resolves to the chain root (#269)."""
+    cmd = [
+        "ledger",
+        "-f", str(fixture),
+        "balance",
+        "--flat",
+        "--no-pager",
+        "--no-color",
+        "--no-total",
+        "--format=%(account)|%(scrub(amount))\n",
+    ]
+    if canonical is not None:
+        cmd.extend(["-X", canonical])
     raw = subprocess.run(
-        [
-            "ledger",
-            "-f", str(fixture),
-            "balance",
-            "--flat",
-            "--no-pager",
-            "--no-color",
-            "--no-total",
-            "--format=%(account)|%(scrub(amount))\n",
-        ],
+        cmd,
         capture_output=True,
         text=True,
         check=True,
@@ -851,6 +860,7 @@ class Case:
     fixture: Path
     canonical: CanonicalFn
     canonical_args: dict | None = None  # for canonicals that need extra args
+    canonical_commodity: str | None = None  # chain-root commodity for -X canonicalisation
 
 
 POSITIVE: list[Case] = [
@@ -927,9 +937,12 @@ def diff_sets(canonical: set[Tuple3], doppio: set[Tuple3]) -> str | None:
 def run_positive(case: Case, dop_bin: Path) -> bool:
     print(f"  [{case.label}] {case.fixture.name}", end=" ... ", flush=True)
     # Phase 0: balance equality (the original parity check, #196).
-    canonical = case.canonical(case.fixture)
+    if case.canonical_commodity is not None:
+        canonical_bal = case.canonical(case.fixture, canonical=case.canonical_commodity)
+    else:
+        canonical_bal = case.canonical(case.fixture)
     doppio = doppio_balances(case.fixture, dop_bin)
-    bal_diff = diff_sets(canonical, doppio)
+    bal_diff = diff_sets(canonical_bal, doppio)
 
     # Phase 1: per-transaction tags + metadata (#226). Skipped for ledger-cli
     # since its native output doesn't expose tags structurally.


### PR DESCRIPTION
## Summary

- Adds `canonical_commodity: str | None` to the `Case` dataclass in `scripts/parity_check.py`. When set, the harness passes `-X <commodity>` to ledger-cli so it reports balances in the chain-root commodity, matching doppio's library-level canonicalisation-to-chain-root. Existing cases without `canonical_commodity` are unaffected.
- Extends `ledger_balances(fixture, canonical=None)` to build the command list conditionally and append `-X <canonical>` when the parameter is provided.
- Threads `case.canonical_commodity` through `run_positive` to the balance extractor call.

## Design tradeoff

This implements **option A** from #269: canonicalise on the harness/ledger-cli side rather than adding a display-style flag to doppio. Option B (a `--canonical-style=ledger-cli` CLI flag) would conflate library semantics with display style and add API surface; option A keeps the library/CLI separation clean and makes parity compare semantics rather than commodity strings.

## Status of `ledger:wow`

`ledger:wow` is **not wired into POSITIVE in this PR**. After applying `-X G`, the comparison still diverges:

1. `Expenses:Fees:Mail` stays as `29.10s` in ledger-cli output (the transitive `s→G` conversion is not applied by `-X`), while doppio reports `0.291G`.
2. Numeric amounts differ: `Assets:Tajer` is `147.82G` (ledger-cli) vs `200.8220G` (doppio); `Expenses:Items` is `69.45G` vs `16.445G`.
3. Ledger-cli emits lot-annotated items as `"Orb of Deception" 1` (unconvertible), which the harness `_parse_ledger_amount` regex does not handle.

This is a deeper semantic gap, tracked in #270. The harness infrastructure ships now so fixtures using single-hop `C`-directive chains can already use `canonical_commodity`.

Closes #269

refs #197
refs #270

## Test plan

- [x] `python3 scripts/parity_check.py --self-test` — 12/12 comparator assertions held
- [x] `python3 scripts/parity_check.py --negative` — all 4 negative controls pass
- [x] `python3 scripts/parity_check.py` — all 18 positive cases pass (beancount requires `pip install beancount==3.2.0`, ledger/hledger cases verified locally)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — all tests pass