### PR TITLE
chore: cut v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-05-08
+
+This release lands `C` commodity-conversion directive support (#248) with a
+correct transitive-chain fixpoint (#266) and principled divisor formula
+(#274), automated transaction rules with multiplier semantics (#249) and the
+explicit `*N` form (#254), implicit cost-basis inference for two-leg
+multi-commodity transactions (#251), double-quoted commodity names (#262),
+signed commodity-first amounts (#264), and a fix for a pre-1.0 latent
+parens-in-amount silent-miscomputation bug (#272). Plus parity-corpus
+expansion (drewr3.dat, wow.dat) and harness extensions.
+
+The library API is additive: `ResolutionError` gains
+`InvalidAutoRuleQuery`, `InvalidCommodityConversion`, and
+`CommodityConversionCycle` variants (the enum was already
+`#[non_exhaustive]` post-2.0); `ElaborationConfig` gains
+`infer_implicit_total_cost`. `Context::commodity_aliases` is renamed to
+`commodity_conversions` with a new tuple-valued type (refactor; same
+observable behaviour for journals using only `alias` directives). The
+`.dop` wire format is unchanged.
+
+Two known wow.dat parity divergences with ledger-cli are deferred: the
+display-time chain-canonicalisation question (#270) and the auto-balance
+posting's per-lot identity preservation (#276). Neither affects the
+elaborated balance values for journals that don't use the specific
+constructs (multi-hop chains across commodity boundaries, or multi-commodity
+inter-account inventory transfers via auto-balanced postings); both are
+tracked for 2.2.
+
 ### Fixed
 
 - **`C`-directive divisor formula corrected to `N2/N1` for all N1** (#274):
@@ -102,13 +130,28 @@
 
 - **Vendor `tests/parity/ledger-drewr3.dat`** (refs #257, refs #197): the
   ledger-cli upstream `test/input/drewr3.dat` fixture is vendored with a
-  provenance comment block (source URL, commit SHA, license, exercises). It is
-  NOT yet wired into the positive parity harness: `drewr3.dat` exposed a
-  gap in how `dop balance --flat` reports the balance of intermediate accounts
-  that carry both direct postings and child-account postings (ledger-cli
-  aggregates the subtree; doppio reports only the direct balance). The fixture
-  is tracked in the repo so the gap is reproducible; the harness entry will be
-  added once the gap is resolved.
+  provenance comment block (source URL, commit SHA, license, exercises). It
+  was wired into the positive parity harness in PR #259 alongside a fix to
+  `scripts/parity_check.py` to compare per-account direct balances rather
+  than ledger-cli's subtree-aggregated `display_total` (the gap that
+  surfaced the choice).
+
+- **Vendor `tests/parity/ledger-wow.dat`** (refs #197): the ledger-cli
+  upstream `test/input/wow.dat` fixture is vendored as the primary
+  regression target for `C` directive semantics (#248). Commodity letters
+  are renamed from upstream `c`/`s`/`G` to `COPPER`/`SILVER`/`GOLD` because
+  ledger-cli treats `s`/`m`/`h` as built-in time units (60s = 1m, etc.)
+  which collides with the `C`-directive when used as commodity names. The
+  fixture is NOT yet wired into the positive parity harness — three
+  divergence categories remain (display-rounding, single-hop chain
+  canonicalisation in ledger-cli's `bal` display, and an auto-balance
+  posting bug tracked in #276); see #270 for the full inventory.
+
+- **Harness regex extension for quoted-name-first amounts** (refs #197):
+  `_parse_ledger_amount` in `scripts/parity_check.py` now handles
+  ledger-cli's commodity-first quoted output (`"Long Name" N`) for
+  lot-annotated items. The surrounding quotes are stripped so the
+  commodity matches doppio's JSON output convention.
 
 - **Implicit cost-basis inference for ledger-cli and hledger** (#251): a
   two-real-posting multi-commodity transaction where neither posting carries an

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "doppio"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "doppio-cli"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 # Shared metadata that applies to every member crate by default. Crates
 # can override individual fields locally.
 [workspace.package]
-version = "2.0.0"
+version = "2.1.0"
 edition = "2024"
 rust-version = "1.95.0"
 repository = "https://github.com/alevy/doppio"

--- a/docs/SUPPORTED_FEATURES.md
+++ b/docs/SUPPORTED_FEATURES.md
@@ -1,6 +1,6 @@
 # doppio: Supported Ledger features
 
-**Last updated**: 2026-05-06 (doppio v1.0.0)
+**Last updated**: 2026-05-08 (doppio v2.1.0)
 
 Feature-by-feature comparison of doppio's syntax surface against
 [ledger-cli](https://ledger-cli.org/) and [hledger](https://hledger.org/).

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,6 +1,6 @@
 # doppio Requirements
 
-**Last updated**: 2026-05-06 (doppio v1.0.0)
+**Last updated**: 2026-05-08 (doppio v2.1.0)
 
 ---
 


### PR DESCRIPTION
## Summary

Release v2.1.0. Workspace version bumped 2.0.0 → 2.1.0; CHANGELOG `[Unreleased]` finalised as `[2.1.0] - 2026-05-08`; docs "Last updated" stamps refreshed.

## Surface since v2.0.0

### Fixed

- C-directive divisor formula corrected to `N2/N1` for all N1, with a new `InvalidCommodityConversion` variant for zero-LHS (#274).
- Parenthesised expressions in posting amounts now evaluate correctly — pre-1.0 latent bug (`(54G)` → `1G` instead of `54G`); fixed by reordering `(expr)` before `(bool_expr)` in `base_primary` (#272).
- C-directive transitive chain applied during balance verification via eager fixpoint pass; cycles surface as `CommodityConversionCycle` (#266).
- Signed numbers in commodity-first amount form (`"Foo" -1`, `USD -1`) — grammar gap that mis-parsed wow.dat-style sale postings as binary subtraction (#264).

### Added

- `C N1 X = N2 Y` commodity-conversion directive for the ledger-cli frontend (#248 stage 2).
- Double-quoted commodity names (`"Plans: Wildthorn Mail"`) for both ledger and hledger frontends (#262).
- Explicit `*N` multiplier syntax in `=` auto-rule bodies (#254).
- Implicit cost-basis inference for two-leg multi-commodity transactions in ledger and hledger (#251). Beancount unaffected.
- Automated transaction rules (`= QUERY`) with full multiplier semantics for ledger and hledger (#249). Periodic `~` directives parsed-and-discarded.

### Internal / refactor

- `Context::commodity_aliases` renamed to `commodity_conversions` with `(canonical, divisor)` tuple values; pre-stage for #248 stage 2 (#248 stage 1, no observable change).

### Test infrastructure

- `tests/parity/ledger-drewr3.dat` and `tests/parity/ledger-wow.dat` vendored from ledger-cli upstream with provenance comment blocks. drewr3.dat is wired into POSITIVE; wow.dat is held out pending #270 / #276. Harness `_parse_ledger_amount` extended for ledger-cli's commodity-first quoted output. ledger-cli `display_total` → `amount` format-string change so doppio's per-account direct balance is the apples-to-apples comparison target.

## Library API

- `ResolutionError` gains `InvalidAutoRuleQuery`, `InvalidCommodityConversion`, `CommodityConversionCycle` variants. The enum was already `#[non_exhaustive]` post-2.0, so this is additive.
- `ElaborationConfig` gains `infer_implicit_total_cost: bool` (default `false`; set `true` in ledger and hledger frontend defaults).
- `Context::commodity_aliases` renamed to `commodity_conversions` with a new tuple-valued type. Field is `pub`, so the rename is technically API-breaking; observable behaviour is identical for journals using only `alias` directives. Project policy is principled-math interpretation rather than mimicking ledger-cli's "LHS must = 1" quirk.
- `.dop` wire format is unchanged (still version 3); v2.0.0-built `.dop` files load unchanged in v2.1.0.

## Deferred to 2.2

- #270 — wow.dat parity 3-category gap inventory (display rounding / single-hop chain canonicalisation in ledger-cli's `bal` display / auto-balance lot identity).
- #276 — auto-balance posting drops lot identity for multi-commodity transactions (real elaborator bug, constrained trigger).
- #258 — hledger `--auto` opt-in (CLI UX scope).
- #256 — standard.dat parity evaluation (deferred until at least #276 is resolved).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` — 400 lib + 49 parity + 28 + 22 + 18 + 12 + 11 + 8 + 7 + 5 + 3 = 533+ tests pass
- [x] `cargo test --doc` — all doc tests pass
- [x] `cargo doc --no-deps` runs (warnings present, pre-existing tech debt; documented in RELEASE.md)
- [x] `cargo publish --dry-run -p doppio --allow-dirty` exits 0; packaged 80 files / 898.5 KiB
- [x] CI green required before merge