### PR TITLE
fix(ledger): try (expr) before (bool_expr) in base_primary; parenthesised arithmetic now correct (#272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### Fixed
 
+- **Parenthesised expressions in posting amounts now evaluate correctly** (#272):
+  A pre-existing grammar bug (present since pre-1.0, commit `8a5661b7`) caused any
+  parenthesised expression in a ledger posting amount — such as `(9G * 6)` or `(54G)` —
+  to silently evaluate to `1` (for any non-zero value) or `0`, instead of the actual value.
+  The root cause was that `base_primary` in `ledger.pest` tried the `(bool_expr)` alternative
+  *before* `(expr)`.  Because `bool_expr` accepts a bare `value_expr` (the comparison is
+  optional), `(54G)` matched `(bool_expr)` first, producing a `Group(BoolExpr)` AST node
+  that the evaluator correctly reduces to `1` (true) or `0` (false) — but wrong for
+  arithmetic.  The fix swaps the order so `(expr)` is tried first; real boolean expressions
+  like `(amt > 0)` contain `>` which is not an `infix_op`, so pest backtracks to
+  `(bool_expr)` and existing assert/filter usage is unaffected.  Any journal using
+  parenthesised arithmetic in posting amounts (`($a + $b)`, `(price * qty)`, `(total / N)`)
+  was silently computing wrong balances; the fix restores correct numeric output.
+
 - **`C`-directive transitive chain (fixpoint) applied during balance verification** (#266):
   PR #261 (#248 stage 2) implemented `C` commodity-conversion directives but omitted the
   transitive-chain pass.  When `C 1.00s = 100c` and `C 1.00G = 100s` are both in scope,

--- a/crates/doppio/src/grammars/ledger/ledger.pest
+++ b/crates/doppio/src/grammars/ledger/ledger.pest
@@ -420,8 +420,8 @@ base_primary = _{
     function_call
     | amount
     | string
-    | "(" ~ bool_expr ~ ")"
     | "(" ~ expr ~ ")"
+    | "(" ~ bool_expr ~ ")"
     | commodity
 }
 

--- a/crates/doppio/src/grammars/ledger/mod.rs
+++ b/crates/doppio/src/grammars/ledger/mod.rs
@@ -1152,8 +1152,9 @@ fn run_pratt(pairs: pest::iterators::Pairs<Rule>) -> ValueExpr {
                 ValueExpr::Str(s[1..s.len() - 1].to_string())
             }
             // A parenthesised bool_expr in a value-expression context.
-            // base_primary tries bool_expr before expr, so comparisons/chains
-            // inside parens land here rather than as mis-parsed arithmetic.
+            // base_primary tries expr first, then bool_expr as a fallback.
+            // Comparisons/chains inside parens that fail expr (e.g. `amt > 0`)
+            // backtrack here and produce a Group node.
             Rule::bool_expr => ValueExpr::Group(Box::new(parse_bool_expr(pair))),
             _ => unreachable!("{:?}", pair.as_rule()),
         })
@@ -2003,6 +2004,8 @@ account Assets:Savings
             panic!("expected transaction");
         };
         // The amount should be a Typed (or Binary) expr, not a Group.
+        // (expr) is tried first in base_primary, so `(100 + 200)` lands in expr
+        // before bool_expr ever sees it.
         let details = tx.postings[0].amount.as_ref().unwrap();
         assert!(
             matches!(
@@ -2014,6 +2017,201 @@ account Assets:Savings
             ),
             "expected Typed or Binary, got {details:?}"
         );
