### PR TITLE
feat(web): load .dop from local file (upload + drag-and-drop) (#298)

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted } from "vue";
+import { computed, onMounted, ref } from "vue";
 import { storeToRefs } from "pinia";
 import { useJournalStore } from "@/store/journal";
 import FilterBar from "@/components/FilterBar.vue";
@@ -7,7 +7,7 @@ import DashboardView from "@/components/DashboardView.vue";
 import { compareLocalDate, localDateToString } from "@/lib/dop";
 
 const journals = useJournalStore();
-const { journal, error, loading } = storeToRefs(journals);
+const { journal, error, loading, sourceLabel } = storeToRefs(journals);
 
 const summary = computed(() => {
   const j = journal.value;
@@ -26,69 +26,191 @@ onMounted(() => {
   const url = `${import.meta.env.BASE_URL}sample.dop`;
   journals.loadFromUrl(url);
 });
+
+// ── File picker ─────────────────────────────────────────────────────────────
+
+const fileInput = ref<HTMLInputElement | null>(null);
+
+function openFilePicker() {
+  fileInput.value?.click();
+}
+
+function onFileInputChange(event: Event) {
+  const file = (event.target as HTMLInputElement).files?.[0];
+  if (file) loadFile(file);
+  // Reset so re-selecting the same file still triggers change.
+  if (fileInput.value) fileInput.value.value = "";
+}
+
+// ── Drag-and-drop ────────────────────────────────────────────────────────────
+
+const isDragOver = ref(false);
+
+function onDragEnter(event: DragEvent) {
+  event.preventDefault();
+  isDragOver.value = true;
+}
+
+function onDragOver(event: DragEvent) {
+  event.preventDefault();
+}
+
+function onDragLeave(event: DragEvent) {
+  // Only clear when leaving the outermost element (relatedTarget is outside).
+  if (!(event.currentTarget as HTMLElement).contains(event.relatedTarget as Node | null)) {
+    isDragOver.value = false;
+  }
+}
+
+function onDrop(event: DragEvent) {
+  event.preventDefault();
+  isDragOver.value = false;
+  const file = event.dataTransfer?.files[0];
+  if (file) loadFile(file);
+}
+
+// ── Shared file loader ───────────────────────────────────────────────────────
+
+function loadFile(file: File) {
+  const reader = new FileReader();
+  reader.onload = () => {
+    if (reader.result instanceof ArrayBuffer) {
+      journals.loadFromBuffer(reader.result, file.name);
+    }
+  };
+  reader.readAsArrayBuffer(file);
+}
 </script>
 
 <template>
-  <header class="hero">
-    <div class="hero-inner">
-      <div class="hero-titles">
-        <h1>doppio</h1>
-        <p class="tagline">
-          A typed compiler pipeline for
-          <a href="https://ledger-cli.org/" target="_blank" rel="noopener">Ledger</a>
-          plain-text accounting. This page reads
-          <a
-            href="https://github.com/alevy/doppio/blob/main/web/fixtures/sample.ledger"
-            target="_blank"
-            rel="noopener"
-          >a fictional sample journal</a>
-          via a JS-native protobuf decoder -- no Rust or WASM at runtime.
-        </p>
+  <!-- Full-page drag-and-drop wrapper -->
+  <div
+    class="app-root"
+    :class="{ 'drag-active': isDragOver }"
+    @dragenter="onDragEnter"
+    @dragover="onDragOver"
+    @dragleave="onDragLeave"
+    @drop="onDrop"
+  >
+    <!-- Hidden native file input -->
+    <input
+      ref="fileInput"
+      type="file"
+      accept=".dop"
+      class="visually-hidden"
+      @change="onFileInputChange"
+    />
+
+    <header class="hero">
+      <div class="hero-inner">
+        <div class="hero-titles">
+          <h1>doppio</h1>
+          <p class="tagline">
+            A typed compiler pipeline for
+            <a href="https://ledger-cli.org/" target="_blank" rel="noopener">Ledger</a>
+            plain-text accounting. This page reads
+            <a
+              href="https://github.com/alevy/doppio/blob/main/web/fixtures/sample.ledger"
+              target="_blank"
+              rel="noopener"
+            >a fictional sample journal</a>
+            via a JS-native protobuf decoder -- no Rust or WASM at runtime.
+          </p>
+        </div>
+        <div class="hero-actions">
+          <div v-if="summary" class="hero-meta">
+            <span><strong>{{ summary.transactions }}</strong> transactions</span>
+            <span><strong>{{ summary.accounts }}</strong> accounts</span>
+            <span class="range">{{ summary.first }} → {{ summary.last }}</span>
+          </div>
+          <div class="file-controls">
+            <button class="btn-open" @click="openFilePicker">Open .dop file</button>
+            <span v-if="sourceLabel" class="source-label" :title="sourceLabel">
+              {{ sourceLabel }}
+            </span>
+          </div>
+        </div>
       </div>
-      <div v-if="summary" class="hero-meta">
-        <span><strong>{{ summary.transactions }}</strong> transactions</span>
-        <span><strong>{{ summary.accounts }}</strong> accounts</span>
-        <span class="range">{{ summary.first }} → {{ summary.last }}</span>
-      </div>
+    </header>
+
+    <!-- Drag-over overlay -->
+    <div v-if="isDragOver" class="drop-overlay" aria-hidden="true">
+      <div class="drop-overlay-inner">Drop .dop file to load</div>
     </div>
-  </header>
 
-  <main class="content">
-    <section v-if="error" class="card error">
-      <h2>Failed to load <code>sample.dop</code></h2>
-      <pre>{{ error }}</pre>
-    </section>
+    <main class="content">
+      <section v-if="error" class="card error">
+        <h2>Failed to load <code>{{ sourceLabel ?? "file" }}</code></h2>
+        <pre>{{ error }}</pre>
+      </section>
 
-    <section v-else-if="loading || !journal" class="card placeholder">
-      <h2>Loading…</h2>
-    </section>
+      <section v-else-if="loading || !journal" class="card placeholder">
+        <h2>Loading…</h2>
+      </section>
 
-    <template v-else>
-      <FilterBar />
-      <DashboardView />
-    </template>
-  </main>
+      <template v-else>
+        <FilterBar />
+        <DashboardView />
+      </template>
+    </main>
 
-  <footer class="footer">
-    <p>
-      Source:
-      <a href="https://github.com/alevy/doppio" target="_blank" rel="noopener">
-        github.com/alevy/doppio
-      </a>
-      ·
-      Schema:
-      <a
-        href="https://github.com/alevy/doppio/blob/main/proto/doppio.proto"
-        target="_blank"
-        rel="noopener"
-      >
-        proto/doppio.proto
-      </a>
-    </p>
-  </footer>
+    <footer class="footer">
+      <p>
+        Source:
+        <a href="https://github.com/alevy/doppio" target="_blank" rel="noopener">
+          github.com/alevy/doppio
+        </a>
+        ·
+        Schema:
+        <a
+          href="https://github.com/alevy/doppio/blob/main/proto/doppio.proto"
+          target="_blank"
+          rel="noopener"
+        >
+          proto/doppio.proto
+        </a>
+      </p>
+    </footer>
+  </div>
 </template>
 
 <style scoped>
+/* ── Page wrapper ─────────────────────────────────────────────────────────── */
+
+.app-root {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  position: relative;
+}
+
+/* ── Drag-and-drop overlay ───────────────────────────────────────────────── */
+
+.drop-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: rgba(59, 130, 246, 0.12);
+  border: 3px dashed #3b82f6;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.drop-overlay-inner {
+  background: #fff;
+  border: 2px solid #3b82f6;
+  border-radius: 0.75rem;
+  padding: 1.25rem 2.5rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #1d4ed8;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+}
+
+/* ── Hero ─────────────────────────────────────────────────────────────────── */
+
 .hero {
   padding: 2rem 1.5rem 1.25rem;
   border-bottom: 1px solid #e5e5e5;
@@ -121,6 +243,15 @@ onMounted(() => {
   color: #555;
 }
 
+/* ── Right-side hero actions (meta + file controls) ──────────────────────── */
+
+.hero-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.5rem;
+}
+
 .hero-meta {
   display: flex;
   flex-wrap: wrap;
@@ -133,6 +264,61 @@ onMounted(() => {
 .hero-meta .range {
   color: #888;
 }
+
+/* ── File controls ────────────────────────────────────────────────────────── */
+
+.file-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.btn-open {
+  padding: 0.35rem 0.8rem;
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: #1d4ed8;
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.btn-open:hover {
+  background: #dbeafe;
+  border-color: #93c5fd;
+}
+
+.btn-open:active {
+  background: #bfdbfe;
+}
+
+.source-label {
+  font-size: 0.78rem;
+  color: #666;
+  max-width: 14rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── Visually hidden (accessible hide for file input) ────────────────────── */
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ── Content ──────────────────────────────────────────────────────────────── */
 
 .content {
   flex: 1;
@@ -163,6 +349,8 @@ onMounted(() => {
   color: #888;
   padding: 2rem 1rem;
 }
+
+/* ── Footer ───────────────────────────────────────────────────────────────── */
 
 .footer {
   border-top: 1px solid #e5e5e5;

--- a/web/src/store/journal.ts
+++ b/web/src/store/journal.ts
@@ -5,6 +5,8 @@ interface State {
   journal: Journal | null;
   error: string | null;
   loading: boolean;
+  /** Human-readable label for the currently-loaded source (URL basename or local filename). */
+  sourceLabel: string | null;
 }
 
 export const useJournalStore = defineStore("journal", {
@@ -12,6 +14,7 @@ export const useJournalStore = defineStore("journal", {
     journal: null,
     error: null,
     loading: false,
+    sourceLabel: null,
   }),
   actions: {
     async loadFromUrl(url: string) {
@@ -24,8 +27,32 @@ export const useJournalStore = defineStore("journal", {
         }
         const buf = new Uint8Array(await res.arrayBuffer());
         this.journal = readDop(buf);
+        // Display only the final path segment of the URL as the source label.
+        this.sourceLabel = url.split("/").pop() ?? url;
       } catch (e) {
         this.journal = null;
+        this.sourceLabel = null;
+        if (e instanceof DopError) {
+          this.error = `[${e.kind}] ${e.message}`;
+        } else if (e instanceof Error) {
+          this.error = e.message;
+        } else {
+          this.error = String(e);
+        }
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    loadFromBuffer(buf: ArrayBuffer, label: string) {
+      this.loading = true;
+      this.error = null;
+      try {
+        this.journal = readDop(new Uint8Array(buf));
+        this.sourceLabel = label;
+      } catch (e) {
+        this.journal = null;
+        this.sourceLabel = null;
         if (e instanceof DopError) {
           this.error = `[${e.kind}] ${e.message}`;
         } else if (e instanceof Error) {


### PR DESCRIPTION
## Summary

- Adds an **"Open .dop file" button** in the page header (top-right, alongside the transaction meta) that opens a native file dialog filtered to `.dop` files.
- Adds **full-page drag-and-drop**: a blue dashed overlay appears when a file is dragged onto the page, and dropping it loads the file immediately.
- Both paths feed the `ArrayBuffer` through the existing `readDop` decoder pipeline (unchanged) via a new `loadFromBuffer` store action that mirrors `loadFromUrl`.
- The **fixed-URL fetch on page-load is preserved** — visitors still see the sample journal immediately; the local-file controls override once a file is picked or dropped.
- A **source label** (URL basename or local filename) is displayed next to the button so users know what they're looking at. The error card heading also shows the source label.
- Decoder errors are surfaced in the existing error card — no new validation, just routing `DopError` to visible UI instead of the console.

## Test plan

- [ ] Page loads with `sample.dop` by default; source label shows `sample.dop`.
- [ ] Click "Open .dop file", select a valid `.dop` file — dashboard re-renders, source label updates to filename.
- [ ] Click "Open .dop file", select an invalid file — error card appears with `[kind] message` from `readDop`.
- [ ] Drag a valid `.dop` file onto the page — blue overlay appears on drag-over, drops and re-renders on release.
- [ ] Drag an invalid file — error card appears.
- [ ] Re-select the same file after picking it once — still triggers load (input value is reset after each pick).
- [ ] `npm run build` passes; `npm test` passes (58 tests).

Closes #298