### PR TITLE
feat(doppio-wasm): wasm-bindgen shim for browser-based .dop compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,6 +450,15 @@ dependencies = [
  "rust_decimal",
  "serde_json",
  "tempfile",
+]
+
+[[package]]
+name = "doppio-wasm"
+version = "2.2.0"
+dependencies = [
+ "console_error_panic_hook",
+ "doppio",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -628,9 +647,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1462,9 +1481,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1475,9 +1494,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1485,9 +1504,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1498,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -1541,9 +1560,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,10 @@
 [workspace]
-members = ["crates/doppio", "crates/doppio-categorize", "crates/doppio-cli"]
+members = [
+    "crates/doppio",
+    "crates/doppio-categorize",
+    "crates/doppio-cli",
+    "crates/doppio-wasm",
+]
 resolver = "3"
 
 # Shared metadata that applies to every member crate by default. Crates

--- a/crates/doppio-wasm/.gitignore
+++ b/crates/doppio-wasm/.gitignore
@@ -1,0 +1,2 @@
+pkg/
+pkg-node/

--- a/crates/doppio-wasm/Cargo.toml
+++ b/crates/doppio-wasm/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "doppio-wasm"
+description = "wasm-bindgen shim that exposes doppio's compile pipeline to JavaScript."
+readme = "README.md"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license-file = "../../LICENSE"
+keywords.workspace = true
+categories.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+doppio = { path = "../doppio" }
+wasm-bindgen = "=0.2.117"
+console_error_panic_hook = "0.1"

--- a/crates/doppio-wasm/README.md
+++ b/crates/doppio-wasm/README.md
@@ -1,0 +1,125 @@
+# doppio-wasm
+
+A [wasm-bindgen](https://rustwasm.github.io/wasm-bindgen/) shim that exposes
+doppio's compile pipeline to JavaScript. This is the write-side reference
+implementation of the `.dop` format for browser and Node.js environments —
+given plain-text accounting source (ledger, hledger, or beancount), it returns
+a complete `.dop` binary blob that the doppio reader can decode.
+
+Part of [issue #299](https://github.com/alevy/doppio/issues/299) — PR1 of the
+browser-based "compile ledger/hledger/beancount → downloadable .dop" demo.
+PR2 will ship the browser UI that calls this shim.
+
+## JS API
+
+```js
+import init, { compile } from "./pkg/doppio_wasm.js";
+
+await init(); // loads the .wasm module
+
+// Returns Uint8Array — a complete .dop binary blob.
+const bytes = compile(source, "ledger");
+
+// Supported frontends: "ledger", "hledger", "beancount"
+// Unknown frontend name throws an Error.
+// Parse or elaboration failures also throw an Error.
+```
+
+The `compile` function signature is:
+
+```ts
+function compile(source: string, frontend: string): Uint8Array;
+```
+
+A third `config` parameter is reserved for future use and will be added as an
+optional argument when the configuration API stabilises.
+
+### Error handling
+
+Errors thrown by `compile` are plain JavaScript `Error` instances with a
+`.message` property. Parse errors include `(line N, col M)` annotations in the
+message when the underlying error provides that information.
+
+```js
+try {
+  const bytes = compile(badSource, "ledger");
+} catch (e) {
+  console.error(e.message); // e.g. "parse error (line 3, col 1): ..."
+}
+```
+
+## Building
+
+### Prerequisites
+
+- Rust toolchain with the `wasm32-unknown-unknown` target:
+  ```
+  rustup target add wasm32-unknown-unknown
+  ```
+- `wasm-bindgen-cli` version **0.2.117** (must match the Cargo dep exactly):
+  ```
+  # via nix:
+  nix shell nixpkgs#wasm-bindgen-cli
+
+  # or via cargo:
+  cargo install wasm-bindgen-cli --version 0.2.117
+  ```
+
+### Build command
+
+```bash
+bash crates/doppio-wasm/build-wasm.sh
+```
+
+This produces two output directories under `crates/doppio-wasm/`:
+
+| Directory  | Target  | Use case |
+|------------|---------|----------|
+| `pkg/`     | `web`   | Browser apps (PR2 / static site) — uses `import.meta.url` |
+| `pkg-node/`| `nodejs`| Node.js tooling and smoke tests — uses `require` |
+
+Both directories contain:
+- `doppio_wasm.js` — JS glue module
+- `doppio_wasm_bg.wasm` — the compiled WebAssembly binary
+- `doppio_wasm.d.ts` — TypeScript declarations
+
+Both `pkg/` and `pkg-node/` are listed in `.gitignore` — regenerate them
+locally with `build-wasm.sh`.
+
+### Bundle size (workspace release defaults, opt-level=3)
+
+Measured with `--release` and workspace `lto=fat`, `codegen-units=1`, `strip=true`:
+
+| Encoding | Size |
+|----------|------|
+| Raw      | ~2.33 MB |
+| gzip     | ~653 KB  |
+| brotli   | ~431 KB  |
+
+Size optimisations (`opt-level = "z"`) are available as a follow-up; the prior
+probe (without bindgen glue) measured ~285 KB brotli. See [issue #299
+comment](https://github.com/alevy/doppio/issues/299) for the full size table.
+
+## Smoke test
+
+```bash
+bash crates/doppio-wasm/test-smoke.sh
+```
+
+This builds the `pkg-node/` binding (if not present) then runs
+`tests/smoke.mjs` against Node.js. The test checks:
+- A valid ledger journal compiles to a non-empty `Uint8Array` with the `.dop`
+  magic header (`DOP\0` + version 3).
+- Unknown frontend names throw.
+- Syntactically invalid source throws a parse error.
+
+## Known v1 limitations
+
+- **`include` directives are silently ignored.** The file-opener is a no-op
+  stub — all source text must be passed inline in the `source` argument.
+  Plumbing async JS opener callbacks is deferred to a future release.
+
+- **No `config` parameter yet.** The `compile` function currently uses each
+  frontend's default elaboration settings (tolerance, balance mode, assertion
+  scope). An optional third `config` parameter will be added in a future
+  release without breaking the existing two-argument call sites.

--- a/crates/doppio-wasm/build-wasm.sh
+++ b/crates/doppio-wasm/build-wasm.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Build script for the doppio-wasm crate.
+#
+# Produces two output directories:
+#   pkg/      -- wasm-bindgen output targeting the web (ESM, for PR2 / browser use)
+#   pkg-node/ -- wasm-bindgen output targeting Node.js (CJS, for the smoke test)
+#
+# Usage (from repo root or crate directory):
+#   bash crates/doppio-wasm/build-wasm.sh
+#
+# Requirements:
+#   - Rust toolchain with wasm32-unknown-unknown target installed
+#   - wasm-bindgen-cli matching the crate's wasm-bindgen version (0.2.117)
+#     Install via: nix shell nixpkgs#wasm-bindgen-cli
+#     or: cargo install wasm-bindgen-cli --version 0.2.117
+
+set -euo pipefail
+
+CRATE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$CRATE_DIR/../.." && pwd)"
+
+echo "==> Building doppio-wasm (release, wasm32-unknown-unknown)..."
+cargo build --target wasm32-unknown-unknown -p doppio-wasm --release \
+    --manifest-path "$REPO_ROOT/Cargo.toml"
+
+WASM_FILE="$REPO_ROOT/target/wasm32-unknown-unknown/release/doppio_wasm.wasm"
+
+echo "==> Running wasm-bindgen (target: web -> pkg/)..."
+wasm-bindgen --target web --out-dir "$CRATE_DIR/pkg" "$WASM_FILE"
+
+echo "==> Running wasm-bindgen (target: nodejs -> pkg-node/)..."
+wasm-bindgen --target nodejs --out-dir "$CRATE_DIR/pkg-node" "$WASM_FILE"
+
+echo ""
+echo "==> Output sizes:"
+WASM_RAW=$(wc -c < "$CRATE_DIR/pkg/doppio_wasm_bg.wasm")
+WASM_GZ=$(gzip -c "$CRATE_DIR/pkg/doppio_wasm_bg.wasm" | wc -c)
+echo "  Raw:   $(numfmt --to=iec $WASM_RAW)B  ($WASM_RAW bytes)"
+echo "  gzip:  $(numfmt --to=iec $WASM_GZ)B  ($WASM_GZ bytes)"
+
+if command -v brotli >/dev/null 2>&1; then
+    WASM_BR=$(brotli -c "$CRATE_DIR/pkg/doppio_wasm_bg.wasm" | wc -c)
+    echo "  brotli: $(numfmt --to=iec $WASM_BR)B  ($WASM_BR bytes)"
+fi
+
+echo ""
+echo "pkg/ contents (web target, for browser / PR2):"
+ls -lh "$CRATE_DIR/pkg/"
+echo ""
+echo "pkg-node/ contents (nodejs target, for smoke test):"
+ls -lh "$CRATE_DIR/pkg-node/"

--- a/crates/doppio-wasm/src/lib.rs
+++ b/crates/doppio-wasm/src/lib.rs
@@ -1,0 +1,114 @@
+//! wasm-bindgen shim that exposes doppio's compile pipeline to JavaScript.
+//!
+//! # JS API
+//!
+//! ```js
+//! import init, { compile } from "./doppio_wasm.js";
+//!
+//! await init();
+//!
+//! const bytes = compile(source, "ledger"); // Returns Uint8Array (.dop bytes)
+//! ```
+//!
+//! See the crate README for full documentation.
+
+use wasm_bindgen::prelude::*;
+
+/// Compile plain-text accounting source to a `.dop` binary blob.
+///
+/// # Parameters
+///
+/// - `source`: the complete source text of the journal.
+/// - `frontend`: `"ledger"`, `"hledger"`, or `"beancount"`.
+///
+/// # Returns
+///
+/// A `Uint8Array` containing the full `.dop` file (8-byte header + deflate-compressed
+/// protobuf body). Pass it to the browser's `URL.createObjectURL` / a `<a download>`
+/// link or hand it to doppio's `readDop` loader.
+///
+/// # Throws
+///
+/// Throws a JavaScript `Error` on any failure (unknown frontend, parse error,
+/// elaboration error). Parse errors include `line` and `col` annotations in the
+/// message when the underlying error carries that information.
+///
+/// # Known v1 limitations
+///
+/// `include` directives in the source are silently ignored — the file-opener is a
+/// no-op stub. All source text must be passed inline in `source`. This will be
+/// addressed in a future release.
+#[wasm_bindgen]
+pub fn compile(source: &str, frontend: &str) -> Result<Vec<u8>, JsError> {
+    // Install the panic hook on first call so panics surface as JS errors
+    // instead of "RuntimeError: unreachable" with no stack trace.
+    console_error_panic_hook::set_once();
+
+    let fe: Box<dyn doppio::Frontend> = match frontend {
+        "ledger" => Box::new(doppio::LedgerFrontend),
+        "hledger" => Box::new(doppio::HledgerFrontend),
+        "beancount" => Box::new(doppio::BeancountFrontend),
+        other => {
+            return Err(JsError::new(&format!(
+                "unknown frontend {:?}; valid values are \"ledger\", \"hledger\", \"beancount\"",
+                other
+            )));
+        }
+    };
+
+    // No-op opener: `include` directives silently return empty content.
+    // See crate README for the v1 limitation note.
+    let opener: &doppio::frontend::Opener = &|_| Ok(String::new());
+
+    let base = std::path::Path::new("");
+
+    let hir = fe
+        .parse(source, base, opener)
+        .map_err(|e| format_error(e.as_ref()))?;
+
+    let config = fe.elaboration_defaults();
+    let journal = doppio::elaborate(hir, &config).map_err(|e| JsError::new(&e.to_string()))?;
+
+    let mut buf = Vec::new();
+    doppio::write_dop(&journal, &mut buf, doppio::Compression::Deflate)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+
+    Ok(buf)
+}
+
+/// Format a boxed error into a JS-friendly error message.
+///
+/// When the error message matches the pattern emitted by doppio's pest-based
+/// parsers (` --> N:M`) we extract the line/column and prepend them so the
+/// caller sees `"parse error (line N, col M): <message>"`.
+fn format_error(e: &dyn std::error::Error) -> JsError {
+    let msg = e.to_string();
+
+    // pest parse errors include a ` --> line:col` annotation in their Display.
+    // Example: `" --> 3:1\n  |\n3 | ..."`
+    if let Some((line, col)) = extract_line_col(&msg) {
+        JsError::new(&format!("parse error (line {line}, col {col}): {msg}"))
+    } else {
+        JsError::new(&msg)
+    }
+}
+
+/// Attempt to extract `(line, col)` from a pest-formatted error string.
+///
+/// Pest errors render as `" --> LINE:COL\n..."`. We look for the ` --> `
+/// marker and parse the numbers that follow.
+fn extract_line_col(msg: &str) -> Option<(u32, u32)> {
+    // Find the " --> " marker that pest includes in its Display output.
+    let marker = " --> ";
+    let start = msg.find(marker)? + marker.len();
+    let rest = &msg[start..];
+    // The marker is followed by "LINE:COL" (then typically '\n' or end).
+    let colon = rest.find(':')?;
+    let line: u32 = rest[..colon].trim().parse().ok()?;
+    let after_colon = &rest[colon + 1..];
+    let end = after_colon
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(after_colon.len());
+    let col: u32 = after_colon[..end].trim().parse().ok()?;
+    Some((line, col))
+}

--- a/crates/doppio-wasm/test-smoke.sh
+++ b/crates/doppio-wasm/test-smoke.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Run the Node.js smoke test for the doppio-wasm crate.
+#
+# Builds the wasm binary (if not already built), generates the nodejs binding,
+# then executes the smoke test.
+#
+# Usage (from repo root or crate directory):
+#   bash crates/doppio-wasm/test-smoke.sh
+#
+# Requirements: same as build-wasm.sh (see that file for details).
+
+set -euo pipefail
+
+CRATE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$CRATE_DIR/../.." && pwd)"
+
+# Build if pkg-node/ doesn't exist or is stale relative to the source.
+if [ ! -f "$CRATE_DIR/pkg-node/doppio_wasm.js" ]; then
+    echo "==> pkg-node/ not found; running build-wasm.sh first..."
+    bash "$CRATE_DIR/build-wasm.sh"
+fi
+
+echo "==> Running smoke test..."
+node "$CRATE_DIR/tests/smoke.mjs"

--- a/crates/doppio-wasm/tests/smoke.mjs
+++ b/crates/doppio-wasm/tests/smoke.mjs
@@ -1,0 +1,120 @@
+/**
+ * Smoke test for the doppio-wasm Node.js binding.
+ *
+ * Verifies that:
+ *   1. A valid ledger journal compiles to a non-empty Uint8Array that starts
+ *      with the .dop magic header bytes.
+ *   2. An unknown frontend name throws an error.
+ *   3. A syntactically invalid journal throws a parse error.
+ *
+ * Run via: bash crates/doppio-wasm/test-smoke.sh
+ */
+
+import { createRequire } from "module";
+import { fileURLToPath } from "url";
+import path from "path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// The nodejs CJS binding lives in pkg-node/ relative to the crate root.
+const require = createRequire(import.meta.url);
+const { compile } = require(path.join(__dirname, "../pkg-node/doppio_wasm.js"));
+
+// --- Helpers ----------------------------------------------------------------
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(`Assertion failed: ${message}`);
+  }
+}
+
+function assertThrows(fn, msgSubstring) {
+  try {
+    fn();
+    throw new Error(
+      `Expected an error containing "${msgSubstring}" but no error was thrown`,
+    );
+  } catch (e) {
+    if (e.message.includes("Expected an error containing")) throw e; // re-throw assertion errors
+    if (msgSubstring && !e.message.includes(msgSubstring)) {
+      throw new Error(
+        `Expected error message containing "${msgSubstring}", got: "${e.message}"`,
+      );
+    }
+  }
+}
+
+// --- .dop magic bytes -------------------------------------------------------
+//
+// From doppio/src/lib.rs:
+//   const DOP_MAGIC: [u8; 4] = *b"DOP\0";
+//   const DOP_FORMAT_VERSION: u16 = 3;
+//
+// Header layout (8 bytes):
+//   bytes 0..4  -- "DOP\0"
+//   bytes 4..6  -- version LE u16 (3)
+//   byte  6     -- compression (1 = deflate)
+//   byte  7     -- reserved (0)
+const MAGIC = [0x44, 0x4f, 0x50, 0x00]; // "DOP\0"
+const DOP_VERSION = 3;
+
+function checkDopHeader(bytes) {
+  assert(bytes instanceof Uint8Array, "result should be Uint8Array");
+  assert(bytes.length > 8, "result should be longer than 8 bytes");
+
+  for (let i = 0; i < MAGIC.length; i++) {
+    assert(bytes[i] === MAGIC[i], `magic byte ${i}: expected ${MAGIC[i]}, got ${bytes[i]}`);
+  }
+
+  // Version is little-endian u16 at bytes 4..6.
+  const version = bytes[4] | (bytes[5] << 8);
+  assert(version === DOP_VERSION, `expected format version ${DOP_VERSION}, got ${version}`);
+}
+
+// --- Tests ------------------------------------------------------------------
+
+console.log("Test 1: valid ledger journal compiles to .dop bytes");
+{
+  const src = `\
+2024-01-15 Groceries
+    Expenses:Food    $50
+    Assets:Checking
+`;
+  const result = compile(src, "ledger");
+  checkDopHeader(result);
+  console.log(`  OK — output ${result.length} bytes`);
+}
+
+console.log("Test 2: valid hledger journal compiles to .dop bytes");
+{
+  const src = `\
+2024-01-15 Groceries
+    Expenses:Food    $50
+    Assets:Checking
+`;
+  const result = compile(src, "hledger");
+  checkDopHeader(result);
+  console.log(`  OK — output ${result.length} bytes`);
+}
+
+console.log("Test 3: unknown frontend throws");
+{
+  assertThrows(() => compile("anything", "csv"), "unknown frontend");
+  console.log("  OK");
+}
+
+console.log("Test 4: parse error throws");
+{
+  const bad = "this is not valid ledger syntax @@@@\n";
+  assertThrows(() => compile(bad, "ledger"), "");
+  console.log("  OK — parse error propagated");
+}
+
+console.log("Test 5: empty source compiles (empty journal)");
+{
+  const result = compile("", "ledger");
+  checkDopHeader(result);
+  console.log(`  OK — output ${result.length} bytes`);
+}
+
+console.log("\nAll smoke tests passed.");


### PR DESCRIPTION
## Summary

PR1 of 3 for #299 (browser-based "compile ledger/hledger/beancount → downloadable .dop" demo). This PR ships the Rust+JS shim and a Node.js smoke test — no UI. PR2 will consume this shim from a separate `web/compile/` static app.

- Adds `crates/doppio-wasm` — a `cdylib` crate that wraps doppio's compile pipeline via `wasm-bindgen`
- Implements `compile(source: string, frontend: string): Uint8Array` — accepts source text and a frontend name (`"ledger"`, `"hledger"`, `"beancount"`), returns a complete `.dop` binary blob ready for download or decoding
- No-op `include` opener (v1 limitation — documented in README)
- `build-wasm.sh` builds both a `--target web` output (`pkg/`) for the browser and a `--target nodejs` output (`pkg-node/`) for tooling
- `test-smoke.sh` + `tests/smoke.mjs` verify magic-byte header, error propagation, and empty-journal edge case against the Node.js binding

## JS API

```js
import init, { compile } from "./pkg/doppio_wasm.js";
await init();

// Returns Uint8Array — a complete .dop binary blob (8-byte header + deflate proto body)
const bytes = compile(source, "ledger");
```

Throws an `Error` on unknown frontend, parse failure, or elaboration failure. Parse errors include `(line N, col M)` in the message when available.

## Bundle size (release defaults: lto=fat, codegen-units=1, strip=true, opt-level=3)

| Encoding | Size |
|----------|------|
| Raw      | 2.33 MB |
| gzip     | 653 KB |
| brotli   | 431 KB |

Size optimisations (`opt-level = "z"`) are available as a follow-up and can bring brotli to ~285 KB (per the prior probe in #299).

## Test plan

- [x] `cargo build -p doppio-wasm` (host target, dev)
- [x] `cargo build --target wasm32-unknown-unknown -p doppio-wasm --release`
- [x] `wasm-bindgen --target web` produces valid ESM output in `pkg/`
- [x] `wasm-bindgen --target nodejs` produces valid CJS output in `pkg-node/`
- [x] `node tests/smoke.mjs` — all 5 smoke tests pass (valid ledger, valid hledger, unknown frontend throws, parse error throws, empty source)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p doppio-wasm --all-targets -- -D warnings` clean
- [x] `cargo test` — full workspace tests pass

Note: `cargo clippy --all-targets` (workspace-wide) has pre-existing failures in `crates/doppio` unrelated to this PR.

Refs #299