### PR TITLE
fix(resolution): inferred_scale from D/format directives; skip rounding for C-chain @-prices (#288)

### DIFF
--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -1085,32 +1085,38 @@ pub fn elaborate(
                                                 // amounts in their native commodity and
                                                 // only converts to the chain root at
                                                 // display/reporting time.
-                                                let (v, c, chain_converted) = evaluator::eval_and_normalize_amount_with_conversion_flag(
+                                                let (v, c, precision) = evaluator::eval_and_normalize_amount_with_precision(
                                                     expr,
                                                     entry_context,
                                                     state,
                                                     None,
                                                 )?;
                                                 let exact_cost = v * value;
-                                                // Round to the commodity's inferred
-                                                // scale only when:
-                                                // 1. The commodity was observed in direct
-                                                //    posting amounts during resolution
-                                                //    (otherwise skip — unknown precision).
-                                                // 2. The price was NOT chain-converted
-                                                //    (a C-directive conversion produces
-                                                //    exact results; rounding would lose
-                                                //    precision, not remove noise).
-                                                let canonical_cost = if !chain_converted {
-                                                    if let Some(props) =
-                                                        commodity_properties.get(&c)
-                                                    {
-                                                        exact_cost.round_dp(props.inferred_scale)
-                                                    } else {
-                                                        exact_cost
+                                                // Intent-rounding is only meaningful for
+                                                // values that may carry IEEE-double noise
+                                                // from a high-precision input literal.
+                                                // A `Precision::Exact` price (currently:
+                                                // produced by a `C`-directive chain
+                                                // conversion) is mathematically exact;
+                                                // rounding it to the result commodity's
+                                                // inferred display scale would discard
+                                                // genuine precision (e.g. truncating
+                                                // `21050 COPPER → 2.105 GOLD` to
+                                                // `2.10 GOLD`), which ledger-cli does NOT
+                                                // do — it accumulates in the native
+                                                // commodity and only converts at display
+                                                // time.
+                                                let canonical_cost = match precision {
+                                                    evaluator::Precision::Exact => exact_cost,
+                                                    evaluator::Precision::PossiblyNoisy => {
+                                                        commodity_properties
+                                                            .get(&c)
+                                                            .map(|p| {
+                                                                exact_cost
+                                                                    .round_dp(p.inferred_scale)
+                                                            })
+                                                            .unwrap_or(exact_cost)
                                                     }
-                                                } else {
-                                                    exact_cost
                                                 };
                                                 Some((canonical_cost, c))
                                             }
@@ -2797,7 +2803,7 @@ mod evaluator {
         running_state: &RunningState,
         fallback_commodity: Option<&str>,
     ) -> Result<(Decimal, String), ElaborationError> {
-        let (value, commodity, _converted) = eval_and_normalize_amount_with_conversion_flag(
+        let (value, commodity, _precision) = eval_and_normalize_amount_with_precision(
             val,
             eval_context,
             running_state,
@@ -2806,33 +2812,60 @@ mod evaluator {
         Ok((value, commodity))
     }
 
-    /// Like [`eval_and_normalize_amount_with_fallback`], but also returns a boolean
-    /// indicating whether a `C`-directive chain conversion was applied to the result.
+    /// Whether an evaluated amount's value is mathematically exact or may
+    /// carry input-precision noise. Surfaced by
+    /// [`eval_and_normalize_amount_with_precision`] so callers (specifically
+    /// the elaborator's `@`-price cost computation) can decide whether to
+    /// round to the result commodity's intent precision.
     ///
-    /// When `true`, the caller knows that the amount was expressed in a different
-    /// (non-canonical) commodity and was divided through the chain divisor to reach
-    /// the canonical commodity. This is used by the `@`-price cost computation to
-    /// skip scale-based rounding: a value like `21050 COPPER → 2.105 GOLD` is exact
-    /// (the division is lossless), whereas a value like `0.50 @ $53.659999...28dp`
-    /// expressed directly in `$` benefits from rounding to `$`'s declared 2dp.
+    /// `Exact` is set when the amount passes through a `C`-directive
+    /// chain conversion: the value was divided by a fixed divisor stored on
+    /// [`resolution::Context::commodity_conversions`], an operation that is
+    /// lossless by construction. Rounding such values would discard
+    /// genuine precision (e.g. truncating `21050 COPPER → 2.105 GOLD`
+    /// to `2.10 GOLD` and losing 50 COPPER per posting).
     ///
-    /// A plain commodity alias (`commodity X\n  alias Y`, divisor = 1) also sets
-    /// the flag to `true` because a conversion entry exists, but since the divisor
-    /// is 1 the value is mathematically unchanged — rounding would be a no-op at any
-    /// reasonable scale, so skipping it is harmless.
-    pub fn eval_and_normalize_amount_with_conversion_flag(
+    /// `PossiblyNoisy` is set otherwise. The value may have been multiplied
+    /// against an input literal that carries IEEE-double serialisation noise
+    /// (e.g. a tool round-tripping `$53.66` through a 64-bit float emits
+    /// `$53.6599999999999999998612221219`). Rounding to the result
+    /// commodity's inferred scale absorbs that noise without affecting
+    /// values that were already at intent precision.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum Precision {
+        Exact,
+        PossiblyNoisy,
+    }
+
+    /// Like [`eval_and_normalize_amount_with_fallback`], but also returns a
+    /// [`Precision`] tag describing whether the result is mathematically exact
+    /// or may carry input-precision noise.
+    ///
+    /// The tag drives the elaborator's `@`-price intent-rounding decision:
+    /// `Exact` values are emitted unchanged (rounding would discard precision
+    /// rather than absorb noise); `PossiblyNoisy` values are rounded to the
+    /// commodity's inferred display scale to absorb IEEE-double serialisation
+    /// noise from inputs like `$53.6599999999999999998612221219`.
+    ///
+    /// Currently the only signal that produces `Exact` is having passed
+    /// through a `C`-directive chain conversion (a division by a fixed
+    /// divisor stored in [`resolution::Context::commodity_conversions`]),
+    /// which by construction is lossless. A 1:1 alias entry also produces
+    /// `Exact`, which is harmless — the divisor is `Decimal::ONE` so the
+    /// rounding step it skips would have been a no-op anyway.
+    pub fn eval_and_normalize_amount_with_precision(
         val: ast::ValueExpr,
         eval_context: &resolution::Context,
         running_state: &RunningState,
         fallback_commodity: Option<&str>,
-    ) -> Result<(Decimal, String, bool), ElaborationError> {
+    ) -> Result<(Decimal, String, Precision), ElaborationError> {
         // Amount expressions don't involve posting metadata (tags); pass an
         // empty map so the `tag()` built-in is a no-op when called from amount
         // contexts (which would be a programmer error, but we don't panic).
         let empty_meta = BTreeMap::default();
         match eval(val, eval_context, running_state, &empty_meta, EVAL_BUDGET)? {
             ast::ValueExpr::Amount { value, commodity } => {
-                let (value, commodity, converted) = if let Some(commodity) = commodity {
+                let (value, commodity, precision) = if let Some(commodity) = commodity {
                     // Apply commodity conversion: if the commodity appears in
                     // commodity_conversions, divide the amount by the stored divisor
                     // and rebrand to the canonical commodity.
@@ -2846,9 +2879,9 @@ mod evaluator {
                     if let Some((canonical, divisor)) =
                         eval_context.commodity_conversions.get(&commodity)
                     {
-                        (value / divisor, canonical.clone(), true)
+                        (value / divisor, canonical.clone(), Precision::Exact)
                     } else {
-                        (value, commodity, false)
+                        (value, commodity, Precision::PossiblyNoisy)
                     }
                 } else {
                     // No commodity in the expression -- try context default, then
@@ -2859,9 +2892,9 @@ mod evaluator {
                         .or(fallback_commodity)
                         .ok_or(ElaborationError::AmountWithNoCommodity)?
                         .to_owned();
-                    (value, commodity, false)
+                    (value, commodity, Precision::PossiblyNoisy)
                 };
-                Ok((value, commodity, converted))
+                Ok((value, commodity, precision))
             }
             val => Err(ElaborationError::NonAmountWhereAmountExpected(val)),
         }

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -1071,23 +1071,44 @@ pub fn elaborate(
                                                 // rounded to 2dp (cents), removing
                                                 // IEEE-double noise and producing a
                                                 // zero-sum balance.
-                                                let (v, c) = evaluator::eval_and_normalize_amount(
+                                                //
+                                                // Exception: when the `@`-price was
+                                                // expressed in a different commodity and
+                                                // reached the canonical form via a
+                                                // `C`-directive chain conversion (#288),
+                                                // skip rounding. Chain-converted values
+                                                // are exact (e.g. `21050 COPPER / 10000
+                                                // = 2.105 GOLD` with no precision loss),
+                                                // so rounding would introduce error
+                                                // (`2.10`) rather than remove it.
+                                                // ledger-cli matches this: it accumulates
+                                                // amounts in their native commodity and
+                                                // only converts to the chain root at
+                                                // display/reporting time.
+                                                let (v, c, chain_converted) = evaluator::eval_and_normalize_amount_with_conversion_flag(
                                                     expr,
                                                     entry_context,
                                                     state,
+                                                    None,
                                                 )?;
                                                 let exact_cost = v * value;
                                                 // Round to the commodity's inferred
-                                                // scale only when the commodity was
-                                                // observed in direct posting amounts
-                                                // during resolution. If it only appears
-                                                // in @-price annotations (not in the
-                                                // map), skip rounding to avoid coercing
-                                                // a genuinely unknown precision.
-                                                let canonical_cost = if let Some(props) =
-                                                    commodity_properties.get(&c)
-                                                {
-                                                    exact_cost.round_dp(props.inferred_scale)
+                                                // scale only when:
+                                                // 1. The commodity was observed in direct
+                                                //    posting amounts during resolution
+                                                //    (otherwise skip — unknown precision).
+                                                // 2. The price was NOT chain-converted
+                                                //    (a C-directive conversion produces
+                                                //    exact results; rounding would lose
+                                                //    precision, not remove noise).
+                                                let canonical_cost = if !chain_converted {
+                                                    if let Some(props) =
+                                                        commodity_properties.get(&c)
+                                                    {
+                                                        exact_cost.round_dp(props.inferred_scale)
+                                                    } else {
+                                                        exact_cost
+                                                    }
                                                 } else {
                                                     exact_cost
                                                 };
@@ -2776,13 +2797,42 @@ mod evaluator {
         running_state: &RunningState,
         fallback_commodity: Option<&str>,
     ) -> Result<(Decimal, String), ElaborationError> {
+        let (value, commodity, _converted) = eval_and_normalize_amount_with_conversion_flag(
+            val,
+            eval_context,
+            running_state,
+            fallback_commodity,
+        )?;
+        Ok((value, commodity))
+    }
+
+    /// Like [`eval_and_normalize_amount_with_fallback`], but also returns a boolean
+    /// indicating whether a `C`-directive chain conversion was applied to the result.
+    ///
+    /// When `true`, the caller knows that the amount was expressed in a different
+    /// (non-canonical) commodity and was divided through the chain divisor to reach
+    /// the canonical commodity. This is used by the `@`-price cost computation to
+    /// skip scale-based rounding: a value like `21050 COPPER → 2.105 GOLD` is exact
+    /// (the division is lossless), whereas a value like `0.50 @ $53.659999...28dp`
+    /// expressed directly in `$` benefits from rounding to `$`'s declared 2dp.
+    ///
+    /// A plain commodity alias (`commodity X\n  alias Y`, divisor = 1) also sets
+    /// the flag to `true` because a conversion entry exists, but since the divisor
+    /// is 1 the value is mathematically unchanged — rounding would be a no-op at any
+    /// reasonable scale, so skipping it is harmless.
+    pub fn eval_and_normalize_amount_with_conversion_flag(
+        val: ast::ValueExpr,
+        eval_context: &resolution::Context,
+        running_state: &RunningState,
+        fallback_commodity: Option<&str>,
+    ) -> Result<(Decimal, String, bool), ElaborationError> {
         // Amount expressions don't involve posting metadata (tags); pass an
         // empty map so the `tag()` built-in is a no-op when called from amount
         // contexts (which would be a programmer error, but we don't panic).
         let empty_meta = BTreeMap::default();
         match eval(val, eval_context, running_state, &empty_meta, EVAL_BUDGET)? {
             ast::ValueExpr::Amount { value, commodity } => {
-                let (value, commodity) = if let Some(commodity) = commodity {
+                let (value, commodity, converted) = if let Some(commodity) = commodity {
                     // Apply commodity conversion: if the commodity appears in
                     // commodity_conversions, divide the amount by the stored divisor
                     // and rebrand to the canonical commodity.
@@ -2796,9 +2846,9 @@ mod evaluator {
                     if let Some((canonical, divisor)) =
                         eval_context.commodity_conversions.get(&commodity)
                     {
-                        (value / divisor, canonical.clone())
+                        (value / divisor, canonical.clone(), true)
                     } else {
-                        (value, commodity)
+                        (value, commodity, false)
                     }
                 } else {
                     // No commodity in the expression -- try context default, then
@@ -2809,9 +2859,9 @@ mod evaluator {
                         .or(fallback_commodity)
                         .ok_or(ElaborationError::AmountWithNoCommodity)?
                         .to_owned();
-                    (value, commodity)
+                    (value, commodity, false)
                 };
-                Ok((value, commodity))
+                Ok((value, commodity, converted))
             }
             val => Err(ElaborationError::NonAmountWhereAmountExpected(val)),
         }
@@ -7393,5 +7443,83 @@ C 0 X = 100 Y
         );
         let journal = result.unwrap();
         assert_eq!(journal.transactions.len(), 1);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // #288 regression: @-price scale fallback when no direct posting exists
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// Minimal repro of the wow.dat shape that regressed in #288.
+    ///
+    /// GOLD has no direct postings — the `D 1.00 GOLD` directive is a default
+    /// directive, not a posting. The `@ 1.25 GOLD` annotation must establish
+    /// `inferred_scale[GOLD] = 2`, so `1 @ 1.25 GOLD` is elaborated as
+    /// `-1.25 GOLD` on the auto-balance leg (not integer-rounded to `-1 GOLD`).
+    #[test]
+    fn test_at_price_intent_rounding_when_no_direct_posting_at_higher_scale() {
+        let input = "\
+D 1.00 GOLD
+
+2024/01/01 Buy
+    Assets:Items   \"Widget\" 1 @ 1.25 GOLD
+    Assets:Cash
+";
+        let journal = elaborate(input);
+        assert_eq!(journal.transactions.len(), 1);
+        let tx = &journal.transactions[0];
+
+        // The auto-balanced Assets:Cash posting must be -1.25 GOLD, not -1 GOLD.
+        let cash = tx
+            .postings
+            .iter()
+            .find(|p| p.account == "Assets:Cash")
+            .expect("Assets:Cash posting must be present");
+
+        let gold_amount = cash
+            .amount_in("GOLD")
+            .expect("Assets:Cash must hold GOLD (the price commodity)");
+
+        assert_eq!(
+            gold_amount,
+            dec!(-1.25),
+            "Assets:Cash must be -1.25 GOLD (not integer-rounded to -1 GOLD)"
+        );
+    }
+
+    /// Guard the original #281 anchor: standard.dat:1880 still elaborates
+    /// cleanly after the #288 fix.
+    ///
+    /// The four-leg LMVTX/EEEEE transaction has direct `$` postings at scale
+    /// 2 (`$474.31` etc.) and 28-decimal `@` prices. The fix must NOT let the
+    /// 28-decimal prices inflate `inferred_scale[$]` — direct postings must win.
+    #[test]
+    fn test_standard_dat_1880_regression_preserved() {
+        let input = "\
+2003/06/19 * cbb4cc49824bf79827cde838e005848027ca0a38
+    c56a21d2  331.296869 LMVTX @ $53.6599999999999999998612221219
+    c56a21d2  -523.942988 EEEEE @ $33.9299999999999999998438748872
+    c56a21d2  55.981364 LMVTX @ $53.6599999999999999998612221219
+    c56a21d2  -88.534054 EEEEE @ $33.9299999999999999998438748872
+    c56a21d2
+";
+        // This must elaborate cleanly — no TransactionDoesNotBalance error.
+        let journal = elaborate(input);
+        assert_eq!(journal.transactions.len(), 1);
+        let tx = &journal.transactions[0];
+
+        // Quantities must be preserved exactly as written (no over-rounding).
+        let lmvtx_qtys: Vec<rust_decimal::Decimal> = tx
+            .postings
+            .iter()
+            .filter_map(|p| p.amount_in("LMVTX"))
+            .collect();
+        assert!(
+            lmvtx_qtys.contains(&dec!(331.296869)),
+            "first LMVTX qty must be 331.296869, got {lmvtx_qtys:?}"
+        );
+        assert!(
+            lmvtx_qtys.contains(&dec!(55.981364)),
+            "second LMVTX qty must be 55.981364, got {lmvtx_qtys:?}"
+        );
     }
 }

--- a/crates/doppio/src/resolution.rs
+++ b/crates/doppio/src/resolution.rs
@@ -523,13 +523,36 @@ pub struct CommodityProperties {
     pub no_market: bool,
     /// A free-form note describing the commodity.
     pub note: Option<String>,
-    /// Maximum decimal scale observed across all direct posting amounts for
-    /// this commodity. Populated during resolution as a side-effect of the
+    /// Maximum decimal scale intended for this commodity, inferred from the
+    /// journal source. Populated during resolution as a side-effect of the
     /// AST → HIR walk. Used by the elaborator to round `qty * price` costs
     /// for `@`-priced postings to the journal's intended precision before the
     /// balance check, matching ledger-cli's commodity display-precision
     /// mechanism (xact.cc:872-904). Defaults to 0 when no postings of this
     /// commodity were seen.
+    ///
+    /// # Scale-source priority
+    ///
+    /// Two authoritative sources contribute to this value; the maximum across
+    /// both is taken:
+    ///
+    /// 1. **`D` / `commodity format` directives** — the format string
+    ///    explicitly declares the display precision (e.g. `D 1.00 GOLD`
+    ///    declares GOLD has 2 decimal places). This is the primary fix for
+    ///    #288: wow.dat declares `D 1.00 GOLD` which establishes
+    ///    `inferred_scale[GOLD] = 2` so that `@ 1.25 GOLD` costs are not
+    ///    integer-rounded.
+    ///
+    /// 2. **Direct posting amounts** — the amounts written on the posting
+    ///    line itself (not `@`/`@@` price annotations or `{cost}` lot costs).
+    ///    This captures journals that use explicit fractional amounts
+    ///    (e.g. `$474.31`) to establish commodity precision.
+    ///
+    /// `@`-price and `{cost}` lot annotations are intentionally excluded from
+    /// the scale computation because they may carry IEEE-double noise from
+    /// import tools (e.g. a 28-digit `@ $53.659999...` price would
+    /// incorrectly inflate `inferred_scale[$]` to 28, defeating the rounding
+    /// that eliminates floating-point residue from the balance check).
     pub inferred_scale: u32,
 }
 
@@ -1044,6 +1067,26 @@ impl TryFrom<ast::Journal> for HIR {
                                     });
                             }
                             ast::CommodityItem::Format(format) => {
+                                // Extract the decimal scale from the format
+                                // string and use it as a precision anchor for
+                                // `inferred_scale`. This is the primary fix for
+                                // #288: `D 1.00 GOLD` in wow.dat lowers to a
+                                // `Format("1.00 GOLD")` item that declares
+                                // GOLD has scale 2, even though the direct
+                                // GOLD postings in that journal are integer
+                                // amounts (scale 0). The elaborator uses
+                                // `inferred_scale` when rounding `qty * @price`
+                                // costs for GOLD, so without this the
+                                // integer scale 0 would over-round fractional
+                                // GOLD values computed from `@`-price annotations.
+                                //
+                                // `scale_from_format` counts digits after the
+                                // first decimal point in the format string,
+                                // ignoring grouping separators. A format with
+                                // no decimal point contributes scale 0.
+                                let fmt_scale = scale_from_format(&format);
+                                global_context.inferred_scale =
+                                    global_context.inferred_scale.max(fmt_scale);
                                 global_context.format = Some(format);
                             }
                             ast::CommodityItem::NoMarket => {
@@ -1173,11 +1216,27 @@ impl TryFrom<ast::Journal> for HIR {
                         })
                         .collect();
 
-                    // Populate `inferred_scale` on each commodity seen in direct
-                    // posting amounts (not @-price annotations). This is a
-                    // side-effect of the AST → HIR walk; the elaborator reads
-                    // the result from `global_context.commodity_properties` to
-                    // round `qty * price` costs for `@`-priced postings (#281).
+                    // Populate `inferred_scale` from direct posting amounts.
+                    //
+                    // This is a side-effect of the AST → HIR walk; the
+                    // elaborator reads the result from
+                    // `global_context.commodity_properties` to round
+                    // `qty * price` costs for `@`-priced postings (#281).
+                    //
+                    // Only the `value` field of each `AmountDetails::Amount`
+                    // posting contributes here — NOT `@`/`@@` price annotations
+                    // and NOT `{cost}` lot annotations. This prevents
+                    // IEEE-double noise from high-precision price strings
+                    // (e.g. `@ $53.6599999999999999998612221219`, 28 digits)
+                    // from inflating the inferred scale of `$` beyond the
+                    // user's true intent. (#281 anchor preserved for
+                    // standard.dat:1880)
+                    //
+                    // `D` / `commodity format` directives are the other
+                    // authoritative source of scale — they are handled in
+                    // the `CommodityItem::Format` arm above (#288 fix for
+                    // wow.dat where `D 1.00 GOLD` establishes scale 2
+                    // even though direct GOLD postings are integers).
                     {
                         let mut scales: BTreeMap<String, u32> = BTreeMap::new();
                         for posting in &postings {
@@ -1327,16 +1386,16 @@ impl TryFrom<ast::Journal> for HIR {
 /// scale seen for each commodity-bearing amount leaf.
 ///
 /// Called during the AST → HIR resolution walk (in [`HIR::try_from`]) for
-/// every direct posting amount. The result is stored on
+/// direct posting amounts. The result is stored on
 /// [`CommodityProperties::inferred_scale`] and consumed by the elaborator
 /// when rounding `qty * price` costs for `@`-priced postings to the
 /// journal's intended precision (see `crates/doppio/src/elaborator.rs`).
 ///
-/// "Direct posting amount" means the `value` field in an
-/// [`ast::AmountDetails::Amount`] posting — NOT the `@`/`@@` price annotation.
-/// Price annotations are excluded because they may carry IEEE-double noise
-/// (e.g. 28-digit prices like `$53.6599999999999999998612221219`) that would
-/// inflate the apparent scale of the commodity.
+/// Only the `value` field of each posting is passed here — NOT `@`/`@@` price
+/// annotations or `{cost}` lot costs. This prevents IEEE-double noise from
+/// high-precision price strings from inflating the inferred scale.
+/// `D` / `commodity format` directives also feed `inferred_scale` directly
+/// (see [`scale_from_format`]).
 ///
 /// The algorithm records the **maximum** scale across all direct posting amounts
 /// for each commodity. This preserves the highest declared precision: a journal
@@ -1398,6 +1457,35 @@ fn bare_number_scale(expr: &ast::ValueExpr) -> Option<u32> {
         } => Some(value.scale()),
         ast::ValueExpr::Unary { expr, .. } => bare_number_scale(expr),
         _ => None,
+    }
+}
+
+/// Extract the decimal scale declared in a commodity format string.
+///
+/// A format string is the raw source text of a `D` directive or a `format`
+/// sub-item inside a `commodity` block — for example `"1.00 GOLD"`,
+/// `"$1,000.00"`, or `"1,000.00 USD"`.
+///
+/// The scale is the count of ASCII digit characters immediately following the
+/// first `.` in the string, ignoring all other characters (currency symbols,
+/// grouping commas, commodity names). If the string contains no `.`, the
+/// format declares zero decimal places and `0` is returned.
+///
+/// # Examples
+///
+/// ```text
+/// "1.00 GOLD"   -> 2
+/// "$1,000.00"   -> 2
+/// "1,000.00 $"  -> 2
+/// "1.0000 EUR"  -> 4
+/// "1000 USD"    -> 0
+/// ```
+fn scale_from_format(format: &str) -> u32 {
+    if let Some(dot_pos) = format.find('.') {
+        let after_dot = &format[dot_pos + 1..];
+        after_dot.chars().take_while(|c| c.is_ascii_digit()).count() as u32
+    } else {
+        0
     }
 }
 
@@ -1911,6 +1999,230 @@ mod resolution_tests {
         assert_eq!(
             props.inferred_scale, 2,
             "inferred_scale for B must be 2 from the Typed{{Unary{{Sub, 0.71}}}} node"
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Format-directive scale feeds inferred_scale (#288)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// A `D 1.00 GOLD` (or `commodity GOLD\n  format 1.00 GOLD`) directive
+    /// declares that GOLD has 2 decimal places. This scale must be recorded
+    /// in `inferred_scale` even when the only direct GOLD postings in the
+    /// journal are integers (scale 0).
+    ///
+    /// This is the root cause of #288: wow.dat has `D 1.00 GOLD` but all
+    /// direct GOLD postings are integers (`1 GOLD`, `3 GOLD`, …). Without
+    /// the format-directive contribution, `inferred_scale[GOLD] = 0`, causing
+    /// `qty * @price` GOLD costs to be integer-rounded instead of
+    /// 2-decimal-rounded.
+    #[test]
+    fn test_inferred_scale_from_format_directive() {
+        // `D 1.00 GOLD` lowers to a Commodity directive with Format("1.00 GOLD")
+        // and Default items.
+        let journal = ast::Journal {
+            entries: vec![ast::Entry::Directive(ast::Directive::Commodity {
+                name: "GOLD".into(),
+                notes: vec![],
+                items: vec![
+                    ast::CommodityItem::Default,
+                    ast::CommodityItem::Format("1.00 GOLD".into()),
+                ],
+            })],
+        };
+
+        let hir = HIR::try_from(journal).unwrap();
+
+        let props = hir
+            .global_context
+            .commodity_properties
+            .get("GOLD")
+            .expect("GOLD should have properties from D directive");
+
+        assert_eq!(
+            props.inferred_scale, 2,
+            "inferred_scale for GOLD must be 2 from D 1.00 GOLD format directive"
+        );
+    }
+
+    /// When BOTH a format directive AND direct posting amounts exist for a
+    /// commodity, `inferred_scale` takes the maximum of both. This preserves
+    /// the highest declared precision.
+    ///
+    /// Example: `D 1.000 GOLD` (scale 3) + direct `1.00 GOLD` (scale 2) →
+    /// `inferred_scale[GOLD] = 3`.
+    #[test]
+    fn test_inferred_scale_format_and_direct_max() {
+        use rust_decimal::dec;
+
+        let format_directive = ast::Entry::Directive(ast::Directive::Commodity {
+            name: "GOLD".into(),
+            notes: vec![],
+            items: vec![ast::CommodityItem::Format("1.000 GOLD".into())],
+        });
+
+        let tx = ast::Transaction {
+            date: ast::Date {
+                year: Some(2024),
+                month: 1,
+                date: 1,
+            },
+            description: "Format + direct max test".into(),
+            postings: vec![
+                ast::Posting::new("Assets:Wallet").with_amount(ast::AmountDetails::Amount {
+                    value: ast::ValueExpr::Amount {
+                        value: dec!(1.00),
+                        commodity: Some("GOLD".into()),
+                    },
+                    lot_annotation: None,
+                    lot_pricing: None,
+                    balance_assertion: None,
+                }),
+                ast::Posting::new("Assets:Cash"),
+            ],
+            ..Default::default()
+        };
+
+        let journal = ast::Journal {
+            entries: vec![format_directive, ast::Entry::Transaction(tx)],
+        };
+        let hir = HIR::try_from(journal).unwrap();
+
+        let props = hir
+            .global_context
+            .commodity_properties
+            .get("GOLD")
+            .expect("GOLD should have properties");
+
+        assert_eq!(
+            props.inferred_scale, 3,
+            "inferred_scale for GOLD must be 3 (max of format scale 3 and direct scale 2)"
+        );
+    }
+
+    /// `@`-price annotations are NOT included in `inferred_scale`. Only
+    /// direct posting amounts and format directives contribute. This prevents
+    /// IEEE-double noise from high-precision price strings from inflating the
+    /// apparent scale of a commodity that already has clear precision from
+    /// direct postings.
+    ///
+    /// Example: `1 GOLD` direct (scale 0) + `@ 1.250 GOLD` @-price (scale 3)
+    /// → `inferred_scale[GOLD] = 0` (direct only; @-price is not consulted).
+    #[test]
+    fn test_inferred_scale_at_price_not_included() {
+        use rust_decimal::dec;
+
+        // Direct posting: 1 GOLD (scale 0)
+        let posting_direct =
+            ast::Posting::new("Assets:Wallet").with_amount(ast::AmountDetails::Amount {
+                value: ast::ValueExpr::Amount {
+                    value: dec!(1),
+                    commodity: Some("GOLD".into()),
+                },
+                lot_annotation: None,
+                lot_pricing: None,
+                balance_assertion: None,
+            });
+
+        // Posting with @-price annotation: 1 ITEM @ 1.250 GOLD (scale 3)
+        // The @-price must NOT affect inferred_scale[GOLD].
+        let posting_at =
+            ast::Posting::new("Assets:Items").with_amount(ast::AmountDetails::Amount {
+                value: ast::ValueExpr::Amount {
+                    value: dec!(1),
+                    commodity: Some("ITEM".into()),
+                },
+                lot_annotation: None,
+                lot_pricing: Some(ast::LotPricing::Unit(ast::ValueExpr::Amount {
+                    value: dec!(1.250),
+                    commodity: Some("GOLD".into()),
+                })),
+                balance_assertion: None,
+            });
+        let counter = ast::Posting::new("Assets:Cash");
+
+        let tx = ast::Transaction {
+            date: ast::Date {
+                year: Some(2024),
+                month: 1,
+                date: 1,
+            },
+            description: "At-price not included test".into(),
+            postings: vec![posting_direct, posting_at, counter],
+            ..Default::default()
+        };
+
+        let journal = ast::Journal {
+            entries: vec![ast::Entry::Transaction(tx)],
+        };
+        let hir = HIR::try_from(journal).unwrap();
+
+        let props = hir
+            .global_context
+            .commodity_properties
+            .get("GOLD")
+            .expect("GOLD should have properties from direct posting");
+
+        assert_eq!(
+            props.inferred_scale, 0,
+            "inferred_scale for GOLD must be 0 (direct posting only; @-price scale 3 excluded)"
+        );
+    }
+
+    /// `{cost}` lot annotations are NOT included in `inferred_scale`.
+    ///
+    /// Example: `1 AAPL {150.50 USD}` with no direct USD postings and no
+    /// format directive → `inferred_scale[USD] = 0` (lot cost is not consulted).
+    #[test]
+    fn test_inferred_scale_lot_cost_not_included() {
+        use rust_decimal::dec;
+
+        let posting =
+            ast::Posting::new("Assets:Brokerage").with_amount(ast::AmountDetails::Amount {
+                value: ast::ValueExpr::Amount {
+                    value: dec!(1),
+                    commodity: Some("AAPL".into()),
+                },
+                lot_annotation: Some(ast::LotAnnotation {
+                    cost: Some(ast::ValueExpr::Amount {
+                        value: dec!(150.50),
+                        commodity: Some("USD".into()),
+                    }),
+                    ..Default::default()
+                }),
+                lot_pricing: None,
+                balance_assertion: None,
+            });
+        let counter = ast::Posting::new("Assets:Cash");
+
+        let tx = ast::Transaction {
+            date: ast::Date {
+                year: Some(2024),
+                month: 1,
+                date: 1,
+            },
+            description: "Lot cost not included test".into(),
+            postings: vec![posting, counter],
+            ..Default::default()
+        };
+
+        let journal = ast::Journal {
+            entries: vec![ast::Entry::Transaction(tx)],
+        };
+        let hir = HIR::try_from(journal).unwrap();
+
+        // USD should NOT appear in commodity_properties at all (no direct
+        // posting or format directive introduced USD).
+        let has_usd = hir
+            .global_context
+            .commodity_properties
+            .get("USD")
+            .map(|p| p.inferred_scale > 0)
+            .unwrap_or(false);
+
+        assert!(
+            !has_usd,
+            "inferred_scale for USD must NOT be populated from {{cost}} lot annotations"
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes the regression introduced by #284 that caused wow.dat GOLD balances to
over-round, manifesting as `Assets:Tajer GOLD: canonical=147.82 doppio=147.83`
in the parity harness.

Two inter-related bugs, both fixed together:

- **`D`/`commodity format` directives now populate `inferred_scale`** — The
  `CommodityItem::Format` arm in resolution now calls a new `scale_from_format`
  helper that counts decimal digits in the format string and records the result
  in `CommodityProperties::inferred_scale`. This gives `inferred_scale[GOLD] = 2`
  from `D 1.00 GOLD` even though every direct GOLD posting in wow.dat is an
  integer (scale 0). Without this, `inferred_scale[GOLD] = 0` → integer rounding
  of all `@`-price GOLD costs.

- **C-chain-converted `@`-prices are no longer rounded** — when a `@`-price is
  written in a non-canonical commodity (e.g. `@ 21050 COPPER`) and divided through
  the C-directive chain to reach GOLD (`21050 / 10000 = 2.105 GOLD`), the result
  is exact with no IEEE-double noise. Previously, `inferred_scale[GOLD] = 2` caused
  this exact value to be banker's-rounded to `2.10 GOLD`, losing 50 COPPER of
  precision across the journal. The fix adds
  `eval_and_normalize_amount_with_conversion_flag` which surfaces whether a C-chain
  conversion occurred; the `at_price_cash` elaborator path skips scale rounding when
  the flag is set, matching ledger-cli's behavior of accumulating in the native
  commodity and converting at display time.

This corrects the #284 regression while preserving the original intent: IEEE-double
noise prices like `@ $53.6599...28dp` (expressed directly in the target commodity,
no chain conversion) are still rounded to the commodity's inferred scale.

6 affected wow.dat accounts all now match ledger-cli after display-scale=2 rounding:
`Assets:Tajer`, `Equity:Gold`, `Expenses:Capital Loss`, `Expenses:Fees:Auction`,
`Expenses:Items`, `Income:Brokering`.

## Tests added

- `resolution::test_inferred_scale_from_format_directive` — `D 1.00 GOLD` → `inferred_scale[GOLD] = 2`
- `resolution::test_inferred_scale_format_and_direct_max` — max(format=3, direct=2) = 3
- `resolution::test_inferred_scale_at_price_not_included` — `@`-price annotations excluded
- `resolution::test_inferred_scale_lot_cost_not_included` — `{cost}` lot annotations excluded
- `elaborator::test_at_price_intent_rounding_when_no_direct_posting_at_higher_scale` — minimal wow.dat repro with `D 1.00 GOLD`; verifies `-1.25 GOLD` not `-1 GOLD`
- `elaborator::test_standard_dat_1880_regression_preserved` — 4-leg LMVTX/EEEEE transaction still elaborates cleanly

## Test plan

- [x] `cargo test -p doppio` — 418/418 pass
- [x] `parity_check.py ledger:wow` — passes (was failing with `Assets:Tajer GOLD: canonical=147.82 doppio=147.83`)
- [x] `parity_check.py --negative` — all 4 negative controls pass
- [x] `parity_check.py --self-test` — 12/12 + 6/6 assertions hold
- [x] `cargo clippy -p doppio -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

Closes #288