+    }
+
+    // ---
+    // Regression tests for issue #272: parenthesised arithmetic in posting amounts
+    // ---
+
+    /// `(54G)` — bare parenthesised amount must produce `54G`, not `1G`.
+    /// Before the fix, `(54G)` matched `(bool_expr)` first, and the evaluator
+    /// converted the non-zero result to `Amount { value: 1, .. }`.
+    #[test]
+    fn test_paren_amount_no_arithmetic() {
+        let input = "2024-01-01 Test\n    Expenses:Items  (54G)\n    Assets:Bar\n";
+        let journal = parse_ledger(input).expect("should parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!("expected transaction");
+        };
+        let details = tx.postings[0].amount.as_ref().expect("amount present");
+        // After the fix, `(54G)` resolves through `(expr)`, so the inner node
+        // is Amount, not Group.
+        assert!(
+            !matches!(
+                details,
+                AmountDetails::Amount {
+                    value: ValueExpr::Group(_),
+                    ..
+                }
+            ),
+            "expected non-Group amount, got {details:?}"
+        );
+        assert!(
+            matches!(
+                details,
+                AmountDetails::Amount {
+                    value: ValueExpr::Amount { .. },
+                    ..
+                }
+            ),
+            "expected Amount variant, got {details:?}"
+        );
+    }
+
+    /// `(9G * 6)` — parenthesised multiplication must produce a Binary node,
+    /// not a Group (which the evaluator would coerce to `0` or `1`).
+    #[test]
+    fn test_paren_amount_multiply() {
+        let input = "2024-01-01 Test\n    Expenses:Items  (9G * 6)\n    Assets:Bar\n";
+        let journal = parse_ledger(input).expect("should parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!("expected transaction");
+        };
+        let details = tx.postings[0].amount.as_ref().expect("amount present");
+        assert!(
+            !matches!(
+                details,
+                AmountDetails::Amount {
+                    value: ValueExpr::Group(_),
+                    ..
+                }
+            ),
+            "expected non-Group amount, got {details:?}"
+        );
+        assert!(
+            matches!(
+                details,
+                AmountDetails::Amount {
+                    value: ValueExpr::Binary { .. },
+                    ..
+                }
+            ),
+            "expected Binary expr, got {details:?}"
+        );
+    }
+
+    /// `(27G + 27G)` — parenthesised addition must produce a Binary node.
+    #[test]
+    fn test_paren_amount_add() {
+        let input = "2024-01-01 Test\n    Expenses:Items  (27G + 27G)\n    Assets:Bar\n";
+        let journal = parse_ledger(input).expect("should parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!("expected transaction");
+        };
+        let details = tx.postings[0].amount.as_ref().expect("amount present");
+        assert!(
+            matches!(
+                details,
+                AmountDetails::Amount {
+                    value: ValueExpr::Binary { op: Op::Add, .. },
+                    ..
+                }
+            ),
+            "expected Binary(Add), got {details:?}"
+        );
+    }
+
+    /// `(108G / 2)` — parenthesised division must produce a Binary node.
+    #[test]
+    fn test_paren_amount_divide() {
+        let input = "2024-01-01 Test\n    Expenses:Items  (108G / 2)\n    Assets:Bar\n";
+        let journal = parse_ledger(input).expect("should parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!("expected transaction");
+        };
+        let details = tx.postings[0].amount.as_ref().expect("amount present");
+        assert!(
+            matches!(
+                details,
+                AmountDetails::Amount {
+                    value: ValueExpr::Binary { op: Op::Div, .. },
+                    ..
+                }
+            ),
+            "expected Binary(Div), got {details:?}"
+        );
+    }
+
+    /// `(0)` — parenthesised zero must remain a zero Amount, not coerce to
+    /// a bool Group that evaluates to `0` via the "false" path.
+    #[test]
+    fn test_paren_zero_stays_zero() {
+        let input = "2024-01-01 Test\n    Expenses:Items  (0)\n    Assets:Bar\n";
+        let journal = parse_ledger(input).expect("should parse");
+        let Entry::Transaction(tx) = &journal.entries[0] else {
+            panic!("expected transaction");
+        };
+        let details = tx.postings[0].amount.as_ref().expect("amount present");
+        assert!(
+            !matches!(
+                details,
+                AmountDetails::Amount {
+                    value: ValueExpr::Group(_),
+                    ..
+                }
+            ),
+            "expected non-Group for (0), got {details:?}"
+        );
+    }
+
+    /// Bool regression: `(amt > 0)` in an assert must still produce a `Group`
+    /// wrapping a real `BoolExpr` with a comparison.  The `(expr)` alternative
+    /// fails on `>` (not in `infix_op`) and pest backtracks to `(bool_expr)`.
+    #[test]
+    fn test_paren_bool_expr_in_assert_still_works() {
+        let input = "account Assets:Savings\n    assert (amount > 0)\n";
+        let journal = parse_ledger(input).expect("should parse");
+        let Entry::Directive(Directive::Account { items, .. }) = &journal.entries[0] else {
+            panic!("expected Account directive");
+        };
+        let AccountItem::Assert(expr) = items
+            .iter()
+            .find(|i| matches!(i, AccountItem::Assert(_)))
+            .unwrap()
+        else {
+            unreachable!()
+        };
+        assert!(
+            matches!(expr.lhs, ValueExpr::Group(_)),
+            "expected Group for (amount > 0), got {:?}",
+            expr.lhs
+        );
+        // The Group must wrap a real comparison, not a trivial value_expr.
+        if let ValueExpr::Group(inner) = &expr.lhs {
+            assert!(
+                inner.cmp.is_some(),
+                "expected cmp in inner BoolExpr, got None"
+            );
+        }
+    }
+
+    /// Bool regression with `and`: `(amt > 0 and amt2 < 10)` in an assert
+    /// must survive as a Group wrapping a chained BoolExpr.
+    #[test]
+    fn test_paren_bool_expr_and_in_assert_still_works() {
+        let input = "account Assets:Savings\n    assert (amount > 0 and amount < 10)\n";
+        let journal = parse_ledger(input).expect("should parse");
+        let Entry::Directive(Directive::Account { items, .. }) = &journal.entries[0] else {
+            panic!("expected Account directive");
+        };
+        let AccountItem::Assert(expr) = items
+            .iter()
+            .find(|i| matches!(i, AccountItem::Assert(_)))
+            .unwrap()
+        else {
+            unreachable!()
+        };
+        assert!(
+            matches!(expr.lhs, ValueExpr::Group(_)),
+            "expected Group for (amount > 0 and amount < 10), got {:?}",
+            expr.lhs
+        );
+        if let ValueExpr::Group(inner) = &expr.lhs {
+            assert!(
+                inner.chain.is_some(),
+                "expected bool chain in Group, got None"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This is a 2-line grammar fix for a pre-existing latent bug (present since pre-1.0, commit `8a5661b7`, 2026-04-27; shipped in v1.0.0 and v2.0.0) where any parenthesised expression in a ledger posting amount silently evaluated to `0` or `1` instead of the actual value.

**Root cause:** `base_primary` in `ledger.pest` ordered `(bool_expr)` *before* `(expr)`. Since `bool_expr` accepts a bare `value_expr` with an optional comparison suffix, `(54G)` matched `(bool_expr)` first and produced a `Group(BoolExpr)` AST node — which the evaluator correctly reduces to `1` (true) or `0` (false), but wrong for arithmetic amounts.

**Fix:** Swap the two alternatives so `(expr)` is tried first. Real boolean expressions like `(amt > 0)` contain `>` which is not an `infix_op`, so pest backtracks to `(bool_expr)` — existing `assert` / define-body / filter bool-expr usage is fully preserved.

| Input | Before | After | ledger-cli |
|-------|--------|-------|------------|
| `(54G)` | `1G` | `54G` | `54G` |
| `(9G * 6)` | `1G` | `54G` | `54G` |
| `(27G + 27G)` | `1G` | `54G` | `54G` |
| `(108G / 2)` | `1G` | `54G` | `54G` |
| `(0)` | `0G` | `0G` | `0G` |
| `(amount > 0)` in assert | `Group(cmp)` | `Group(cmp)` | n/a |

`wow.dat` verification: `Assets:Tajer` now reports `147.8220G` (matches ledger-cli's `147.82G`).

Closes #272

## Test plan

- [ ] `test_paren_amount_no_arithmetic` — `(54G)` produces `Amount`, not `Group`
- [ ] `test_paren_amount_multiply` — `(9G * 6)` produces `Binary`
- [ ] `test_paren_amount_add` — `(27G + 27G)` produces `Binary(Add)`
- [ ] `test_paren_amount_divide` — `(108G / 2)` produces `Binary(Div)`
- [ ] `test_paren_zero_stays_zero` — `(0)` produces non-Group
- [ ] `test_paren_bool_expr_in_assert_still_works` — `(amount > 0)` in assert still yields `Group` with real comparison
- [ ] `test_paren_bool_expr_and_in_assert_still_works` — `(amount > 0 and amount < 10)` still yields `Group` with chain
- [ ] All pre-existing bool_expr tests (`test_paren_bool_expr_simple`, `test_paren_bool_expr_or_chain_inside_parens`, `test_paren_bool_nested_parens`, `test_define_body_paren_bool_expr`, `test_issue_89_failing_input`) pass unchanged
- [ ] `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test --workspace` all pass
- [ ] Negative parity check passes; positive parity check not runnable in CI (no `ledger`/`hledger` binaries available)
- [ ] Note: refs #270, #197 for remaining wow.dat display-parity gaps (not addressed here)