### PR TITLE
feat(cli): terminal-aware color for dop balance (refs #216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`--color` global flag for terminal-aware color output** (refs #216):
+  `dop balance` now renders negative amounts in red and account names in blue
+  when stdout is a TTY, matching ledger-cli's `bal --force-color` color scheme.
+  The flag accepts `auto` (default), `always`, and `never`:
+  - `auto`: emit color when stdout is a TTY and `NO_COLOR` is unset
+    (per <https://no-color.org/>).
+  - `always`: force ANSI escapes even when piped or redirected.
+  - `never`: suppress all color codes.
+  Existing snapshot tests are unaffected because they capture stdout via a pipe
+  (non-TTY), so `auto` yields plain ASCII. Added `anstream` and `anstyle` as
+  workspace dependencies.
+
 ### Changed
 
 - **`dop balance` tree mode now rolls up subtotals to parent rows** (refs #216):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -60,15 +75,24 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -275,7 +299,7 @@ version = "4.5.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "370daa45065b80218950227371916a1633217ae42b2715b2287b606dcd618e24"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -443,6 +467,8 @@ dependencies = [
 name = "doppio-cli"
 version = "2.2.0"
 dependencies = [
+ "anstream 1.0.0",
+ "anstyle",
  "chrono",
  "clap",
  "doppio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ categories = ["finance", "parser-implementations"]
 [workspace.dependencies]
 # Shared deps with their versions pinned at workspace level. Each member
 # crate re-declares the deps it actually uses with `workspace = true`.
+anstream = "1.0.0"
+anstyle = "1.0.14"
 chrono = { version = "0.4.42", default-features = false }
 clap = { version = "4.5.59", features = ["derive"] }
 glob = "0.3.3"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ dop balance my-journal.dop --pattern "^Expenses" --format json
 
 Prints account balances grouped by commodity. Flags: `--depth N` (truncate hierarchy), `--flat` (single-line output), `--begin`/`--end` (date range), `--cleared` (cleared transactions only), `--tag KEY` (transactions tagged with `KEY`), `--pattern REGEX` (filter accounts), `--format text|json|csv`.
 
+When stdout is a terminal, balance output is colorized: negative amounts appear in red and account names in blue, matching ledger-cli's color scheme. Pass `--color=never` to suppress color or `--color=always` to force it even when piped. The `NO_COLOR` environment variable is also honoured.
+
 ### `register` -- posting register
 
 ```

--- a/crates/doppio-cli/Cargo.toml
+++ b/crates/doppio-cli/Cargo.toml
@@ -19,6 +19,8 @@ path = "src/main.rs"
 doppio = { path = "../doppio", version = "2.0.0" }
 
 # CLI-specific deps not used by the library:
+anstream = { workspace = true }
+anstyle = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 regex = { workspace = true }

--- a/crates/doppio-cli/src/color.rs
+++ b/crates/doppio-cli/src/color.rs
@@ -1,0 +1,63 @@
+//! Terminal-color helpers for `dop` output.
+//!
+//! # Scheme
+//!
+//! The color scheme matches ledger-cli's `bal --force-color` output:
+//! - **Account names** are rendered in blue (ANSI color 34).
+//! - **Negative amounts** are rendered in red (ANSI color 31).
+//! - **Positive amounts and the separator line** are unstyled.
+//!
+//! # Detection
+//!
+//! Color is controlled by the `--color` global flag (`auto` / `always` / `never`):
+//! - `auto` (default): emit color when stdout is a TTY *and* the `NO_COLOR`
+//!   environment variable is unset or empty, per <https://no-color.org/>.
+//! - `always`: always emit ANSI escapes even when piped/redirected.
+//! - `never`: always suppress color.
+//!
+//! Snapshot tests run with stdout captured (not a TTY), so `auto` naturally
+//! yields plain ASCII there — no changes to existing snapshots are needed.
+
+use anstyle::{AnsiColor, Style};
+
+/// The resolved color mode after combining `--color`, `NO_COLOR`, and TTY state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColorMode {
+    /// Emit ANSI color codes.
+    On,
+    /// Emit plain ASCII only.
+    Off,
+}
+
+impl ColorMode {
+    /// Render an amount right-aligned to `width` display columns, with red ANSI
+    /// styling around the content if this mode is `On` and `is_negative` is true.
+    ///
+    /// `s` is the pre-formatted display string (e.g. `"$ -2,000.00"`).
+    /// `is_negative` is derived from the underlying decimal value so that
+    /// commodity-prefix formats (where the `-` is not the first character) are
+    /// handled correctly.
+    ///
+    /// Leading spaces (the right-align padding) are emitted outside the ANSI
+    /// codes, matching ledger-cli's visual layout.
+    pub fn render_amount(&self, s: &str, width: usize, is_negative: bool) -> String {
+        let content_len = s.chars().count();
+        let pad = width.saturating_sub(content_len);
+        let spaces = " ".repeat(pad);
+        if *self == ColorMode::On && is_negative {
+            let style = Style::new().fg_color(Some(anstyle::Color::Ansi(AnsiColor::Red)));
+            format!("{spaces}{style}{s}{style:#}")
+        } else {
+            format!("{spaces}{s}")
+        }
+    }
+
+    /// Wrap an account name string with blue ANSI styling if this mode is `On`.
+    pub fn style_account<'a>(&self, s: &'a str) -> std::borrow::Cow<'a, str> {
+        if *self == ColorMode::Off {
+            return std::borrow::Cow::Borrowed(s);
+        }
+        let style = Style::new().fg_color(Some(anstyle::Color::Ansi(AnsiColor::Blue)));
+        std::borrow::Cow::Owned(format!("{style}{s}{style:#}"))
+    }
+}

--- a/crates/doppio-cli/src/main.rs
+++ b/crates/doppio-cli/src/main.rs
@@ -1,18 +1,65 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs::File,
-    io::Read as _,
+    io::{Read as _, Write as _},
     path::PathBuf,
 };
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use regex::Regex;
 
 mod account_path;
+mod color;
+
+use color::ColorMode;
+
+/// Three-way color preference flag, matching the `ls`/`git`/`grep` convention.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum ColorChoice {
+    /// Emit color when stdout is a TTY and `NO_COLOR` is unset (default).
+    Auto,
+    /// Always emit ANSI color codes, even when piped or redirected.
+    Always,
+    /// Never emit color codes.
+    Never,
+}
+
+impl ColorChoice {
+    /// Resolve to a concrete [`ColorMode`] by querying TTY state and environment.
+    ///
+    /// Delegates `auto` detection to `anstream`, which honours `NO_COLOR`,
+    /// `CLICOLOR_FORCE`, and `CLICOLOR` in addition to the raw TTY check.
+    fn resolve(self) -> ColorMode {
+        match self {
+            ColorChoice::Always => ColorMode::On,
+            ColorChoice::Never => ColorMode::Off,
+            ColorChoice::Auto => {
+                // anstream::AutoStream::auto queries the stream's TTY state plus
+                // NO_COLOR / CLICOLOR_FORCE / CLICOLOR / CI env vars.
+                // current_choice() returns AlwaysAnsi when ANSI output is active.
+                let choice = anstream::AutoStream::auto(std::io::stdout()).current_choice();
+                if choice == anstream::ColorChoice::AlwaysAnsi
+                    || choice == anstream::ColorChoice::Always
+                {
+                    ColorMode::On
+                } else {
+                    ColorMode::Off
+                }
+            }
+        }
+    }
+}
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
 struct Cli {
+    /// Control color output: auto (default), always, or never.
+    ///
+    /// `auto` enables color when stdout is a TTY and NO_COLOR is unset.
+    /// Matches the convention of ls, git, grep, and ledger-cli.
+    #[arg(long, global = true, default_value = "auto", value_name = "WHEN")]
+    color: ColorChoice,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -382,6 +429,7 @@ fn maybe_convert_amount(
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
+    let color = cli.color.resolve();
 
     match cli.command {
         Commands::Compile {
@@ -892,6 +940,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             match format {
                 OutputFormat::Text => {
+                    let stdout = std::io::stdout();
+                    let mut out = stdout.lock();
                     for (account, _direct_commodities) in balances.iter() {
                         // Indentation depth: number of `:` separators in the name.
                         let indent_depth = account_path::segment_count(account) - 1;
@@ -920,6 +970,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             Box::new(rolled.iter().map(|(&c, &v)| (c, v)))
                         };
 
+                        let colored_label = color.style_account(label);
                         let mut commodities_iter = display_commodities;
                         if let Some((commodity, value)) = commodities_iter.next() {
                             let balance = display_amount(
@@ -927,7 +978,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 value,
                                 commodity_format(commodity, &journal.commodities),
                             );
-                            println!("{balance:>20}  {prefix}{label}");
+                            // Right-align within 20 display columns; ANSI codes are
+                            // applied outside the padding so column widths are correct.
+                            // Pass the decimal value for negativity detection because
+                            // commodity-prefix formats (e.g. "$ -2,000.00") don't start
+                            // with '-'.
+                            let colored_balance =
+                                color.render_amount(&balance, 20, value.is_sign_negative());
+                            writeln!(out, "{colored_balance}  {prefix}{colored_label}")?;
                         }
                         for (commodity, value) in commodities_iter {
                             let balance = display_amount(
@@ -935,7 +993,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 value,
                                 commodity_format(commodity, &journal.commodities),
                             );
-                            println!("{balance:>20}");
+                            let colored_balance =
+                                color.render_amount(&balance, 20, value.is_sign_negative());
+                            writeln!(out, "{colored_balance}")?;
                         }
                     }
                 }

--- a/crates/doppio-cli/tests/balance.rs
+++ b/crates/doppio-cli/tests/balance.rs
@@ -27,6 +27,24 @@ fn run(args: &[&str]) -> String {
     String::from_utf8(out.stdout).expect("non-UTF-8 stdout")
 }
 
+/// Run `dop` with the given args, returning raw bytes so we can check for
+/// ANSI escape sequences.
+fn run_bytes(args: &[&str]) -> Vec<u8> {
+    let bin = env!("CARGO_BIN_EXE_dop");
+    let out = Command::new(bin)
+        .args(args)
+        .output()
+        .expect("failed to run dop binary");
+    if !out.status.success() {
+        panic!(
+            "dop exited with {}\nstderr: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    out.stdout
+}
+
 fn tagged_journal() -> &'static str {
     "2024-01-01 Tagged
     ; :payroll:
@@ -386,5 +404,110 @@ fn tree_mode_multi_commodity_parent_rollup() {
     assert!(
         out.contains("EUR"),
         "EUR commodity should appear in rolled-up parent: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// --color flag: ANSI color output (refs #216)
+// ---------------------------------------------------------------------------
+
+/// Journal with a negative balance (Income account) and a positive balance
+/// (Assets account) — enough to exercise both the red-negative and
+/// blue-account-name color paths.
+fn color_test_journal() -> &'static str {
+    "2024-01-01 Salary
+    Assets:Checking  $2000.00
+    Income:Salary   $-2000.00
+"
+}
+
+#[test]
+fn color_always_emits_ansi_escapes() {
+    let f = tmp_journal_file(color_test_journal());
+    let bytes = run_bytes(&[
+        "--color=always",
+        "balance",
+        f.path().to_str().unwrap(),
+        "--flat",
+    ]);
+
+    // The ANSI escape introducer ESC[ must appear at least once.
+    assert!(
+        bytes.windows(2).any(|w| w == b"\x1b["),
+        "--color=always should emit ANSI escape sequences"
+    );
+}
+
+#[test]
+fn color_always_colors_negative_amounts_red() {
+    let f = tmp_journal_file(color_test_journal());
+    let bytes = run_bytes(&[
+        "--color=always",
+        "balance",
+        f.path().to_str().unwrap(),
+        "--flat",
+    ]);
+    let output = String::from_utf8(bytes).expect("non-UTF-8 stdout");
+
+    // Red is ANSI code 31; the negative amount line must contain \x1b[31m.
+    assert!(
+        output.contains("\x1b[31m"),
+        "--color=always should render negative amounts in red (\\x1b[31m): {output}"
+    );
+}
+
+#[test]
+fn color_always_colors_account_names_blue() {
+    let f = tmp_journal_file(color_test_journal());
+    let bytes = run_bytes(&[
+        "--color=always",
+        "balance",
+        f.path().to_str().unwrap(),
+        "--flat",
+    ]);
+    let output = String::from_utf8(bytes).expect("non-UTF-8 stdout");
+
+    // Blue is ANSI code 34; account names must be wrapped.
+    assert!(
+        output.contains("\x1b[34m"),
+        "--color=always should render account names in blue (\\x1b[34m): {output}"
+    );
+}
+
+#[test]
+fn color_never_suppresses_ansi_escapes() {
+    let f = tmp_journal_file(color_test_journal());
+    let bytes = run_bytes(&[
+        "--color=never",
+        "balance",
+        f.path().to_str().unwrap(),
+        "--flat",
+    ]);
+
+    assert!(
+        !bytes.windows(2).any(|w| w == b"\x1b["),
+        "--color=never should produce plain ASCII with no ANSI escapes"
+    );
+}
+
+#[test]
+fn color_auto_with_no_color_env_suppresses_ansi() {
+    // NO_COLOR=1 with --color=auto (the default) must suppress color even if
+    // forced through an otherwise color-capable path.
+    let f = tmp_journal_file(color_test_journal());
+    let bin = env!("CARGO_BIN_EXE_dop");
+    let out = Command::new(bin)
+        .args(["balance", f.path().to_str().unwrap(), "--flat"])
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("failed to run dop");
+    assert!(
+        out.status.success(),
+        "dop should exit successfully: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !out.stdout.windows(2).any(|w| w == b"\x1b["),
+        "NO_COLOR=1 should suppress ANSI escapes in --color=auto mode"
     );
 }


### PR DESCRIPTION
## Summary

- Add a global `--color=auto|always|never` flag to the `dop` binary, following the `ls`/`git`/`grep`/`ledger-cli` convention.
- `dop balance` now colorizes output when stdout is a TTY: **negative amounts in red** (ANSI 31), **account names in blue** (ANSI 34).
- `NO_COLOR` environment variable is honoured per <https://no-color.org/>.
- Existing snapshot tests are unaffected — they capture stdout via a pipe (non-TTY), so `auto` yields plain ASCII without any snapshot changes.

## Color scheme

Inspected `ledger -f <fixture> bal --force-color` on representative fixtures to determine the exact scheme:

```
         $ -9,324.00  <red>Assets</red>            ← negative: red (ANSI 31)
         $ -4,124.00    <red>Checking</red>        ← negative subtree: red
         $ 12,174.00  <blue>Expenses</blue>        ← positive: unstyled amount, blue account name
--------------------                               ← separator: unstyled
                   0                               ← total: unstyled
```

Rules matched:
- **Negative amounts** → red (`\x1b[31m`)
- **Account names** (all types) → blue (`\x1b[34m`)
- **Positive amounts, separator line, total** → unstyled

The color scheme is intentionally minimal, matching ledger-cli and avoiding over-decoration.

## Flag behaviour

| Invocation | Color emitted |
|---|---|
| `dop balance` on a TTY | color (auto) |
| `dop balance \| cat` | plain ASCII (auto detects pipe) |
| `NO_COLOR=1 dop balance` | plain ASCII (auto honours NO_COLOR) |
| `dop balance --color=always > out.txt` | ANSI escapes written to file |
| `dop balance --color=never` on a TTY | plain ASCII |

## Implementation notes

- Color decision is resolved once at startup into `ColorMode::On/Off` so ANSI codes are either always or never generated for a given run. This means `--color=always` emits ANSI even when piped; `--color=never`/`NO_COLOR` suppresses them even on a TTY.
- Alignment is correct: padding spaces are emitted _outside_ ANSI codes, so column widths aren't inflated by escape-byte counts.
- Amount negativity is detected via `rust_decimal::Decimal::is_sign_negative()` rather than string scanning, which correctly handles commodity-prefix formats like `$ -2,000.00` (where `-` is not the first character).
- `dop register` is **not** changed in this PR. The register text path uses `println!` to a non-colorized writer and would require its own separate engineering effort to handle correctly (different column layout, running totals). Left for a follow-up.
- Terminal-width adaptation (column auto-sizing) is deliberately **out of scope** per the original issue discussion.

## New dependencies

- `anstyle = "1.0.14"` — zero-dep ANSI style codes (the clap-ecosystem standard)
- `anstream = "1.0.0"` — TTY/`NO_COLOR`/`CLICOLOR` detection; used for the `auto` color choice resolution

## Tests

- `color_always_emits_ansi_escapes` — `--color=always` produces `\x1b[` bytes
- `color_always_colors_negative_amounts_red` — `\x1b[31m` present for negative balance
- `color_always_colors_account_names_blue` — `\x1b[34m` present for account names
- `color_never_suppresses_ansi_escapes` — `--color=never` produces plain ASCII
- `color_auto_with_no_color_env_suppresses_ansi` — `NO_COLOR=1` suppresses color

All 20 existing snapshot tests and all other integration tests continue to pass unchanged.

Refs #216