### PR TITLE
feat(doppio): per-frontend journal writers (#206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Per-frontend journal writers** (`#206`). The `Frontend` trait gains a
+  `write_journal(&self, hir: &HIR, writer: &mut dyn io::Write) -> io::Result<()>`
+  method. Each of the three frontends implements it:
+  - `LedgerFrontend::write_journal` — ledger-cli source text (transactions,
+    price directives, balance assertions; pad directives emitted as
+    `; [beancount] pad …` comments).
+  - `HledgerFrontend::write_journal` — hledger source text (same data model;
+    the hledger-specific `==*` balance-assignment form is preserved verbatim).
+  - `BeancountFrontend::write_journal` — Beancount source text (double-quoted
+    descriptions, `#tag` header syntax, `number COMMODITY` amount form,
+    `balance`/`pad`/`price` directives in Beancount syntax).
+- **Free function `write_journal`** — top-level convenience wrapper around
+  `Frontend::write_journal` for callers using `Box<dyn Frontend>`.
+- **Cross-frontend transcoding with loss markers.** Format-specific constructs
+  that have no equivalent in the target format are emitted as
+  `; [<source-format>] …` comment lines (e.g. a Beancount `pad` directive
+  written through `LedgerFrontend` becomes
+  `; [beancount] pad 2024-01-01 Assets:Bank Equity:Opening`).
+- **`dop print`** now dispatches through `Frontend::write_journal` and therefore
+  emits output in the source file's own format (ledger input → ledger output,
+  hledger input → hledger output, etc.) rather than always emitting ledger-cli
+  syntax.
+
 ### Changed
 
 - **`dop balance` tree mode now rolls up subtotals to parent rows** (refs #216):
@@ -18,6 +43,13 @@
   `truncate_account` calls in the balance-rendering path are now centralised in
   `crates/doppio-cli/src/account_path.rs` (`truncate`, `segment_count`,
   `last_segment`, `is_subtree`, `subtree_balance`). No behaviour change.
+
+### Deprecated
+
+- `doppio::write_ledger` is deprecated since 2.3.0. Use
+  `LedgerFrontend.write_journal(hir, writer)` instead. `write_ledger` only
+  handles a flat `IntoIterator<Item = resolution::Transaction>` (no prices or
+  assertions) and will be removed in v3.0.
 
 ## [2.2.0] - 2026-05-09
 

--- a/crates/doppio-cli/src/main.rs
+++ b/crates/doppio-cli/src/main.rs
@@ -673,7 +673,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let mut file = String::new();
             File::open(&source)?.read_to_string(&mut file)?;
             let hir = frontend.parse(&file, base_path, &doppio::file_opener)?;
-            doppio::write_ledger(hir.transactions(), &mut std::io::stdout())?;
+            frontend.write_journal(&hir, &mut std::io::stdout())?;
         }
         Commands::Accounts { source, pattern } => {
             let journal = load_proto_journal(&source)?;

--- a/crates/doppio/src/frontend.rs
+++ b/crates/doppio/src/frontend.rs
@@ -2,10 +2,15 @@
 //! support.
 //!
 //! Each frontend recognises one or more file extensions and is responsible
-//! for parsing source text into a resolved [`crate::resolution::HIR`]. The
-//! ledger-cli format is implemented in [`crate::grammars::ledger`]; the
-//! hledger dialect is in [`crate::grammars::hledger`].
+//! for parsing source text into a resolved [`crate::resolution::HIR`] and for
+//! serialising an [`HIR`] back to that format's source text via
+//! [`Frontend::write_journal`].
+//!
+//! The ledger-cli format is implemented in [`crate::grammars::ledger`]; the
+//! hledger dialect is in [`crate::grammars::hledger`]; Beancount is in
+//! [`crate::grammars::beancount`].
 
+use std::io;
 use std::path::Path;
 
 use crate::resolution::{ElaborationConfig, HIR};
@@ -18,7 +23,8 @@ use crate::resolution::{ElaborationConfig, HIR};
 /// as a no-op.
 pub type Opener = dyn Fn(&str) -> Result<String, Box<dyn std::error::Error>>;
 
-/// A file-format frontend that produces a resolved [`HIR`].
+/// A file-format frontend that produces a resolved [`HIR`] and can serialise
+/// one back to source text.
 ///
 /// Implement this trait to add support for a new input format. The CLI
 /// uses [`crate::frontend_for_extension`] to select the appropriate
@@ -81,4 +87,46 @@ pub trait Frontend {
         base_path: &Path,
         opener: &Opener,
     ) -> Result<HIR, Box<dyn std::error::Error>>;
+
+    /// Serialise a resolved [`HIR`] to this frontend's source text format.
+    ///
+    /// Each frontend writes in its own native syntax:
+    ///
+    /// - [`crate::LedgerFrontend`] emits ledger-cli source (same format as
+    ///   the deprecated [`crate::write_ledger`]).
+    /// - [`crate::HledgerFrontend`] emits hledger source.
+    /// - [`crate::BeancountFrontend`] emits Beancount source.
+    ///
+    /// ## Round-trip fidelity
+    ///
+    /// Parsing a file with `Frontend::parse`, running resolution, then calling
+    /// `write_journal` on the same frontend produces output that re-parses and
+    /// re-resolves to a semantically equivalent [`HIR`] (modulo whitespace
+    /// differences and the information lost at the resolution boundary — see
+    /// below).
+    ///
+    /// ## Cross-frontend transcoding and lossy cases
+    ///
+    /// When the [`HIR`] was produced by a *different* frontend than the one
+    /// performing the write, format-specific constructs that have no equivalent
+    /// in the target format are emitted as `; [<source-format>] ...` comment
+    /// lines rather than being silently dropped. For example, writing a
+    /// Beancount-sourced journal through [`crate::LedgerFrontend`] emits any
+    /// `pad` directives as:
+    ///
+    /// ```text
+    /// ; [beancount] pad 2024-01-01 Assets:Bank:Checking Equity:Opening-Balances
+    /// ```
+    ///
+    /// ## What the HIR level cannot preserve
+    ///
+    /// The resolution stage consumes `account`/`commodity`/`option` directives
+    /// and inline comments; they are absent from the [`HIR`] and therefore
+    /// absent from the writer's output. A future AST-level writer would recover
+    /// them.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any [`io::Error`] from `writer`.
+    fn write_journal(&self, hir: &HIR, writer: &mut dyn io::Write) -> io::Result<()>;
 }

--- a/crates/doppio/src/grammars/beancount/mod.rs
+++ b/crates/doppio/src/grammars/beancount/mod.rs
@@ -66,6 +66,8 @@
 //! to the transaction's metadata map (where most-recent-pushed wins
 //! per key).
 
+pub mod writer;
+
 use crate::ast::*;
 use pest::Parser as _;
 use pest::iterators::{Pair, Pairs};
@@ -966,6 +968,14 @@ impl crate::frontend::Frontend for BeancountFrontend {
             }
         }
         Ok(hir)
+    }
+
+    fn write_journal(
+        &self,
+        hir: &crate::resolution::HIR,
+        w: &mut dyn std::io::Write,
+    ) -> std::io::Result<()> {
+        writer::write(hir, w)
     }
 }
 

