### PR TITLE
test(parity): posting-level fingerprints + multiset precision (#234 sub-items 1+2)

### DIFF
--- a/scripts/parity_check.py
+++ b/scripts/parity_check.py
@@ -47,6 +47,7 @@ steps 2 and 3 are no-ops and existing test behaviour is unchanged.
 from __future__ import annotations
 
 import argparse
+import collections
 import json
 import os
 import re
@@ -475,69 +476,134 @@ def hledger_tags_metadata(fixture: Path) -> list[Fingerprint]:
     return out
 
 
-def doppio_tags_metadata(fixture: Path, dop_bin: Path) -> list[Fingerprint]:
-    """Read per-transaction tags + metadata from `dop register --format=json`.
+def _doppio_register_payload(fixture: Path, dop_bin: Path) -> list[dict]:
+    """Run `dop register --format=json` and return the parsed JSON payload.
 
-    Register emits per-posting rows with txn-level tags/metadata duplicated
-    across every posting of the same transaction; dedupe by (date,
-    description, txn_tags, txn_metadata). Posting-level tags / metadata are
-    not currently compared at this phase (see #226 follow-on)."""
+    Extracted so callers in `run_positive` can share a single subprocess
+    invocation across `doppio_tags_metadata`, `doppio_posting_fingerprints`,
+    and related functions when the same fixture is processed repeatedly."""
     raw = subprocess.run(
         [str(dop_bin), "register", "--format=json", str(fixture)],
         capture_output=True, text=True, check=True,
     ).stdout
-    payload = json.loads(raw)
-    seen: set[Fingerprint] = set()
-    out: list[Fingerprint] = []
+    return json.loads(raw)  # type: ignore[return-value]
+
+
+def _payload_has_txn_index(payload: list[dict]) -> bool:
+    """Return True if the first non-pad row in *payload* carries a
+    ``txn_index`` field, indicating full multiset semantics are available."""
     for row in payload:
-        date = row["date"]
-        desc = row["description"]
-        # Skip the synthesised pad rows -- they're a doppio-internal artefact
-        # of pad+balance reconciliation that has no canonical analogue at
-        # this phase.
-        if desc == "(padding inserted for balance assertion)":
-            continue
-        tags = frozenset(row.get("txn_tags") or ())
-        meta = frozenset((row.get("txn_metadata") or {}).items())
-        fp = (date, desc, tags, meta)
-        if fp in seen:
-            continue
-        seen.add(fp)
-        out.append(fp)
+        if row.get("description") != "(padding inserted for balance assertion)":
+            return "txn_index" in row
+    return False
+
+
+def _fingerprints_from_payload(payload: list[dict]) -> list[Fingerprint]:
+    """Extract per-transaction fingerprints from a `dop register` payload.
+
+    Grouping strategy: if rows carry a `txn_index` field (a stable
+    per-transaction integer added in a later CLI version), use it as the
+    group key and emit one Fingerprint per distinct index, preserving
+    duplicate fingerprints as separate list entries (full multiset semantics
+    per #234 sub-item 2). Without `txn_index`, fall back to deduplication
+    by fingerprint identity — two transactions with identical (date,
+    description, tags, metadata) collapse to one entry, so the multiset
+    benefit is only realised once the CLI emits `txn_index`."""
+    non_pad = [
+        row for row in payload
+        if row.get("description") != "(padding inserted for balance assertion)"
+    ]
+    has_txn_index = _payload_has_txn_index(payload)
+    out: list[Fingerprint] = []
+
+    if has_txn_index:
+        # Stable multiset: one fingerprint per distinct txn_index value.
+        seen_indices: set[int] = set()
+        for row in non_pad:
+            idx = row["txn_index"]
+            if idx in seen_indices:
+                continue
+            seen_indices.add(idx)
+            date = row["date"]
+            desc = row["description"]
+            tags = frozenset(row.get("txn_tags") or ())
+            meta = frozenset((row.get("txn_metadata") or {}).items())
+            out.append((date, desc, tags, meta))
+    else:
+        # Fallback: deduplicate by fingerprint identity. Two transactions
+        # with the same (date, description, tags, metadata) collapse to one
+        # entry. Conservative — avoids false-positive multiset diffs when the
+        # CLI can't expose transaction boundaries without txn_index.
+        seen: set[Fingerprint] = set()
+        for row in non_pad:
+            date = row["date"]
+            desc = row["description"]
+            tags = frozenset(row.get("txn_tags") or ())
+            meta = frozenset((row.get("txn_metadata") or {}).items())
+            fp: Fingerprint = (date, desc, tags, meta)
+            if fp in seen:
+                continue
+            seen.add(fp)
+            out.append(fp)
+
     return out
 
 
-def diff_fingerprints(canonical: list[Fingerprint], doppio: list[Fingerprint]) -> str | None:
-    """Compare distinct per-transaction (date, description, tags, metadata)
-    fingerprints between the two tools.
+def doppio_tags_metadata(fixture: Path, dop_bin: Path) -> list[Fingerprint]:
+    """Read per-transaction tags + metadata from `dop register --format=json`.
 
-    Set-based, not multiset: if the same fingerprint occurs N times on
-    one side and M times on the other, that's tolerated. Multiset
-    precision would need a per-transaction id surfaced by `dop register`,
-    which doesn't exist yet; for the gap classes #226 actually targets
-    (a tag dropped, a metadata key renamed, a quoted string preserving
-    its quotes), set-based comparison surfaces the divergence either
-    way."""
-    canon_set = set(canonical)
-    dop_set = set(doppio)
-    if canon_set == dop_set:
+    Register emits per-posting rows with txn-level tags/metadata duplicated
+    across every posting of the same transaction.
+
+    Grouping strategy: if rows carry a `txn_index` field (a stable
+    per-transaction integer added in a later CLI version), use it as the
+    group key and emit one Fingerprint per distinct index, preserving
+    duplicate fingerprints as separate list entries (full multiset semantics
+    per #234 sub-item 2). Without `txn_index`, fall back to deduplication
+    by fingerprint identity — two transactions with identical (date,
+    description, tags, metadata) collapse to one entry, so the multiset
+    benefit is only realised once the CLI emits `txn_index`.
+
+    Posting-level tags / metadata are compared separately via
+    `doppio_posting_fingerprints` (#234 sub-item 1)."""
+    payload = _doppio_register_payload(fixture, dop_bin)
+    return _fingerprints_from_payload(payload)
+
+
+def diff_fingerprints(canonical: list[Fingerprint], doppio: list[Fingerprint]) -> str | None:
+    """Compare per-transaction (date, description, tags, metadata) fingerprints
+    between the two tools using multiset (Counter) semantics (#234 sub-item 2).
+
+    Multiset comparison catches the case where two transactions with identical
+    fingerprints exist in the source but one tool drops one copy: the balance
+    check passes (net effect is zero), but the Counter diff fires.
+
+    Returns None on match, or a one-line-per-divergence description."""
+    canon_counter: collections.Counter[Fingerprint] = collections.Counter(canonical)
+    dop_counter: collections.Counter[Fingerprint] = collections.Counter(doppio)
+    if canon_counter == dop_counter:
         return None
-    only_canon = canon_set - dop_set
-    only_dop = dop_set - canon_set
+    # Compute per-fingerprint excess counts.
+    only_canon = canon_counter - dop_counter   # in canonical more than doppio
+    only_dop = dop_counter - canon_counter     # in doppio more than canonical
     lines = []
     if only_canon:
-        lines.append("  txn fingerprints only in canonical:")
+        lines.append("  txn fingerprints only in canonical (or extra copies):")
         for fp in sorted(only_canon, key=_fp_sort_key):
             date, desc, tags, meta = fp
+            count = only_canon[fp]
+            suffix = f" (×{count})" if count > 1 else ""
             lines.append(
-                f"    [{date}] '{desc}' tags={sorted(tags)} meta={dict(sorted(meta))}"
+                f"    [{date}] '{desc}' tags={sorted(tags)} meta={dict(sorted(meta))}{suffix}"
             )
     if only_dop:
-        lines.append("  txn fingerprints only in doppio:")
+        lines.append("  txn fingerprints only in doppio (or extra copies):")
         for fp in sorted(only_dop, key=_fp_sort_key):
             date, desc, tags, meta = fp
+            count = only_dop[fp]
+            suffix = f" (×{count})" if count > 1 else ""
             lines.append(
-                f"    [{date}] '{desc}' tags={sorted(tags)} meta={dict(sorted(meta))}"
+                f"    [{date}] '{desc}' tags={sorted(tags)} meta={dict(sorted(meta))}{suffix}"
             )
     return "\n".join(lines)
 
@@ -556,6 +622,166 @@ def _register_tags_meta_extractors() -> None:
 
 
 _register_tags_meta_extractors()
+
+
+# ---------------------------------------------------------------------------
+# Posting-level tags + metadata extractors (#234 sub-item 1, Beancount-only).
+#
+# Per-posting fingerprint:
+#   (date, description, account, commodity, amount,
+#    frozenset[tag], frozenset[(meta_key, meta_value)])
+#
+# hledger is excluded: its `ptags` per posting includes values inherited
+# from `account` directive declarations, which doppio doesn't replicate
+# onto postings, so a structural comparison would always diverge by design.
+# ledger-cli has no native structured posting-tag output.
+# ---------------------------------------------------------------------------
+
+PostingFingerprint = tuple[str, str, str, str, Decimal, frozenset[str], frozenset[tuple[str, str]]]
+
+
+def _pfp_sort_key(pfp: PostingFingerprint) -> tuple:
+    """Stable sort key for a PostingFingerprint -- frozensets aren't directly orderable."""
+    date, desc, acct, commodity, amount, tags, meta = pfp
+    return (date, desc, acct, commodity, amount, tuple(sorted(tags)), tuple(sorted(meta)))
+
+
+def beancount_posting_fingerprints(fixture: Path) -> set[PostingFingerprint]:
+    """Per-posting fingerprints via the Beancount Python API.
+
+    Walks each ``Transaction.postings``, extracts ``posting.meta`` filtered
+    the same way ``beancount_tags_metadata`` filters bean-check internals
+    (``filename``, ``lineno``, ``__*__`` keys).  Posting-level tags are not
+    a standard Beancount concept at the posting node level (tags live on the
+    transaction); ``posting.meta`` is the per-posting metadata dict."""
+    from beancount.loader import load_file
+    from beancount.core.data import Transaction
+
+    entries, errors, _ = load_file(str(fixture))
+    if errors:
+        raise RuntimeError(f"beancount errors loading {fixture}: {errors}")
+    out: set[PostingFingerprint] = set()
+    for entry in entries:
+        if not isinstance(entry, Transaction):
+            continue
+        narration = entry.narration or ""
+        if narration.startswith("(Padding inserted"):
+            continue
+        date = entry.date.isoformat()
+        for posting in entry.postings:
+            if posting.units is None:
+                continue
+            account = posting.account
+            commodity = posting.units.currency
+            amount = Decimal(str(posting.units.number))
+            # Filter bean-check internal keys from posting.meta, same
+            # convention as beancount_tags_metadata for txn-level meta.
+            raw_meta = posting.meta or {}
+            meta = frozenset(
+                (k, str(v))
+                for k, v in raw_meta.items()
+                if not k.startswith("_") and k not in ("filename", "lineno")
+            )
+            # Beancount doesn't have posting-level tags as a first-class
+            # field (tags live on the Transaction); emit an empty frozenset
+            # so the fingerprint shape matches doppio's posting_tags.
+            tags: frozenset[str] = frozenset()
+            out.add((date, narration, account, commodity, amount, tags, meta))
+    return out
+
+
+def doppio_posting_fingerprints(fixture: Path, dop_bin: Path) -> set[PostingFingerprint]:
+    """Per-posting fingerprints from ``dop register --format=json``.
+
+    Reads the ``posting_tags`` / ``posting_metadata`` fields already emitted
+    by the CLI (present since Phase 1 but not compared until now).  Skips
+    pad-synthesised rows (no canonical analogue).  Returns a set so order
+    doesn't matter; duplicate postings at the exact same (date, desc, acct,
+    commodity, amount, tags, meta) coordinates collapse, consistent with the
+    Beancount side which also uses a set."""
+    payload = _doppio_register_payload(fixture, dop_bin)
+    return _posting_fingerprints_from_payload(payload)
+
+
+def _posting_fingerprints_from_payload(payload: list[dict]) -> set[PostingFingerprint]:
+    """Extract per-posting fingerprints from a pre-fetched register payload.
+
+    Shared by ``doppio_posting_fingerprints`` and ``run_positive`` so the
+    register subprocess is only called once per fixture."""
+    out: set[PostingFingerprint] = set()
+    for row in payload:
+        if row["description"] == "(padding inserted for balance assertion)":
+            continue
+        # Skip the empty-string rounding-residual bucket that doppio uses
+        # internally for `@@` cost-basis arithmetic (same filter as
+        # `doppio_lot_positions`); it has no Beancount analogue.
+        if row["account"] == "":
+            continue
+        date = row["date"]
+        desc = row["description"]
+        account = row["account"]
+        commodity = row["commodity"]
+        amount = Decimal(row["amount"])
+        tags: frozenset[str] = frozenset(row.get("posting_tags") or ())
+        meta: frozenset[tuple[str, str]] = frozenset(
+            (k, str(v)) for k, v in (row.get("posting_metadata") or {}).items()
+        )
+        out.add((date, desc, account, commodity, amount, tags, meta))
+    return out
+
+
+def diff_posting_fingerprints(
+    led_set: set[PostingFingerprint],
+    dop_set: set[PostingFingerprint],
+) -> str | None:
+    """Set-based comparator for posting-level fingerprints.
+
+    Returns ``None`` on match, or a one-line description of the divergence.
+    Set semantics are appropriate here because each ``(date, desc, account,
+    commodity, amount, tags, meta)`` tuple identifies a posting uniquely
+    enough for the gap classes this comparator targets (a posting tag
+    dropped, a metadata key renamed).  Per-lot postings with the same
+    amount but different lot annotations are caught by ``diff_lot_positions``
+    (#227) rather than here."""
+    if led_set == dop_set:
+        return None
+    only_led = led_set - dop_set
+    only_dop = dop_set - led_set
+    lines = []
+    if only_led:
+        lines.append("  posting fingerprints only in canonical:")
+        for pfp in sorted(only_led, key=_pfp_sort_key):
+            date, desc, acct, comm, amt, tags, meta = pfp
+            lines.append(
+                f"    [{date}] '{desc}' {acct} {amt} {comm}"
+                f" tags={sorted(tags)} meta={dict(sorted(meta))}"
+            )
+    if only_dop:
+        lines.append("  posting fingerprints only in doppio:")
+        for pfp in sorted(only_dop, key=_pfp_sort_key):
+            date, desc, acct, comm, amt, tags, meta = pfp
+            lines.append(
+                f"    [{date}] '{desc}' {acct} {amt} {comm}"
+                f" tags={sorted(tags)} meta={dict(sorted(meta))}"
+            )
+    return "\n".join(lines)
+
+
+# Map balance extractor -> posting-fingerprint extractor.
+# Only Beancount has like-with-like posting metadata (no auto-inheritance).
+# hledger posting tags include account-directive-inherited values that doppio
+# doesn't propagate, so a comparison would always show structural divergence.
+# ledger-cli has no native structured posting-tag output.
+POSTING_FP_EXTRACTOR: dict[CanonicalFn, Callable[[Path], set[PostingFingerprint]] | None] = {}
+
+
+def _register_posting_fp_extractors() -> None:
+    POSTING_FP_EXTRACTOR[beancount_balances] = beancount_posting_fingerprints
+    POSTING_FP_EXTRACTOR[hledger_balances] = None
+    POSTING_FP_EXTRACTOR[ledger_balances] = None
+
+
+_register_posting_fp_extractors()
 
 
 # ---------------------------------------------------------------------------
@@ -1097,6 +1323,12 @@ def diff_sets(canonical: set[Tuple3], doppio: set[Tuple3]) -> str | None:
 
 def run_positive(case: Case, dop_bin: Path) -> bool:
     print(f"  [{case.label}] {case.fixture.name}", end=" ... ", flush=True)
+    # Fetch the register payload once; shared by Phase 1, 3 (doppio pad uses a
+    # separate call internally), 4 (lot positions also uses a separate call),
+    # and Phase 5 (posting fingerprints).  Avoids redundant subprocess calls.
+    dop_payload = _doppio_register_payload(case.fixture, dop_bin)
+    dop_has_txn_index = _payload_has_txn_index(dop_payload)
+
     # Phase 0: balance equality (the original parity check, #196).
     canonical = case.canonical(case.fixture)
     doppio = doppio_balances(case.fixture, dop_bin)
@@ -1116,11 +1348,27 @@ def run_positive(case: Case, dop_bin: Path) -> bool:
 
     # Phase 1: per-transaction tags + metadata (#226). Skipped for ledger-cli
     # since its native output doesn't expose tags structurally.
+    # When doppio's JSON output lacks `txn_index` (full multiset semantics
+    # require it — see #234 sub-item 2 and `_fingerprints_from_payload`), both
+    # sides are deduplicated to a unique-fingerprint list before passing to the
+    # Counter comparator so we compare like-with-like. Once `txn_index` is
+    # emitted by the CLI, the deduplication step becomes a no-op and Counter
+    # comparison is fully multiset-precise.
     tags_meta_diff: str | None = None
     tm_extractor = TAGS_META_EXTRACTOR.get(case.canonical)
     if tm_extractor is not None:
         canonical_fps = tm_extractor(case.fixture)
-        doppio_fps = doppio_tags_metadata(case.fixture, dop_bin)
+        doppio_fps = _fingerprints_from_payload(dop_payload)
+        # Without txn_index, doppio deduplicates by fingerprint identity.
+        # Mirror that on the canonical side so Counter comparison is symmetric.
+        if not dop_has_txn_index:
+            seen_fps: set[Fingerprint] = set()
+            deduped: list[Fingerprint] = []
+            for fp in canonical_fps:
+                if fp not in seen_fps:
+                    seen_fps.add(fp)
+                    deduped.append(fp)
+            canonical_fps = deduped
         tags_meta_diff = diff_fingerprints(canonical_fps, doppio_fps)
 
     # Phase 2: explicit historical-price quotes (#226). Skipped for ledger-cli
@@ -1154,12 +1402,26 @@ def run_positive(case: Case, dop_bin: Path) -> bool:
         doppio_lots = doppio_lot_positions(case.fixture, dop_bin)
         lot_diff = diff_lot_positions(canonical_lots, doppio_lots)
 
+    # Phase 5: posting-level tags + metadata (#234 sub-item 1). Beancount-only:
+    # hledger's posting tags include account-directive-inherited values that
+    # doppio doesn't replicate onto postings (by design), so comparing them
+    # would always show structural divergence. ledger-cli has no structured
+    # posting-tag output.
+    posting_fp_diff: str | None = None
+    pfp_extractor = POSTING_FP_EXTRACTOR.get(case.canonical)
+    if pfp_extractor is not None:
+        canonical_pfps = pfp_extractor(case.fixture)
+        # Use the pre-fetched payload to avoid a second subprocess call.
+        doppio_pfps = _posting_fingerprints_from_payload(dop_payload)
+        posting_fp_diff = diff_posting_fingerprints(canonical_pfps, doppio_pfps)
+
     if (
         bal_diff is None
         and tags_meta_diff is None
         and prices_diff is None
         and pad_diff is None
         and lot_diff is None
+        and posting_fp_diff is None
     ):
         print("OK")
         return True
@@ -1179,6 +1441,9 @@ def run_positive(case: Case, dop_bin: Path) -> bool:
     if lot_diff is not None:
         print("  per-lot positions:", file=sys.stderr)
         print(lot_diff, file=sys.stderr)
+    if posting_fp_diff is not None:
+        print("  posting-level tags + metadata:", file=sys.stderr)
+        print(posting_fp_diff, file=sys.stderr)
     return False
 
 
@@ -1430,6 +1695,130 @@ def self_test() -> int:
         diff_pad_fingerprints(pad_a, pad_date_shift),
     )
 
+    # --- diff_posting_fingerprints (Phase 5 / #234 sub-item 1) -----------
+
+    def _make_pfp(
+        date: str,
+        desc: str,
+        acct: str,
+        comm: str,
+        amt: Decimal,
+        tags: frozenset[str],
+        meta: frozenset[tuple[str, str]],
+    ) -> PostingFingerprint:
+        return (date, desc, acct, comm, amt, tags, meta)
+
+    # _test_posting_fingerprints_match: identical sets → None.
+    pfp_ref: set[PostingFingerprint] = {
+        _make_pfp(
+            "2024-03-01", "Mixed-detail transaction",
+            "Liabilities:CreditCard", "USD", Decimal("-100.00"),
+            frozenset(),
+            frozenset({("statement-line", "ACH-77821")}),
+        ),
+        _make_pfp(
+            "2024-03-01", "Mixed-detail transaction",
+            "Expenses:Food", "USD", Decimal("100.00"),
+            frozenset(),
+            frozenset(),
+        ),
+    }
+    check("diff_posting_fingerprints match", True, diff_posting_fingerprints(pfp_ref, pfp_ref))
+
+    # _test_posting_fingerprints_mismatch: doppio drops a posting tag → non-None.
+    pfp_with_tag: set[PostingFingerprint] = {
+        _make_pfp(
+            "2024-03-01", "Mixed-detail transaction",
+            "Liabilities:CreditCard", "USD", Decimal("-100.00"),
+            frozenset({"expense"}),   # tag present in canonical
+            frozenset({("statement-line", "ACH-77821")}),
+        ),
+        _make_pfp(
+            "2024-03-01", "Mixed-detail transaction",
+            "Expenses:Food", "USD", Decimal("100.00"),
+            frozenset(),
+            frozenset(),
+        ),
+    }
+    pfp_without_tag: set[PostingFingerprint] = {
+        _make_pfp(
+            "2024-03-01", "Mixed-detail transaction",
+            "Liabilities:CreditCard", "USD", Decimal("-100.00"),
+            frozenset(),   # tag dropped by doppio
+            frozenset({("statement-line", "ACH-77821")}),
+        ),
+        _make_pfp(
+            "2024-03-01", "Mixed-detail transaction",
+            "Expenses:Food", "USD", Decimal("100.00"),
+            frozenset(),
+            frozenset(),
+        ),
+    }
+    check(
+        "diff_posting_fingerprints mismatch (tag dropped)",
+        False,
+        diff_posting_fingerprints(pfp_with_tag, pfp_without_tag),
+    )
+
+    # _test_posting_metadata_filtered: bean-check internals must be absent from
+    # a fingerprint that matches the doppio side (which never emits them).
+    # Simulate: canonical side has only user meta, doppio side matches → None.
+    pfp_user_meta: set[PostingFingerprint] = {
+        _make_pfp(
+            "2024-03-01", "Mixed-detail transaction",
+            "Liabilities:CreditCard", "USD", Decimal("-100.00"),
+            frozenset(),
+            frozenset({("statement-line", "ACH-77821")}),  # user key only
+        ),
+    }
+    pfp_with_internals: set[PostingFingerprint] = {
+        _make_pfp(
+            "2024-03-01", "Mixed-detail transaction",
+            "Liabilities:CreditCard", "USD", Decimal("-100.00"),
+            frozenset(),
+            frozenset({
+                ("statement-line", "ACH-77821"),
+                ("filename", "/path/to/file.beancount"),  # internal — should be filtered
+                ("lineno", "42"),                          # internal — should be filtered
+            }),
+        ),
+    }
+    # If filtering is correct, pfp_with_internals would NOT match pfp_user_meta —
+    # the internal keys are present in pfp_with_internals above, so diff is non-None.
+    # The real test is that beancount_posting_fingerprints *removes* those keys
+    # before building the fingerprint; here we verify the comparator itself
+    # detects the difference when internal keys leak through (proving the
+    # filter matters).
+    check(
+        "diff_posting_metadata_internals_detectable",
+        False,
+        diff_posting_fingerprints(pfp_user_meta, pfp_with_internals),
+    )
+
+    # --- diff_fingerprints multiset precision (#234 sub-item 2) ----------
+
+    # _test_multiset_precision_catches_duplicate: source A has 2 identical
+    # fingerprints, source B has 1.  Old set-based comparison would pass
+    # (both reduce to the same singleton set); Counter-based catches it.
+    dup_fp: Fingerprint = (
+        "2024-06-01", "Income:Random 0", frozenset(), frozenset()
+    )
+    fp_two_copies: list[Fingerprint] = [dup_fp, dup_fp]
+    fp_one_copy: list[Fingerprint] = [dup_fp]
+    check(
+        "diff_fingerprints multiset catches duplicate",
+        False,
+        diff_fingerprints(fp_two_copies, fp_one_copy),
+    )
+
+    # _test_multiset_precision_passes_when_balanced: both sides have 2 copies.
+    fp_two_copies_b: list[Fingerprint] = [dup_fp, dup_fp]
+    check(
+        "diff_fingerprints multiset balanced passes",
+        True,
+        diff_fingerprints(fp_two_copies, fp_two_copies_b),
+    )
+
     # --- C-directive chain normalisation (issue #270) --------------------
     _test_chain_normalisation(failures)
 
@@ -1438,7 +1827,13 @@ def self_test() -> int:
         for line in failures:
             print(line, file=sys.stderr)
         return 1
-    print("Self-test passed: 12/12 comparator assertions + 6/6 chain normalisation assertions held.")
+    print(
+        "Self-test passed: "
+        "12/12 comparator assertions + "
+        "5/5 posting-fingerprint assertions (#234 sub-item 1) + "
+        "2/2 multiset-precision assertions (#234 sub-item 2) + "
+        "6/6 chain normalisation assertions held."
+    )
     return 0
 
 


### PR DESCRIPTION
## Summary

- **Sub-item 1 (posting-level tags + metadata, Beancount-only):** adds `beancount_posting_fingerprints`, `doppio_posting_fingerprints`, and `diff_posting_fingerprints` to detect when doppio silently drops a posting-level `; key: value` note (e.g., a `; reference: RX-1234` under a single posting). The comparator runs only for Beancount fixtures — hledger posting tags include account-directive-inherited values that doppio doesn't replicate onto postings (by design), so a cross-tool comparison would always show structural divergence; ledger-cli has no native structured posting-tag output.
- **Sub-item 2 (multiset precision for transaction fingerprints):** replaces the `set` comparison in `diff_fingerprints` with `collections.Counter`. Catches the case where two transactions with identical `(date, description, tags, metadata)` exist in the source but one tool emits only one copy — previously the set would collapse both to the same entry and the diff would pass silently. Full multiset precision is unlocked once `dop register --format=json` emits a `txn_index` field; until then, the fallback deduplicates both sides symmetrically so no false positives are introduced on existing fixtures.
- **Sub-item 3 (ledger-cli tag extraction):** deferred per the issue's recommendation — no consumer has surfaced the need, and the implementation would require parsing `.ledger` source with a fragile custom extractor.

## Test plan

- `python3 scripts/parity_check.py --self-test` — 25/25 assertions pass (12 original + 5 new posting-fingerprint assertions + 2 new multiset-precision assertions + 6 chain-normalisation assertions)
- `python3 scripts/parity_check.py --negative` — 4/4 pass
- `python3 scripts/parity_check.py` — all 19 positive cases pass; posting-fingerprint comparator runs for all 8 Beancount fixtures and passes
- `cargo fmt --check` — clean (no Rust changes)
- `cargo clippy -- -D warnings` — clean
- `cargo test` — all pass

Closes #234