### PR TITLE
feat(cli): tree-mode balance rollup + colon-segment helper (refs #216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **`dop balance` tree mode now rolls up subtotals to parent rows** (refs #216):
+  Previously, tree mode was "indented-flat" — each row printed only the direct
+  balance of that account, leaving parent rows blank when they had no direct
+  postings. Tree mode now matches ledger-cli's `bal` behaviour: each parent row
+  shows the sum of its own direct postings plus all descendant postings. Leaf
+  rows continue to show only their own direct balance. The `--flat` flag is
+  unchanged. Intermediate parent accounts that have no direct postings are
+  materialised as tree rows so the hierarchy is fully visible.
+
+- **Colon-segment handling extracted to `account_path` module**: the ad-hoc
+  inline `chars().filter(|c| c == ':').count()`, `rsplit_once(':')`, and
+  `truncate_account` calls in the balance-rendering path are now centralised in
+  `crates/doppio-cli/src/account_path.rs` (`truncate`, `segment_count`,
+  `last_segment`, `is_subtree`, `subtree_balance`). No behaviour change.
+
 ## [2.2.0] - 2026-05-09
 
 This release closes the standard.dat parity loop: ledger-cli's 5,619-line

--- a/crates/doppio-cli/src/account_path.rs
+++ b/crates/doppio-cli/src/account_path.rs
@@ -1,0 +1,160 @@
+//! Helpers for navigating colon-separated account-path strings.
+//!
+//! Account names in doppio (and ledger-cli) use `:` as a hierarchy separator,
+//! e.g. `Assets:Bank:Checking`. This module centralises all parsing of that
+//! structure so the rest of the CLI does not need to inline ad-hoc colon
+//! counting or `rsplit_once` calls.
+
+/// Truncate an account name to at most `depth` colon-separated components.
+///
+/// Returns a subslice of `account` ending just before the `depth`-th colon,
+/// or the full string if it has fewer than `depth` components.
+///
+/// - `truncate("Expenses:Food:Restaurants", 2)` → `"Expenses:Food"`
+/// - `truncate("Assets:Checking", 1)` → `"Assets"`
+/// - `truncate("Assets", 1)` → `"Assets"`
+pub fn truncate(account: &str, depth: usize) -> &str {
+    let mut count = 0;
+    for (i, c) in account.char_indices() {
+        if c == ':' {
+            count += 1;
+            if count == depth {
+                return &account[..i];
+            }
+        }
+    }
+    account
+}
+
+/// Return the number of colon-separated segments in the account name.
+///
+/// Equals the nesting depth in the account tree: a top-level account like
+/// `Assets` returns `1`; `Assets:Bank:Checking` returns `3`.
+pub fn segment_count(account: &str) -> usize {
+    account.chars().filter(|&c| c == ':').count() + 1
+}
+
+/// Return the last colon-separated segment of an account name.
+///
+/// For a top-level account with no colon this is the full string.
+///
+/// - `last_segment("Assets:Bank:Checking")` → `"Checking"`
+/// - `last_segment("Assets")` → `"Assets"`
+pub fn last_segment(account: &str) -> &str {
+    account.rsplit_once(':').map(|(_, s)| s).unwrap_or(account)
+}
+
+/// Return `true` if `maybe_child` is `account` itself or a direct or indirect
+/// descendant (i.e. `maybe_child` starts with `account` followed by `:`).
+///
+/// Prevents false positives such as `"Assets:BankExtra"` matching under
+/// `"Assets:Bank"`.
+pub fn is_subtree(account: &str, maybe_child: &str) -> bool {
+    maybe_child == account
+        || maybe_child
+            .strip_prefix(account)
+            .map(|rest| rest.starts_with(':'))
+            .unwrap_or(false)
+}
+
+/// Compute the rolled-up per-commodity balance for `account` and all its
+/// descendants from the flat `balances` map produced by the balance command.
+///
+/// Keys in `balances` that equal `account` or start with `account:` are
+/// summed. Zero-balance commodities are retained in the output.
+pub fn subtree_balance<'a>(
+    balances: &'a std::collections::BTreeMap<
+        String,
+        std::collections::BTreeMap<String, rust_decimal::Decimal>,
+    >,
+    account: &str,
+) -> std::collections::BTreeMap<&'a str, rust_decimal::Decimal> {
+    let mut out: std::collections::BTreeMap<&str, rust_decimal::Decimal> =
+        std::collections::BTreeMap::new();
+    for (acct, commodities) in balances {
+        if is_subtree(account, acct) {
+            for (commodity, amount) in commodities {
+                *out.entry(commodity.as_str()).or_default() += amount;
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn truncate_basic() {
+        assert_eq!(truncate("Expenses:Food:Restaurants", 2), "Expenses:Food");
+        assert_eq!(truncate("Assets:Checking", 1), "Assets");
+        assert_eq!(truncate("Assets", 1), "Assets");
+    }
+
+    #[test]
+    fn truncate_exact_depth() {
+        assert_eq!(truncate("Assets:Bank:Checking", 3), "Assets:Bank:Checking");
+    }
+
+    #[test]
+    fn segment_count_counts_segments() {
+        assert_eq!(segment_count("Assets"), 1);
+        assert_eq!(segment_count("Assets:Bank"), 2);
+        assert_eq!(segment_count("Assets:Bank:Checking"), 3);
+    }
+
+    #[test]
+    fn last_segment_extracts_tail() {
+        assert_eq!(last_segment("Assets:Bank:Checking"), "Checking");
+        assert_eq!(last_segment("Assets:Bank"), "Bank");
+        assert_eq!(last_segment("Assets"), "Assets");
+    }
+
+    #[test]
+    fn is_subtree_recognises_descendants() {
+        assert!(is_subtree("Assets:Bank", "Assets:Bank"));
+        assert!(is_subtree("Assets:Bank", "Assets:Bank:Checking"));
+        assert!(is_subtree("Assets:Bank", "Assets:Bank:Savings"));
+        assert!(!is_subtree("Assets:Bank", "Assets:BankExtra"));
+        assert!(!is_subtree("Assets:Bank", "Liabilities"));
+        assert!(!is_subtree("Assets", "Assets2"));
+    }
+
+    #[test]
+    fn subtree_balance_sums_descendants() {
+        let mut balances: BTreeMap<String, BTreeMap<String, rust_decimal::Decimal>> =
+            BTreeMap::new();
+        balances
+            .entry("Assets:Bank:Checking".to_owned())
+            .or_default()
+            .insert("USD".to_owned(), rust_decimal::Decimal::from(100));
+        balances
+            .entry("Assets:Bank:Savings".to_owned())
+            .or_default()
+            .insert("USD".to_owned(), rust_decimal::Decimal::from(200));
+
+        let result = subtree_balance(&balances, "Assets:Bank");
+        assert_eq!(
+            result.get("USD").copied(),
+            Some(rust_decimal::Decimal::from(300))
+        );
+    }
+
+    #[test]
+    fn subtree_balance_no_false_prefix_match() {
+        let mut balances: BTreeMap<String, BTreeMap<String, rust_decimal::Decimal>> =
+            BTreeMap::new();
+        balances
+            .entry("Assets:BankExtra".to_owned())
+            .or_default()
+            .insert("USD".to_owned(), rust_decimal::Decimal::from(999));
+
+        let result = subtree_balance(&balances, "Assets:Bank");
+        assert!(
+            result.is_empty(),
+            "should not match Assets:BankExtra under Assets:Bank"
+        );
+    }
+}

--- a/crates/doppio-cli/src/main.rs
+++ b/crates/doppio-cli/src/main.rs
@@ -8,6 +8,8 @@ use std::{
 use clap::{Parser, Subcommand};
 use regex::Regex;
 
+mod account_path;
+
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
 struct Cli {
@@ -237,36 +239,6 @@ fn load_proto_journal_with_tolerance(
                 doppio::resolution::ToleranceMode::FractionOfSmallestPrecision(fraction);
         }
         Ok(doppio::elaborate(hir, &config)?)
-    }
-}
-
-/// Truncate an account name to at most `depth` colon-separated components.
-///
-/// Returns a subslice of `account` ending at the position of the `depth`-th
-/// colon, or the full string if it has fewer than `depth` components.
-///
-/// # Examples
-///
-/// ```
-/// assert_eq!(truncate_account("Expenses:Food:Restaurants", 2), "Expenses:Food");
-/// assert_eq!(truncate_account("Assets:Checking", 1), "Assets");
-/// assert_eq!(truncate_account("Assets", 1), "Assets");
-/// ```
-fn truncate_account(account: &str, depth: usize) -> &str {
-    let mut colon_pos = None;
-    let mut count = 0;
-    for (i, c) in account.char_indices() {
-        if c == ':' {
-            count += 1;
-            if count == depth {
-                colon_pos = Some(i);
-                break;
-            }
-        }
-    }
-    match colon_pos {
-        Some(pos) => &account[..pos],
-        None => account,
     }
 }
 
@@ -877,7 +849,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         continue;
                     }
                     let account = match depth {
-                        Some(d) => truncate_account(&posting.account, d).to_owned(),
+                        Some(d) => account_path::truncate(&posting.account, d).to_owned(),
                         None => posting.account.clone(),
                     };
                     if let Some(amount) = &posting.amount {
@@ -900,27 +872,59 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
 
+            // In tree mode, materialise synthetic parent rows for every
+            // intermediate account path implied by the leaf accounts.  This
+            // ensures that e.g. `Assets:Bank` appears as a tree row with its
+            // rolled-up subtotal even when it carries no direct postings.
+            if !flat {
+                let leaf_accounts: Vec<String> = balances.keys().cloned().collect();
+                for acct in &leaf_accounts {
+                    // Walk every prefix of the path (all but the full string).
+                    let mut pos = 0;
+                    while let Some(colon_off) = acct[pos..].find(':') {
+                        let prefix_end = pos + colon_off;
+                        let parent = &acct[..prefix_end];
+                        balances.entry(parent.to_owned()).or_default();
+                        pos = prefix_end + 1;
+                    }
+                }
+            }
+
             match format {
                 OutputFormat::Text => {
-                    for (account, commodities) in balances.iter() {
-                        let indent_depth = account.chars().filter(|&c| c == ':').count();
+                    for (account, _direct_commodities) in balances.iter() {
+                        // Indentation depth: number of `:` separators in the name.
+                        let indent_depth = account_path::segment_count(account) - 1;
+
                         let label: &str = if flat || indent_depth == 0 {
                             account.as_str()
                         } else {
-                            // Show only the last component in tree mode.
-                            account
-                                .rsplit_once(':')
-                                .map(|(_, last)| last)
-                                .unwrap_or(account.as_str())
+                            // In tree mode show only the last segment; the
+                            // hierarchy is conveyed by indentation.
+                            account_path::last_segment(account)
                         };
                         let indent = if flat { 0 } else { indent_depth * 2 };
                         let prefix = " ".repeat(indent);
 
-                        let mut commodities_iter = commodities.iter();
+                        // In tree mode, display the rolled-up subtree balance so
+                        // that parent rows with no direct postings show the sum of
+                        // all their descendants (matching ledger-cli's `bal`).
+                        // In flat mode, use only the direct balance for this account.
+                        let rolled: std::collections::BTreeMap<&str, rust_decimal::Decimal>;
+                        let display_commodities: Box<
+                            dyn Iterator<Item = (&str, rust_decimal::Decimal)>,
+                        > = if flat {
+                            Box::new(_direct_commodities.iter().map(|(c, v)| (c.as_str(), *v)))
+                        } else {
+                            rolled = account_path::subtree_balance(&balances, account);
+                            Box::new(rolled.iter().map(|(&c, &v)| (c, v)))
+                        };
+
+                        let mut commodities_iter = display_commodities;
                         if let Some((commodity, value)) = commodities_iter.next() {
                             let balance = display_amount(
                                 commodity,
-                                *value,
+                                value,
                                 commodity_format(commodity, &journal.commodities),
                             );
                             println!("{balance:>20}  {prefix}{label}");
@@ -928,7 +932,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         for (commodity, value) in commodities_iter {
                             let balance = display_amount(
                                 commodity,
-                                *value,
+                                value,
                                 commodity_format(commodity, &journal.commodities),
                             );
                             println!("{balance:>20}");

--- a/crates/doppio-cli/tests/balance.rs
+++ b/crates/doppio-cli/tests/balance.rs
@@ -269,3 +269,122 @@ fn balance_exchange_converts_eur_to_usd() {
         "source commodity 'EUR' should be absent after conversion: {out}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Tree-mode balance rollup (refs #216)
+// ---------------------------------------------------------------------------
+
+/// Journal with two leaf accounts under a common parent that has no direct
+/// postings. Tree mode should show the parent row with the rolled-up subtotal.
+fn bank_hierarchy_journal() -> &'static str {
+    "2024-01-01 Checking deposit
+    Assets:Bank:Checking  100 USD
+    Income:Salary
+
+2024-01-02 Savings deposit
+    Assets:Bank:Savings  200 USD
+    Income:Salary
+"
+}
+
+#[test]
+fn tree_mode_parent_shows_rolled_up_subtotal() {
+    let f = tmp_journal_file(bank_hierarchy_journal());
+    let out = run(&["balance", f.path().to_str().unwrap()]);
+
+    // The "Bank" row (Assets:Bank) should show 300 USD — the sum of Checking
+    // and Savings — even though Assets:Bank has no direct postings.
+    assert!(
+        out.contains("300"),
+        "parent row should carry rolled-up subtotal (300 USD): {out}"
+    );
+    // Leaf rows still show their own direct balances.
+    assert!(
+        out.contains("100"),
+        "Checking leaf should show 100 USD: {out}"
+    );
+    assert!(
+        out.contains("200"),
+        "Savings leaf should show 200 USD: {out}"
+    );
+    // The parent account label appears in the output.
+    assert!(
+        out.contains("Bank"),
+        "parent account 'Bank' label should appear in tree output: {out}"
+    );
+}
+
+#[test]
+fn tree_mode_parent_row_appears_even_with_no_direct_postings() {
+    let f = tmp_journal_file(bank_hierarchy_journal());
+    let out = run(&["balance", f.path().to_str().unwrap()]);
+    // `Bank` is an intermediate node with no direct postings; it must appear
+    // as its own row (not be silently skipped).
+    let bank_count = out.lines().filter(|l| l.contains("Bank")).count();
+    assert!(
+        bank_count >= 1,
+        "at least one row for 'Bank' (the parent) should appear: {out}"
+    );
+}
+
+#[test]
+fn flat_mode_shows_only_direct_balances() {
+    let f = tmp_journal_file(bank_hierarchy_journal());
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+
+    // Flat mode should not show a synthetic Assets:Bank row (no direct postings).
+    assert!(
+        !out.contains("Assets:Bank\n") && !out.contains("Assets:Bank "),
+        "flat mode should not synthesise a parent row for Assets:Bank: {out}"
+    );
+    // The full account names should appear.
+    assert!(
+        out.contains("Assets:Bank:Checking"),
+        "full account name Assets:Bank:Checking should appear in flat mode: {out}"
+    );
+    assert!(
+        out.contains("Assets:Bank:Savings"),
+        "full account name Assets:Bank:Savings should appear in flat mode: {out}"
+    );
+    // The leaf values are the direct balances, not rolled-up subtotals.
+    assert!(
+        out.contains("100"),
+        "Checking balance 100 should appear in flat mode: {out}"
+    );
+    assert!(
+        out.contains("200"),
+        "Savings balance 200 should appear in flat mode: {out}"
+    );
+    // Rolled-up 300 should NOT appear as a separate synthetic row — though it
+    // may appear if any individual account happens to have 300 USD directly.
+    // This test is intentionally loose on that point; the key check is that no
+    // synthetic parent row is emitted.
+}
+
+#[test]
+fn tree_mode_multi_commodity_parent_rollup() {
+    let content = "2024-01-01 USD deposit
+    Assets:Bank:Checking  100 USD
+    Income:Salary
+
+2024-01-02 EUR deposit
+    Assets:Bank:Savings  200 EUR
+    Income:Consulting
+";
+    let f = tmp_journal_file(content);
+    let out = run(&["balance", f.path().to_str().unwrap()]);
+
+    // The parent row (Assets:Bank / Bank) should show both 100 USD and 200 EUR.
+    assert!(
+        out.contains("100") && out.contains("200"),
+        "parent row should carry both commodity totals: {out}"
+    );
+    assert!(
+        out.contains("USD"),
+        "USD commodity should appear in rolled-up parent: {out}"
+    );
+    assert!(
+        out.contains("EUR"),
+        "EUR commodity should appear in rolled-up parent: {out}"
+    );
+}

--- a/docs/SUPPORTED_FEATURES.md
+++ b/docs/SUPPORTED_FEATURES.md
@@ -118,7 +118,7 @@ Status legend:
 | Subcommand / flag | Status | Notes |
 |---|---|---|
 | `dop compile -o OUT SRC` | + | Writes a `.dop` v2 binary |
-| `dop balance` | + | Tree output by default; `--flat` for flat |
+| `dop balance` | + | Tree output by default; rolls up subtotals to parent rows (matching ledger-cli `bal`). `--flat` for flat single-line-per-account output |
 | `dop balance --depth N` | + | |
 | `dop balance --begin DATE` / `--end DATE` | + | |
 | `dop balance --cleared` | + | |


### PR DESCRIPTION
## Summary

- **Tree-mode rollup**: `dop balance` (default tree mode) now shows the
  subtree-summed total on every parent row, matching ledger-cli's `bal`.
  Parent accounts with no direct postings are materialised as tree rows
  with their rolled-up subtotal rather than being silently skipped.

- **Colon-segment helper module**: the ad-hoc inline `chars().filter(…).count()`,
  `rsplit_once(':')`, and `truncate_account` calls are consolidated into
  `crates/doppio-cli/src/account_path.rs` (`truncate`, `segment_count`,
  `last_segment`, `is_subtree`, `subtree_balance`).

## Before / after

**Journal:**
```
2024-01-01 Checking deposit
    Assets:Bank:Checking  100 USD
    Income:Salary

2024-01-02 Savings deposit
    Assets:Bank:Savings  200 USD
    Income:Salary
```

**Before (`dop balance`):**
```
             USD 100      Checking
             USD 200      Savings
            USD -300    Salary
```
(`Assets:Bank` row was absent; `Assets` row was absent)

**After (`dop balance`):**
```
             USD 300  Assets
             USD 300    Bank
             USD 100      Checking
             USD 200      Savings
            USD -300  Income
            USD -300    Salary
```

**`dop balance --flat` (unchanged):**
```
             USD 100  Assets:Bank:Checking
             USD 200  Assets:Bank:Savings
            USD -300  Income:Salary
```

## Scope

This PR addresses the "Hierarchical balance rollup" item from #216.
Color and terminal-width-aware register remain in that umbrella.

Refs #216

## Test plan

- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo test --workspace` passes (616+ tests, 4 new rollup tests in `balance.rs`)
- [ ] New tests: `tree_mode_parent_shows_rolled_up_subtotal`, `tree_mode_parent_row_appears_even_with_no_direct_postings`, `flat_mode_shows_only_direct_balances`, `tree_mode_multi_commodity_parent_rollup`