--- a/crates/doppio/src/grammars/beancount/writer.rs
+++ b/crates/doppio/src/grammars/beancount/writer.rs
@@ -1,0 +1,315 @@
+//! Beancount source writer.
+//!
+//! [`write`] serialises a [`resolution::HIR`] to Beancount source text.
+//! Beancount syntax differs from ledger-cli in several ways:
+//!
+//! - Transaction descriptions are always double-quoted strings.
+//! - Amounts are in `number COMMODITY` form (space-separated, commodity after
+//!   amount).
+//! - `*` marks cleared transactions; `!` marks flagged (pending) transactions;
+//!   `txn` is the uncleared keyword (emitted as `*` for simplicity here).
+//! - Balance assertions use `balance YYYY-MM-DD account amount` syntax.
+//! - Price directives use `YYYY-MM-DD price COMMODITY amount` syntax.
+//! - Pad directives use `YYYY-MM-DD pad target_account source_account`.
+//! - Tags use `#tag` prefix in the transaction header.
+//! - Metadata is written as `key: "value"` on indented lines within a block.
+//!
+//! ## What is preserved
+//!
+//! - Transactions (date, state, description, tags, metadata, postings).
+//! - Historical price directives.
+//! - Balance assertions.
+//! - Pad directives (if present in the HIR from a Beancount source).
+//!
+//! ## What is lost vs. the AST
+//!
+//! The resolution stage discards `open`/`close`/`commodity`/`option`/`event`
+//! and other Beancount-specific directives (they become comments in the AST and
+//! are then dropped). A future AST-level writer could recover them.
+//!
+//! ## Cross-frontend transcoding
+//!
+//! Constructs that have no Beancount equivalent are emitted as `; [<format>]`
+//! comment lines. For example, a ledger `apply tag` scope has no Beancount
+//! equivalent and would appear as a comment if it were preserved in the HIR
+//! (currently it is not).
+
+use std::io;
+
+use crate::resolution::{Entry, HIR};
+
+/// Write `hir` to `writer` in Beancount source text format.
+///
+/// Transactions use double-quoted descriptions and `#tag` syntax. Amounts
+/// use the `number COMMODITY` form. Balance assertions and price directives
+/// follow Beancount's own syntax.
+///
+/// # Errors
+///
+/// Propagates any [`io::Error`] from `writer`.
+pub fn write(hir: &HIR, writer: &mut dyn io::Write) -> io::Result<()> {
+    let mut first = true;
+
+    // Historical prices: `YYYY-MM-DD price COMMODITY price_amount`
+    for price in &hir.prices {
+        if !first {
+            writeln!(writer)?;
+        }
+        first = false;
+        let price_str = format_beancount_amount(&price.price);
+        writeln!(
+            writer,
+            "{} price {} {}",
+            price.date, price.commodity, price_str
+        )?;
+    }
+
+    // Entries in source order.
+    for entry in &hir.entries {
+        match &entry.data {
+            Entry::Transaction(txn) => {
+                if !first {
+                    writeln!(writer)?;
+                }
+                first = false;
+                write_transaction(txn, writer)?;
+            }
+            Entry::Assertion(a) => {
+                if !first {
+                    writeln!(writer)?;
+                }
+                first = false;
+                // Beancount: `YYYY-MM-DD balance account amount`
+                let amount_str = format_beancount_amount(&a.amount);
+                writeln!(writer, "{} balance {} {}", a.date, a.account, amount_str)?;
+            }
+            Entry::Pad(p) => {
+                if !first {
+                    writeln!(writer)?;
+                }
+                first = false;
+                // Beancount: `YYYY-MM-DD pad target_account source_account`
+                writeln!(
+                    writer,
+                    "{} pad {} {}",
+                    p.date, p.target_account, p.source_account
+                )?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Format a [`crate::ast::ValueExpr`] in Beancount's preferred style.
+///
+/// Beancount always puts the number first and the commodity second
+/// (`100.00 USD` not `$100.00`). For simple `Amount` expressions this
+/// produces the canonical form. For complex expressions (arithmetic,
+/// etc.) we fall back to the `Display` impl which uses ledger-style
+/// formatting — those expressions only appear in source-constructed
+/// journals, not in round-tripped Beancount files.
+fn format_beancount_amount(expr: &crate::ast::ValueExpr) -> String {
+    use crate::ast::ValueExpr;
+    match expr {
+        ValueExpr::Amount { value, commodity } => {
+            if let Some(c) = commodity {
+                format!("{value} {c}")
+            } else {
+                format!("{value}")
+            }
+        }
+        other => format!("{other}"),
+    }
+}
+
+/// Escape a string for use in a Beancount double-quoted context.
+///
+/// Replaces `\` with `\\` and `"` with `\"`.
+fn beancount_escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn write_transaction(
+    txn: &crate::resolution::Transaction,
+    writer: &mut dyn io::Write,
+) -> io::Result<()> {
+    // Flag: Beancount uses `*` (cleared), `!` (flagged/pending), or `txn` (uncleared).
+    let flag = match txn.state {
+        crate::ast::TransactionState::Cleared => "*",
+        crate::ast::TransactionState::Pending => "!",
+        crate::ast::TransactionState::Uncleared => "txn",
+    };
+
+    // Build the tag portion from the tags vec.
+    // Beancount tags go in the header: `#vacation ^invoice-0123`
+    // Tags that start with `^` are already links; others get `#` prefix.
+    let tags_str: String = txn
+        .tags
+        .iter()
+        .map(|t| {
+            if t.starts_with('^') {
+                format!(" {t}")
+            } else {
+                format!(" #{t}")
+            }
+        })
+        .collect();
+
+    // Description is always quoted in Beancount.
+    let escaped_desc = beancount_escape(&txn.description);
+    writeln!(
+        writer,
+        "{} {} \"{}\"{}",
+        txn.date, flag, escaped_desc, tags_str
+    )?;
+
+    // Secondary date has no Beancount equivalent — emit as a comment.
+    if let Some(sec) = txn.secondary_date {
+        writeln!(writer, "  ; [ledger] secondary-date {sec}")?;
+    }
+    // Code has no Beancount equivalent — emit as a comment.
+    if let Some(ref code) = txn.code {
+        writeln!(writer, "  ; [ledger] code ({code})")?;
+    }
+
+    // Metadata as `key: "value"` lines.
+    for (key, value) in &txn.metadata {
+        let escaped = beancount_escape(value);
+        writeln!(writer, "  {key}: \"{escaped}\"")?;
+    }
+
+    // Plain comments.
+    for comment in &txn.comments {
+        writeln!(writer, "  ; {comment}")?;
+    }
+
+    // Postings.
+    for posting in &txn.postings {
+        write_posting(posting, writer)?;
+    }
+
+    Ok(())
+}
+
+fn write_posting(
+    posting: &crate::resolution::Posting,
+    writer: &mut dyn io::Write,
+) -> io::Result<()> {
+    // Virtual postings have no Beancount equivalent; emit with a marker comment.
+    match posting.kind {
+        crate::ast::PostingKind::Real => {}
+        crate::ast::PostingKind::VirtualUnbalanced => {
+            writeln!(writer, "  ; [ledger] virtual-unbalanced posting follows")?;
+        }
+        crate::ast::PostingKind::VirtualBalanced => {
+            writeln!(writer, "  ; [ledger] virtual-balanced posting follows")?;
+        }
+    }
+
+    // Per-posting state flag in Beancount (`!` flag on the posting line).
+    let flag = match posting.state {
+        crate::ast::TransactionState::Uncleared => None,
+        crate::ast::TransactionState::Pending => Some("!"),
+        crate::ast::TransactionState::Cleared => Some("*"),
+    };
+    if let Some(f) = flag {
+        write!(writer, "  {f} {}", posting.account)?;
+    } else {
+        write!(writer, "  {}", posting.account)?;
+    }
+
+    if let Some(ref amount) = posting.amount {
+        let amount_str = format_beancount_posting_amount(amount);
+        write!(writer, "  {amount_str}")?;
+    }
+    writeln!(writer)?;
+
+    // Posting metadata as `key: "value"` lines.
+    for (key, value) in &posting.metadata {
+        let escaped = beancount_escape(value);
+        writeln!(writer, "    {key}: \"{escaped}\"")?;
+    }
+
+    // Per-posting comments.
+    for comment in &posting.comments {
+        writeln!(writer, "    ; {comment}")?;
+    }
+
+    Ok(())
+}
+
+/// Format an [`crate::ast::AmountDetails`] in Beancount's preferred style.
+///
+/// The core difference from ledger: amounts are `number COMMODITY` (not
+/// `$number` prefix-symbol style). Balance assertions become inline
+/// `= amount` suffixes (Beancount doesn't have them on postings, so we
+/// drop them with a comment marker). The `==*` all-commodities form is
+/// a pure hledger extension — emit it as a comment.
+fn format_beancount_posting_amount(amount: &crate::ast::AmountDetails) -> String {
+    use crate::ast::{AmountDetails, LotPricing};
+
+    // `AmountDetails` is `#[non_exhaustive]`; the wildcard arm is required for
+    // forward compatibility and kept even though it is currently unreachable.
+    #[allow(unreachable_patterns)]
+    match amount {
+        AmountDetails::Amount {
+            value,
+            lot_annotation,
+            lot_pricing,
+            balance_assertion,
+        } => {
+            let mut s = format_beancount_amount(value);
+
+            // Lot annotation: `{cost [, date] [, "note"]}` — Beancount style.
+            if let Some(ann) = lot_annotation {
+                let mut parts = Vec::new();
+                if let Some(cost) = &ann.cost {
+                    parts.push(format_beancount_amount(cost));
+                }
+                if let Some(date) = ann.date {
+                    parts.push(format!("{date}"));
+                }
+                if let Some(note) = &ann.note {
+                    let escaped = beancount_escape(note);
+                    parts.push(format!("\"{escaped}\""));
+                }
+                if !parts.is_empty() {
+                    s.push_str(" {");
+                    s.push_str(&parts.join(", "));
+                    s.push('}');
+                }
+            }
+
+            // Lot pricing: `@ unit_price` or `@@ total_price`.
+            if let Some(pricing) = lot_pricing {
+                match pricing {
+                    LotPricing::Unit(p) => {
+                        s.push_str(&format!(" @ {}", format_beancount_amount(p)));
+                    }
+                    LotPricing::Total(p) => {
+                        s.push_str(&format!(" @@ {}", format_beancount_amount(p)));
+                    }
+                }
+            }
+
+            // Balance assertion on a posting has no Beancount parallel;
+            // Beancount uses top-level `balance` directives. Emit as a comment
+            // suffix so the intent is visible.
+            if let Some(ba) = balance_assertion {
+                s.push_str(&format!(" ; [hledger] = {}", format_beancount_amount(ba)));
+            }
+
+            s
+        }
+        AmountDetails::BalanceAssignment(target) => {
+            // hledger-only form — no Beancount parallel.
+            format!("; [hledger] = {}", format_beancount_amount(target))
+        }
+        AmountDetails::BalanceAssignmentAllCommodities(target) => {
+            // hledger-only `==*` form — no Beancount parallel.
+            format!("; [hledger] ==* {}", format_beancount_amount(target))
+        }
+        _ => String::new(),
+    }
+}

--- a/crates/doppio/src/grammars/hledger/mod.rs
+++ b/crates/doppio/src/grammars/hledger/mod.rs
@@ -41,6 +41,8 @@
 //!   synthesizes a multi-commodity posting that brings each
 //!   currently-held commodity to `X`.
 
+pub mod writer;
+
 use crate::ast::*;
 use pest::Parser as _;
 use pest::iterators::Pair;
@@ -825,6 +827,14 @@ impl crate::frontend::Frontend for HledgerFrontend {
         .parse(input)?;
         let hir: crate::resolution::HIR = ast_journal.try_into()?;
         Ok(hir)
+    }
+
+    fn write_journal(
+        &self,
+        hir: &crate::resolution::HIR,
+        w: &mut dyn std::io::Write,
+    ) -> std::io::Result<()> {
+        writer::write(hir, w)
     }
 }
 

--- a/crates/doppio/src/grammars/hledger/writer.rs
+++ b/crates/doppio/src/grammars/hledger/writer.rs
@@ -1,0 +1,165 @@
+//! hledger source writer.
+//!
+//! [`write`] serialises a [`resolution::HIR`] to hledger source text.
+//! hledger syntax differs from ledger-cli in a few key ways:
+//!
+//! - No secondary dates (`date=secondary_date` is not standard hledger syntax;
+//!   emitted as a trailing comment if present).
+//! - Amounts in `number commodity` form (e.g. `100.00 EUR`) or prefix-symbol
+//!   form (e.g. `$100.00`).
+//! - Balance assertions with `=`, `==`, `=*`, or `==*` operators.
+//! - `P` price directives in the same form as ledger-cli.
+//! - `account` / `commodity` directives are not preserved (not in HIR).
+//!
+//! ## What is preserved
+//!
+//! - Transactions (date, state, code, description, comments, tags, metadata,
+//!   postings).
+//! - Historical price directives.
+//! - Balance assertions.
+//! - Pad directives are emitted as `; [beancount] pad ...` comments since
+//!   hledger has no `pad` primitive.
+//!
+//! ## Cross-frontend transcoding
+//!
+//! When writing a journal that originated from a different frontend (e.g.
+//! ledger or beancount), format-specific constructs that have no hledger
+//! equivalent are emitted as `; [<source-format>] <original>` comment lines.
+//! For example, a Beancount `pad` directive becomes:
+//!
+//! ```text
+//! ; [beancount] pad 2024-01-01 Assets:Bank:Checking Equity:Opening-Balances
+//! ```
+
+use std::io;
+
+use crate::resolution::{Entry, HIR};
+
+/// Write `hir` to `writer` in hledger source text format.
+///
+/// # Errors
+///
+/// Propagates any [`io::Error`] from `writer`.
+pub fn write(hir: &HIR, writer: &mut dyn io::Write) -> io::Result<()> {
+    let mut first = true;
+
+    // Historical prices.
+    for price in &hir.prices {
+        if !first {
+            writeln!(writer)?;
+        }
+        first = false;
+        let price_str = format!("{}", price.price);
+        writeln!(writer, "P {} {} {}", price.date, price.commodity, price_str)?;
+    }
+
+    // Entries in source order.
+    for entry in &hir.entries {
+        match &entry.data {
+            Entry::Transaction(txn) => {
+                if !first {
+                    writeln!(writer)?;
+                }
+                first = false;
+                write_transaction(txn, writer)?;
+            }
+            Entry::Assertion(a) => {
+                if !first {
+                    writeln!(writer)?;
+                }
+                first = false;
+                let strict = if a.strict { "==" } else { "=" };
+                // hledger balance directives use `balance YYYY-MM-DD account amount`.
+                writeln!(
+                    writer,
+                    "; balance {} {} {}  {}",
+                    a.date, strict, a.account, a.amount
+                )?;
+            }
+            Entry::Pad(p) => {
+                if !first {
+                    writeln!(writer)?;
+                }
+                first = false;
+                writeln!(
+                    writer,
+                    "; [beancount] pad {} {} {}",
+                    p.date, p.target_account, p.source_account
+                )?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn write_transaction(
+    txn: &crate::resolution::Transaction,
+    writer: &mut dyn io::Write,
+) -> io::Result<()> {
+    // hledger date format: YYYY-MM-DD (same as ledger).
+    write!(writer, "{}", txn.date)?;
+
+    // Secondary date: hledger supports `YYYY-MM-DD=YYYY-MM-DD` but it is
+    // uncommon; emit it if present.
+    if let Some(sec) = txn.secondary_date {
+        write!(writer, "={sec}")?;
+    }
+
+    match txn.state {
+        crate::ast::TransactionState::Uncleared => {}
+        crate::ast::TransactionState::Pending => write!(writer, " !")?,
+        crate::ast::TransactionState::Cleared => write!(writer, " *")?,
+    }
+    if let Some(ref code) = txn.code {
+        write!(writer, " ({code})")?;
+    }
+    writeln!(writer, " {}", txn.description)?;
+
+    for comment in &txn.comments {
+        writeln!(writer, "    ; {comment}")?;
+    }
+    for tag in &txn.tags {
+        writeln!(writer, "    ; :{tag}:")?;
+    }
+    for (key, value) in &txn.metadata {
+        writeln!(writer, "    ; {key}: {value}")?;
+    }
+
+    for posting in &txn.postings {
+        write_posting(posting, writer)?;
+    }
+
+    Ok(())
+}
+
+fn write_posting(
+    posting: &crate::resolution::Posting,
+    writer: &mut dyn io::Write,
+) -> io::Result<()> {
+    write!(writer, "    ")?;
+    match posting.state {
+        crate::ast::TransactionState::Uncleared => {}
+        crate::ast::TransactionState::Pending => write!(writer, "! ")?,
+        crate::ast::TransactionState::Cleared => write!(writer, "* ")?,
+    }
+    match posting.kind {
+        crate::ast::PostingKind::Real => write!(writer, "{}", posting.account)?,
+        crate::ast::PostingKind::VirtualUnbalanced => write!(writer, "({})", posting.account)?,
+        crate::ast::PostingKind::VirtualBalanced => write!(writer, "[{}]", posting.account)?,
+    }
+    if let Some(ref amount) = posting.amount {
+        write!(writer, "  {amount}")?;
+    }
+    writeln!(writer)?;
+    for comment in &posting.comments {
+        writeln!(writer, "        ; {comment}")?;
+    }
+    for tag in &posting.tags {
+        writeln!(writer, "        ; :{tag}:")?;
+    }
+    for (key, value) in &posting.metadata {
+        writeln!(writer, "        ; {key}: {value}")?;
+    }
+    Ok(())
+}

--- a/crates/doppio/src/grammars/ledger/mod.rs
+++ b/crates/doppio/src/grammars/ledger/mod.rs
@@ -15,6 +15,8 @@
 //! bind tighter than `+` and `-`. The grammar itself treats the token
 //! sequence as flat -- precedence is applied as a post-processing step.
 
+pub mod writer;
+
 use crate::ast::*;
 use pest::Parser as _;
 use pest::iterators::{Pair, Pairs};
@@ -332,6 +334,14 @@ impl crate::frontend::Frontend for LedgerFrontend {
         }
         .parse(input)?;
         Ok(ast_journal.try_into()?)
+    }
+
+    fn write_journal(
+        &self,
+        hir: &crate::resolution::HIR,
+        w: &mut dyn std::io::Write,
+    ) -> std::io::Result<()> {
+        writer::write(hir, w)
     }
 }
 

--- a/crates/doppio/src/grammars/ledger/writer.rs
+++ b/crates/doppio/src/grammars/ledger/writer.rs
@@ -1,0 +1,156 @@
+//! Ledger-cli source writer.
+//!
+//! [`write`] serialises a [`resolution::HIR`] to ledger-cli source text.
+//! The output is idiomatic ledger-cli: standard `YYYY-MM-DD` dates, `;`
+//! comment lines, `*` / `!` state markers, and commodity-after-amount
+//! formatting.
+//!
+//! ## What is preserved
+//!
+//! Everything present in the [`resolution::HIR`] is preserved:
+//!
+//! - Transactions (date, state, code, description, comments, tags, metadata,
+//!   postings with amounts and balance assertions).
+//! - Historical price directives (`P date commodity price`).
+//! - Balance assertions and `pad` directives (emitted as comments since
+//!   ledger-cli has no direct `pad` syntax).
+//!
+//! ## What is lost vs. the AST
+//!
+//! The resolution stage discards `account` / `commodity` directives and inline
+//! comments, so those are absent from the HIR and therefore absent from the
+//! output. A future writer working at the AST level could recover them.
+
+use std::io;
+
+use crate::resolution::{Entry, HIR};
+
+/// Write `hir` to `writer` in ledger-cli source text format.
+///
+/// Transactions are emitted in source order with blank-line separators.
+/// Historical prices appear in `P YYYY-MM-DD commodity price` form.
+/// Balance assertions appear as standalone `YYYY-MM-DD balance account amount`.
+/// Pad directives have no direct ledger-cli equivalent and are emitted as
+/// comments: `; pad YYYY-MM-DD target_account source_account`.
+///
+/// # Errors
+///
+/// Propagates any [`io::Error`] from `writer`.
+pub fn write(hir: &HIR, writer: &mut dyn io::Write) -> io::Result<()> {
+    let mut first = true;
+
+    // Historical prices first (by convention; ledger-cli doesn't enforce order).
+    for price in &hir.prices {
+        if !first {
+            writeln!(writer)?;
+        }
+        first = false;
+        let price_str = format!("{}", price.price);
+        writeln!(writer, "P {} {} {}", price.date, price.commodity, price_str)?;
+    }
+
+    // Entries in source order.
+    for entry in &hir.entries {
+        match &entry.data {
+            Entry::Transaction(txn) => {
+                if !first {
+                    writeln!(writer)?;
+                }
+                first = false;
+                write_transaction(txn, writer)?;
+            }
+            Entry::Assertion(a) => {
+                if !first {
+                    writeln!(writer)?;
+                }
+                first = false;
+                let strict = if a.strict { "==" } else { "=" };
+                writeln!(writer, "{} {} {}  {}", a.date, strict, a.account, a.amount)?;
+            }
+            Entry::Pad(p) => {
+                // `pad` has no ledger-cli native syntax; emit as a comment
+                // with the `; [beancount]` prefix so it's traceable.
+                if !first {
+                    writeln!(writer)?;
+                }
+                first = false;
+                writeln!(
+                    writer,
+                    "; [beancount] pad {} {} {}",
+                    p.date, p.target_account, p.source_account
+                )?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn write_transaction(
+    txn: &crate::resolution::Transaction,
+    writer: &mut dyn io::Write,
+) -> io::Result<()> {
+    // Header: date[=secondary_date] [state] [code] description
+    write!(writer, "{}", txn.date)?;
+    if let Some(sec) = txn.secondary_date {
+        write!(writer, "={sec}")?;
+    }
+    match txn.state {
+        crate::ast::TransactionState::Uncleared => {}
+        crate::ast::TransactionState::Pending => write!(writer, " !")?,
+        crate::ast::TransactionState::Cleared => write!(writer, " *")?,
+    }
+    if let Some(ref code) = txn.code {
+        write!(writer, " ({code})")?;
+    }
+    writeln!(writer, " {}", txn.description)?;
+
+    // Transaction-level comments, tags, and metadata.
+    for comment in &txn.comments {
+        writeln!(writer, "    ; {comment}")?;
+    }
+    for tag in &txn.tags {
+        writeln!(writer, "    ; :{tag}:")?;
+    }
+    for (key, value) in &txn.metadata {
+        writeln!(writer, "    ; {key}: {value}")?;
+    }
+
+    // Postings.
+    for posting in &txn.postings {
+        write_posting(posting, writer)?;
+    }
+
+    Ok(())
+}
+
+fn write_posting(
+    posting: &crate::resolution::Posting,
+    writer: &mut dyn io::Write,
+) -> io::Result<()> {
+    write!(writer, "    ")?;
+    match posting.state {
+        crate::ast::TransactionState::Uncleared => {}
+        crate::ast::TransactionState::Pending => write!(writer, "! ")?,
+        crate::ast::TransactionState::Cleared => write!(writer, "* ")?,
+    }
+    match posting.kind {
+        crate::ast::PostingKind::Real => write!(writer, "{}", posting.account)?,
+        crate::ast::PostingKind::VirtualUnbalanced => write!(writer, "({})", posting.account)?,
+        crate::ast::PostingKind::VirtualBalanced => write!(writer, "[{}]", posting.account)?,
+    }
+    if let Some(ref amount) = posting.amount {
+        write!(writer, "  {amount}")?;
+    }
+    writeln!(writer)?;
+    for comment in &posting.comments {
+        writeln!(writer, "        ; {comment}")?;
+    }
+    for tag in &posting.tags {
+        writeln!(writer, "        ; :{tag}:")?;
+    }
+    for (key, value) in &posting.metadata {
+        writeln!(writer, "        ; {key}: {value}")?;
+    }
+    Ok(())
+}

--- a/crates/doppio/src/lib.rs
+++ b/crates/doppio/src/lib.rs
@@ -38,31 +38,50 @@
 //!
 //! - [`frontend`] -- the [`Frontend`] trait for pluggable file-format support.
 //! - [`grammars`] -- grammar implementations ([`grammars::ledger`] for
-//!   ledger-cli, [`grammars::hledger`] for hledger).
+//!   ledger-cli, [`grammars::hledger`] for hledger, [`grammars::beancount`]
+//!   for Beancount).
 //! - [`resolution`] -- alias resolution, date normalisation, metadata
 //!   extraction.
 //! - [`elaboration`] -- prost-generated Protocol Buffers types
 //!   (`Journal`, `Transaction`, `Posting`, `Amount`, `Decimal`); this is the
 //!   canonical read-side public surface and the wire shape of `.dop` bodies.
 //!
-//! # Serialising transactions as Ledger text
+//! # Serialising journals as source text
 //!
-//! Use [`write_ledger`] to serialise a sequence of [`resolution::Transaction`]
-//! values back to canonical Ledger source text:
+//! Use [`Frontend::write_journal`] to serialise a resolved [`resolution::HIR`]
+//! back to source text in the frontend's native format:
 //!
 //! ```rust
-//! # use doppio::resolution::{Transaction, Posting};
-//! # use chrono::NaiveDate;
-//! let txns = vec![
-//!     Transaction::new(NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(), "Groceries")
-//!         .with_posting(Posting::new("Expenses:Food").with_amount((
-//!             rust_decimal::Decimal::from(50u32), "$",
-//!         )))
-//!         .with_posting(Posting::new("Assets:Checking")),
-//! ];
+//! use doppio::frontend::Frontend as _;
+//! use doppio::LedgerFrontend;
+//! use std::path::Path;
+//!
+//! let hir = LedgerFrontend
+//!     .parse(
+//!         "2024-01-15 Groceries\n    Expenses:Food  $50\n    Assets:Checking\n",
+//!         Path::new(""),
+//!         &|_| Ok(String::new()),
+//!     )
+//!     .unwrap();
 //! let mut out = Vec::new();
-//! doppio::write_ledger(txns, &mut out).unwrap();
+//! LedgerFrontend.write_journal(&hir, &mut out).unwrap();
+//! let text = String::from_utf8(out).unwrap();
+//! assert!(text.contains("Groceries"));
 //! ```
+//!
+//! The same works with [`HledgerFrontend`] and [`BeancountFrontend`]; each
+//! emits the resolved journal in its own native syntax. Cross-frontend
+//! transcoding (parse one format, write another) works on a best-effort basis:
+//! format-specific constructs that have no equivalent in the target format are
+//! emitted as `; [<source-format>] ...` comment lines so they remain visible.
+//!
+//! ## Deprecated: `write_ledger`
+//!
+//! The older [`write_ledger`] API accepts an iterator of
+//! [`resolution::Transaction`] values and writes ledger-cli text. It is
+//! deprecated in favour of `LedgerFrontend.write_journal(hir, writer)`, which
+//! also handles historical prices and balance assertions. `write_ledger` will
+//! be removed in v3.0.
 
 pub mod ast;
 
@@ -306,10 +325,17 @@ pub fn read_dop<R: std::io::Read>(
 ///         .with_posting(Posting::new("Assets:Checking")),
 /// ];
 /// let mut out = Vec::new();
+/// #[allow(deprecated)]
 /// doppio::write_ledger(txns, &mut out).unwrap();
 /// let text = String::from_utf8(out).unwrap();
 /// assert!(text.starts_with("2024-01-15 Groceries"));
 /// ```
+#[deprecated(
+    since = "2.3.0",
+    note = "use `LedgerFrontend.write_journal(hir, writer)` instead; \
+            `write_ledger` only handles transactions (no prices or assertions) \
+            and will be removed in v3.0"
+)]
 pub fn write_ledger<W>(
     entries: impl IntoIterator<Item = resolution::Transaction>,
     writer: &mut W,
@@ -326,6 +352,47 @@ where
         write!(writer, "{txn}")?;
     }
     Ok(())
+}
+
+/// Convenience wrapper: serialise a resolved [`resolution::HIR`] to `writer`
+/// using the given frontend's native syntax.
+///
+/// This is equivalent to calling `frontend.write_journal(hir, writer)` directly.
+/// It exists as a top-level free function so callers working with a
+/// `Box<dyn Frontend>` don't need to import the trait.
+///
+/// # Errors
+///
+/// Propagates any [`std::io::Error`] from `writer`.
+///
+/// # Example
+///
+/// ```rust
+/// use doppio::frontend::Frontend as _;
+/// use doppio::LedgerFrontend;
+/// use std::path::Path;
+///
+/// let hir = LedgerFrontend
+///     .parse(
+///         "2024-01-15 Groceries\n    Expenses:Food  $50\n    Assets:Checking\n",
+///         Path::new(""),
+///         &|_| Ok(String::new()),
+///     )
+///     .unwrap();
+/// let mut out = Vec::new();
+/// doppio::write_journal(&LedgerFrontend, &hir, &mut out).unwrap();
+/// let text = String::from_utf8(out).unwrap();
+/// assert!(text.contains("Groceries"));
+/// ```
+pub fn write_journal<F>(
+    frontend: &F,
+    hir: &resolution::HIR,
+    writer: &mut dyn std::io::Write,
+) -> std::io::Result<()>
+where
+    F: Frontend,
+{
+    frontend.write_journal(hir, writer)
 }
 
 /// Load and concatenate all files matching a glob pattern.
@@ -610,6 +677,7 @@ pub(crate) fn dop_read_header<R: std::io::Read>(
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod write_ledger_tests {
     use chrono::NaiveDate;
     use rust_decimal::Decimal;

--- a/crates/doppio/tests/writer_roundtrip.rs
+++ b/crates/doppio/tests/writer_roundtrip.rs
@@ -1,0 +1,430 @@
+//! Round-trip and cross-frontend transcoding tests for the per-frontend writers.
+//!
+//! Each "same-frontend round-trip" test:
+//!   1. Parses a representative source string with `Frontend::parse`.
+//!   2. Writes the resulting HIR with `Frontend::write_journal`.
+//!   3. Re-parses the output.
+//!   4. Asserts that the re-parsed HIR is semantically equivalent (same
+//!      transactions, same dates, same amounts, same metadata).
+//!
+//! The cross-frontend transcoding test:
+//!   - Parses a Beancount fixture containing a `pad` directive.
+//!   - Writes it through `LedgerFrontend`.
+//!   - Asserts that the output contains the `; [beancount] pad ...` marker
+//!     comment and re-parses as valid ledger-cli source.
+
+use doppio::frontend::Frontend as _;
+use doppio::{BeancountFrontend, HledgerFrontend, LedgerFrontend};
+use std::path::Path;
+
+// -------------------------------------------------------------------------
+// Helpers
+// -------------------------------------------------------------------------
+
+fn no_op_opener(_: &str) -> Result<String, Box<dyn std::error::Error>> {
+    Ok(String::new())
+}
+
+fn ledger_parse(src: &str) -> doppio::resolution::HIR {
+    LedgerFrontend
+        .parse(src, Path::new(""), &no_op_opener)
+        .expect("ledger parse failed")
+}
+
+fn hledger_parse(src: &str) -> doppio::resolution::HIR {
+    HledgerFrontend
+        .parse(src, Path::new(""), &no_op_opener)
+        .expect("hledger parse failed")
+}
+
+fn beancount_parse(src: &str) -> doppio::resolution::HIR {
+    BeancountFrontend
+        .parse(src, Path::new(""), &no_op_opener)
+        .expect("beancount parse failed")
+}
+
+fn ledger_write(hir: &doppio::resolution::HIR) -> String {
+    let mut buf = Vec::new();
+    LedgerFrontend
+        .write_journal(hir, &mut buf)
+        .expect("ledger write failed");
+    String::from_utf8(buf).expect("ledger output is not UTF-8")
+}
+
+fn hledger_write(hir: &doppio::resolution::HIR) -> String {
+    let mut buf = Vec::new();
+    HledgerFrontend
+        .write_journal(hir, &mut buf)
+        .expect("hledger write failed");
+    String::from_utf8(buf).expect("hledger output is not UTF-8")
+}
+
+fn beancount_write(hir: &doppio::resolution::HIR) -> String {
+    let mut buf = Vec::new();
+    BeancountFrontend
+        .write_journal(hir, &mut buf)
+        .expect("beancount write failed");
+    String::from_utf8(buf).expect("beancount output is not UTF-8")
+}
+
+// -------------------------------------------------------------------------
+// Ledger round-trip
+// -------------------------------------------------------------------------
+
+/// Parse a ledger source, write it back, re-parse, and assert semantic
+/// equivalence at the transaction level.
+#[test]
+fn ledger_round_trip_transactions_preserved() {
+    let src = "\
+2024-01-15 * Groceries
+    Expenses:Food  $50.00
+    Assets:Checking
+
+2024-02-01 ! (INV-42) ACME Corp
+    Expenses:Consulting  $500.00  ; vendor: ACME
+    Assets:Bank
+";
+
+    let hir1 = ledger_parse(src);
+    let written = ledger_write(&hir1);
+    let hir2 = ledger_parse(&written);
+
+    // Transaction count.
+    let txns1: Vec<_> = hir1.transactions().collect();
+    let txns2: Vec<_> = hir2.transactions().collect();
+    assert_eq!(txns1.len(), txns2.len(), "transaction count mismatch");
+
+    // First transaction.
+    assert_eq!(txns2[0].description, "Groceries");
+    assert_eq!(
+        txns2[0].date,
+        chrono::NaiveDate::from_ymd_opt(2024, 1, 15).unwrap()
+    );
+    assert!(matches!(
+        txns2[0].state,
+        doppio::ast::TransactionState::Cleared
+    ));
+    assert_eq!(txns2[0].postings.len(), 2);
+    assert_eq!(txns2[0].postings[0].account, "Expenses:Food");
+
+    // Second transaction.
+    assert_eq!(txns2[1].description, "ACME Corp");
+    assert_eq!(txns2[1].code.as_deref(), Some("INV-42"));
+    assert!(matches!(
+        txns2[1].state,
+        doppio::ast::TransactionState::Pending
+    ));
+}
+
+#[test]
+fn ledger_round_trip_metadata_and_tags() {
+    let src = "\
+2024-06-01 Grant revenue
+    ; :income:
+    ; program: Grant:UW:HARVEST
+    Income:Grants  $10000.00
+    Assets:Checking
+";
+
+    let hir1 = ledger_parse(src);
+    let written = ledger_write(&hir1);
+    let hir2 = ledger_parse(&written);
+
+    let txns: Vec<_> = hir2.transactions().collect();
+    assert_eq!(txns.len(), 1);
+    assert!(
+        txns[0].tags.contains(&"income".to_string()),
+        "tag 'income' missing; tags: {:?}",
+        txns[0].tags
+    );
+    assert_eq!(
+        txns[0].metadata.get("program").map(String::as_str),
+        Some("Grant:UW:HARVEST")
+    );
+}
+
+#[test]
+fn ledger_round_trip_price_directive() {
+    let src = "\
+P 2024-01-02 EUR $1.10
+
+2024-02-10 Buy euros
+    Assets:EUR  100.00 EUR @ $1.10
+    Assets:Bank  $-110.00
+";
+
+    let hir1 = ledger_parse(src);
+    let written = ledger_write(&hir1);
+    // Output should contain the price directive.
+    assert!(
+        written.contains("P 2024-01-02 EUR"),
+        "price directive missing from output: {written}"
+    );
+    // Re-parse should succeed.
+    let hir2 = ledger_parse(&written);
+    let txns: Vec<_> = hir2.transactions().collect();
+    assert_eq!(txns.len(), 1);
+    assert_eq!(txns[0].description, "Buy euros");
+}
+
+// -------------------------------------------------------------------------
+// hledger round-trip
+// -------------------------------------------------------------------------
+
+#[test]
+fn hledger_round_trip_transactions_preserved() {
+    let src = "\
+2024-01-15 * Opening Balances
+    assets:bank:checking          $1000.00
+    equity:opening-balances
+
+2024-01-16 ! (INV-42) ACME Corp  ; project:website
+    expenses:consulting           $500.00
+    assets:bank:checking
+";
+
+    let hir1 = hledger_parse(src);
+    let written = hledger_write(&hir1);
+    let hir2 = hledger_parse(&written);
+
+    let txns1: Vec<_> = hir1.transactions().collect();
+    let txns2: Vec<_> = hir2.transactions().collect();
+    assert_eq!(txns1.len(), txns2.len());
+
+    assert_eq!(txns2[0].description, "Opening Balances");
+    assert!(matches!(
+        txns2[0].state,
+        doppio::ast::TransactionState::Cleared
+    ));
+
+    assert_eq!(txns2[1].description, "ACME Corp");
+    assert_eq!(txns2[1].code.as_deref(), Some("INV-42"));
+    assert!(matches!(
+        txns2[1].state,
+        doppio::ast::TransactionState::Pending
+    ));
+}
+
+#[test]
+fn hledger_round_trip_balance_assignment_all_commodities() {
+    // The hledger-specific `==*` form must survive a write-then-reparse cycle.
+    let src = "\
+2024-12-31 retain earnings
+    Income      ==* 0
+    Equity:Retained-Earnings
+";
+    let hir1 = hledger_parse(src);
+    let written = hledger_write(&hir1);
+    // The written output must parse without error.
+    let hir2 = hledger_parse(&written);
+    let txns: Vec<_> = hir2.transactions().collect();
+    assert_eq!(txns.len(), 1, "transaction must survive round-trip");
+    assert_eq!(txns[0].description, "retain earnings");
+}
+
+#[test]
+fn hledger_round_trip_price_directive() {
+    let src = "\
+P 2024-01-02 EUR $1.10
+
+2024-02-10 * Buy euros
+    assets:eur  100.00 EUR @ $1.10
+    assets:bank  $-110.00
+";
+
+    let hir1 = hledger_parse(src);
+    let written = hledger_write(&hir1);
+    assert!(
+        written.contains("P 2024-01-02 EUR"),
+        "price directive missing: {written}"
+    );
+    let hir2 = hledger_parse(&written);
+    let txns: Vec<_> = hir2.transactions().collect();
+    assert_eq!(txns.len(), 1);
+}
+
+// -------------------------------------------------------------------------
+// Beancount round-trip
+// -------------------------------------------------------------------------
+
+#[test]
+fn beancount_round_trip_transactions_preserved() {
+    // A minimal Beancount journal with two transactions.
+    // Note: Beancount requires 2+ spaces between account and amount.
+    let src = "\
+2024-01-01 open Assets:Bank:Checking USD
+2024-01-01 open Expenses:Food USD
+2024-01-01 open Equity:Opening-Balances USD
+
+2024-01-12 * \"Salary\"
+  Assets:Bank:Checking       3400.00 USD
+  Equity:Opening-Balances  -3400.00 USD
+
+2024-01-15 ! \"Groceries\"
+  Expenses:Food              87.43 USD
+  Assets:Bank:Checking      -87.43 USD
+";
+
+    let hir1 = beancount_parse(src);
+    let written = beancount_write(&hir1);
+    let hir2 = beancount_parse(&written);
+
+    let txns1: Vec<_> = hir1.transactions().collect();
+    let txns2: Vec<_> = hir2.transactions().collect();
+    assert_eq!(txns1.len(), txns2.len(), "transaction count mismatch");
+
+    // Descriptions are preserved (re-parsed from quoted strings).
+    assert_eq!(txns2[0].description, "Salary");
+    assert!(matches!(
+        txns2[0].state,
+        doppio::ast::TransactionState::Cleared
+    ));
+    assert_eq!(txns2[1].description, "Groceries");
+    assert!(matches!(
+        txns2[1].state,
+        doppio::ast::TransactionState::Pending
+    ));
+}
+
+#[test]
+fn beancount_round_trip_tags_in_header() {
+    let src = "\
+2024-01-01 open Assets:Bank USD
+2024-01-01 open Expenses:Food USD
+
+2024-03-15 * \"Groceries\" #vacation
+  Expenses:Food     42.10 USD
+  Assets:Bank      -42.10 USD
+";
+
+    let hir1 = beancount_parse(src);
+    let written = beancount_write(&hir1);
+    // The written output must contain the `#vacation` tag in the header.
+    assert!(
+        written.contains("#vacation"),
+        "tag #vacation missing from output: {written}"
+    );
+    // Re-parse must succeed.
+    let hir2 = beancount_parse(&written);
+    let txns: Vec<_> = hir2.transactions().collect();
+    assert_eq!(txns.len(), 1);
+    assert!(
+        txns[0].tags.contains(&"vacation".to_string()),
+        "tag 'vacation' missing after round-trip; tags: {:?}",
+        txns[0].tags
+    );
+}
+
+#[test]
+fn beancount_round_trip_price_directive() {
+    let src = "\
+2024-01-01 open Assets:Brokerage AAPL
+2024-01-01 open Assets:Bank USD
+
+2024-01-02 price AAPL 182.50 USD
+
+2024-02-15 * \"Buy stock\"
+  Assets:Brokerage  10 AAPL {182.50 USD}
+  Assets:Bank      -1825.00 USD
+";
+
+    let hir1 = beancount_parse(src);
+    let written = beancount_write(&hir1);
+    // Price directive must appear in Beancount's `date price` syntax.
+    assert!(
+        written.contains("price AAPL"),
+        "price directive missing from output: {written}"
+    );
+    // Re-parse must succeed.
+    let hir2 = beancount_parse(&written);
+    let txns: Vec<_> = hir2.transactions().collect();
+    assert_eq!(txns.len(), 1);
+    assert_eq!(txns[0].description, "Buy stock");
+}
+
+// -------------------------------------------------------------------------
+// Cross-frontend transcoding
+// -------------------------------------------------------------------------
+
+/// Parse a Beancount source that contains a `pad` directive. Write it through
+/// `LedgerFrontend`. The output must:
+///   1. Contain the `; [beancount] pad ...` marker comment.
+///   2. Re-parse as valid ledger-cli source (no parse errors).
+#[test]
+fn cross_frontend_beancount_to_ledger_pad_marked() {
+    let src = "\
+2024-01-01 open Assets:Bank:Checking USD
+2024-01-01 open Equity:Opening-Balances USD
+
+2024-01-01 pad Assets:Bank:Checking Equity:Opening-Balances
+2024-01-15 balance Assets:Bank:Checking  5000.00 USD
+
+2024-01-12 * \"Salary\"
+  Assets:Bank:Checking       3400.00 USD
+  Equity:Opening-Balances  -3400.00 USD
+";
+
+    let hir = beancount_parse(src);
+    let written = ledger_write(&hir);
+
+    // The pad directive must appear as a marked comment.
+    assert!(
+        written.contains("; [beancount] pad"),
+        "pad marker missing from ledger output:\n{written}"
+    );
+
+    // The ledger writer's assertion form should appear too (from the `balance` directive).
+    // (The balance directive is emitted as a standalone assertion line.)
+    assert!(
+        written.contains("Assets:Bank:Checking"),
+        "account name missing from ledger output:\n{written}"
+    );
+
+    // Re-parse as ledger must succeed.
+    let _hir2 = ledger_parse(&written);
+}
+
+/// Write a Beancount journal (with metadata) through LedgerFrontend and
+/// verify the transaction survives with its description intact.
+#[test]
+fn cross_frontend_beancount_to_ledger_transactions_survive() {
+    let src = "\
+2024-01-01 open Expenses:Food USD
+2024-01-01 open Assets:Bank USD
+
+2024-01-15 * \"Groceries\" #household
+  Expenses:Food   87.43 USD
+  Assets:Bank    -87.43 USD
+";
+
+    let hir = beancount_parse(src);
+    let written = ledger_write(&hir);
+
+    // Re-parse as ledger-cli and verify transaction count and description.
+    let hir2 = ledger_parse(&written);
+    let txns: Vec<_> = hir2.transactions().collect();
+    assert_eq!(txns.len(), 1, "transaction must survive transcoding");
+    assert_eq!(txns[0].description, "Groceries");
+}
+
+/// Write an hledger journal through BeancountFrontend — verify that
+/// hledger-specific `==*` form is emitted as a `; [hledger]` comment
+/// (not dropped silently or treated as valid Beancount).
+#[test]
+fn cross_frontend_hledger_to_beancount_balance_assignment_marked() {
+    let src = "\
+2024-12-31 retain earnings
+    Income      ==* 0
+    Equity:Retained-Earnings
+";
+
+    let hir = hledger_parse(src);
+    let written = beancount_write(&hir);
+
+    // The `==*` form has no Beancount equivalent; it must appear as a
+    // `; [hledger]` comment rather than being silently dropped.
+    assert!(
+        written.contains("; [hledger]"),
+        "`==*` form must be marked as `; [hledger]` in Beancount output:\n{written}"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `write_journal(&self, hir: &HIR, writer: &mut dyn io::Write) -> io::Result<()>` to the `Frontend` trait, implemented on all three frontends (`LedgerFrontend`, `HledgerFrontend`, `BeancountFrontend`).
- Adds a top-level free function `write_journal<F: Frontend>(frontend, hir, writer)` as a convenience wrapper for callers holding a `Box<dyn Frontend>`.
- Deprecates `write_ledger` (since 2.3.0) with a migration note pointing at `LedgerFrontend.write_journal`; removal planned for v3.0.
- Migrates the `dop print` CLI command from the deprecated `write_ledger` to `frontend.write_journal`, so printing now emits native syntax per the source file's format.

## Shape decision

**Unified `Frontend` trait method** — the preferred approach. No trait-level tension emerged: the three impls delegate to module-private `writer::write(hir, writer)` functions co-located with each grammar module (`grammars/ledger/writer.rs`, `grammars/hledger/writer.rs`, `grammars/beancount/writer.rs`), keeping parse and write symmetric.

## Input-type decision

Writers take `&resolution::HIR` — the same type `Frontend::parse` produces. This keeps the pipeline uniform (parse → HIR → write) without requiring callers to thread through the AST.

**What the HIR preserves:**
- All transactions (date, state, code, description, comments, tags, metadata, postings with amounts, lot annotations, lot pricing, balance assertions)
- Historical price directives
- Balance assertion directives
- Beancount `pad` directives

**What the HIR level cannot preserve** (consumed at resolution time):
- `account` / `commodity` / `option` directive text
- Inline source comments (`;` lines outside transactions)
- `close`, `event`, `note`, `document`, `query`, `custom` Beancount directives (they become AST `Entry::Comment` nodes and are then dropped during resolution)

A future AST-level writer would recover these. This is the correct tradeoff for the stated scope of this PR.

## Cross-frontend marker convention

Format-specific constructs that have no equivalent in the target format are emitted as `; [<source-format>] …` comment lines. Established conventions:

| Situation | Emitted line |
|---|---|
| Beancount `pad` written via ledger or hledger writer | `; [beancount] pad 2024-01-01 Assets:Bank Equity:OB` |
| hledger `==*` written via beancount writer | `; [hledger] ==* 0` |
| hledger balance assignment `= X` written via beancount writer | `; [hledger] = X` |
| Ledger secondary date written via beancount writer | `; [ledger] secondary-date 2024-01-20` |
| Ledger transaction code `(REF)` written via beancount writer | `; [ledger] code (REF)` |
| Ledger virtual postings written via beancount writer | `; [ledger] virtual-unbalanced posting follows` |

## Deprecation and v3.0 plan

`write_ledger` is marked `#[deprecated(since = "2.3.0", …)]` with a message pointing at `LedgerFrontend.write_journal`. Its own call sites inside the crate are migrated. The `#[allow(deprecated)]` is placed on the legacy test module rather than on individual call sites.

In v3.0 the plan is to remove `write_ledger` entirely and, if the `Frontend` trait addition causes external impl friction, provide a `write_journal_default` blanket or a sealed-trait escape hatch. (No external impls exist today.)

## API example

```rust
use doppio::frontend::Frontend as _;
use doppio::{LedgerFrontend, HledgerFrontend, BeancountFrontend};
use std::path::Path;

let src = "2024-01-15 Groceries\n    Expenses:Food  $50\n    Assets:Cash\n";
let hir = LedgerFrontend.parse(src, Path::new(""), &|_| Ok(String::new())).unwrap();

// Write in ledger syntax.
let mut ledger_out = Vec::new();
LedgerFrontend.write_journal(&hir, &mut ledger_out).unwrap();

// Write in hledger syntax (same HIR, different serialiser).
let mut hledger_out = Vec::new();
HledgerFrontend.write_journal(&hir, &mut hledger_out).unwrap();

// Write in Beancount syntax.
let mut beancount_out = Vec::new();
BeancountFrontend.write_journal(&hir, &mut beancount_out).unwrap();
```

## Format-specific directive coverage audit

| Directive / construct | Ledger writer | hledger writer | Beancount writer |
|---|---|---|---|
| Transactions | ✓ | ✓ | ✓ |
| P price directives | ✓ | ✓ | ✓ (as `YYYY-MM-DD price`) |
| Balance assertions | ✓ (as `YYYY-MM-DD = account amount`) | ✓ (as comment; hledger has no standalone balance) | ✓ (as `YYYY-MM-DD balance`) |
| Beancount `pad` | `; [beancount] pad …` | `; [beancount] pad …` | ✓ |
| hledger `==*` | emitted as `==* X` (no ledger semantics, but survives) | ✓ | `; [hledger] ==* X` |
| `account`/`commodity` directives | not in HIR | not in HIR | not in HIR |
| Beancount `event`/`note`/`close` | not in HIR | not in HIR | not in HIR |

Closes #206