### PR TITLE
test(parity): wire standard.dat into POSITIVE (#256)

### DIFF
--- a/scripts/parity_check.py
+++ b/scripts/parity_check.py
@@ -1032,6 +1032,12 @@ POSITIVE: list[Case] = [
     Case("ledger:demo",           REPO / "tests/parity/ledger-demo.ledger",      ledger_balances),
     Case("ledger:no-trailing-newline", REPO / "tests/parity/ledger-no-trailing-newline.dat", ledger_balances),
     Case("ledger:drewr3",         REPO / "tests/parity/ledger-drewr3.dat",     ledger_balances),
+    # ledger-standard.dat is the 5,619-line ledger-cli upstream stress fixture.
+    # display_scale=2 collapses ledger-cli's 2-decimal display vs doppio's
+    # full-precision output. Closes #256 once #285 (N-leg implicit cost basis)
+    # and #286 (inferred-scale tolerance) have landed.
+    Case("ledger:standard",       REPO / "tests/parity/ledger-standard.dat",   ledger_balances,
+         display_scale=2),
     Case("hledger:quickstart",    REPO / "tests/parity/hledger-quickstart.journal", hledger_balances),
     Case("hledger:ascii",         REPO / "tests/parity/hledger-ascii.journal", hledger_balances),
     Case("hledger:zerostar",      REPO / "tests/parity/hledger-zerostar.journal", hledger_balances),


### PR DESCRIPTION
## Summary

Wires `tests/parity/ledger-standard.dat` (5,619-line ledger-cli upstream stress fixture, vendored under #287) into the POSITIVE parity list. Both transaction shapes that previously blocked it are now fixed:

- **#285 (PR #291)** — generalised implicit cost-basis inference from literal-2-leg to "exactly 2 non-zero commodity nets," handling the 4-leg sale with cancelling cash legs at line 4063.
- **#286 (PR #290)** — derived tolerance from `CommodityProperties.inferred_scale`, matching ledger-cli's display-precision `is_zero()` check, absorbing the sub-cent residue at line 4244.

## Validation

Local parity: **83/83 matching tuples, 0 divergences** after `display_scale=2` rounding.

The full standard.dat now elaborates cleanly under doppio and matches ledger-cli's output across every account/commodity tuple. This is meaningful coverage — the fixture has SHA1-hash account names anonymised from real bookkeeping data, plus targeted multi-commodity patterns (line 1880's IEEE-double-noise prices, line 4063's cancelling-pair sale, line 4244's cents-dust rebalance).

## Closes

`Closes #256` — standard.dat parity, the corpus-expansion item that motivated #281, #285, #286, #288.

## Test plan

- [x] `python3 scripts/parity_check.py --dop-bin target/release/dop` includes `ledger:standard` and reports OK.
- [x] Existing fixtures continue to pass (no Rust code changes; one-line addition to POSITIVE).