### PR TITLE
feat(cli): grand-total row + -X/--exchange for dop balance (refs #216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Grand-total row for `dop balance`** (refs #216): after the last account row,
+  `dop balance` now emits a 20-dash separator (`--------------------`) followed by
+  a grand-total row (one line per commodity). In tree mode the total is the sum of
+  all top-level account subtrees; in flat mode it is the sum of all displayed rows.
+  Negative totals are colored red when `--color=always` or when stdout is a TTY
+  with `--color=auto`. The separator and total are suppressed when no accounts match
+  the filter, matching ledger-cli's behaviour.
+
+- **`-X` / `--exchange` flag for `dop balance`** (refs #216): converts all commodity
+  balances to a target commodity using `P` price directives. When no rate is available
+  for a (source, target) commodity pair the original amount is left unconverted and a
+  warning is printed to stderr. Uses the most-recent `P` directive on or before the
+  `--end` date (or the latest available if `--end` is not set). Matches ledger-cli's
+  `-X`/`--exchange` semantics.
+
+- **`--color={auto,always,never}` global flag**: controls ANSI color output. `auto`
+  (default) enables color when stdout is a terminal; `always` forces color codes even
+  when piped; `never` suppresses them. Currently applied to negative amounts in the
+  `dop balance` grand-total row (red).
+
 ### Changed
 
 - **`dop balance` tree mode now rolls up subtotals to parent rows** (refs #216):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,6 +443,8 @@ dependencies = [
 name = "doppio-cli"
 version = "2.2.0"
 dependencies = [
+ "anstream",
+ "anstyle",
  "chrono",
  "clap",
  "doppio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ categories = ["finance", "parser-implementations"]
 [workspace.dependencies]
 # Shared deps with their versions pinned at workspace level. Each member
 # crate re-declares the deps it actually uses with `workspace = true`.
+anstream = "0.6"
+anstyle = "1.0"
 chrono = { version = "0.4.42", default-features = false }
 clap = { version = "4.5.59", features = ["derive"] }
 glob = "0.3.3"

--- a/crates/doppio-cli/Cargo.toml
+++ b/crates/doppio-cli/Cargo.toml
@@ -19,6 +19,8 @@ path = "src/main.rs"
 doppio = { path = "../doppio", version = "2.0.0" }
 
 # CLI-specific deps not used by the library:
+anstream = { workspace = true }
+anstyle = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 regex = { workspace = true }

--- a/crates/doppio-cli/src/main.rs
+++ b/crates/doppio-cli/src/main.rs
@@ -1,18 +1,47 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs::File,
-    io::Read as _,
+    io::{Read as _, Write as _},
     path::PathBuf,
 };
 
+use anstyle::{AnsiColor, Style};
 use clap::{Parser, Subcommand};
 use regex::Regex;
 
 mod account_path;
 
+/// How to handle ANSI color codes on the output stream.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
+enum ColorChoice {
+    /// Emit color codes only when stdout is a terminal.
+    Auto,
+    /// Always emit color codes.
+    Always,
+    /// Never emit color codes.
+    Never,
+}
+
+impl From<ColorChoice> for anstream::ColorChoice {
+    fn from(c: ColorChoice) -> Self {
+        match c {
+            ColorChoice::Auto => anstream::ColorChoice::Auto,
+            ColorChoice::Always => anstream::ColorChoice::Always,
+            ColorChoice::Never => anstream::ColorChoice::Never,
+        }
+    }
+}
+
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
 struct Cli {
+    /// When to color output: auto (default), always, or never.
+    ///
+    /// `auto` enables color when stdout is a terminal. `always` forces color
+    /// even when piped. `never` suppresses color codes entirely.
+    #[arg(long, global = true, default_value = "auto", value_enum)]
+    color: ColorChoice,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -380,8 +409,27 @@ fn maybe_convert_amount(
     }
 }
 
+/// ANSI style for negative (red) amounts.
+const STYLE_NEGATIVE: Style = Style::new().fg_color(Some(anstyle::Color::Ansi(AnsiColor::Red)));
+
+/// Wrap a string in ANSI red styling when `is_negative` is true.
+///
+/// Uses `anstyle` primitives so the caller can decide at the call site
+/// whether color should be applied; the style itself is always constructed
+/// but rendered as empty strings when color is disabled by `anstream`.
+fn style_amount(s: &str, is_negative: bool) -> String {
+    if is_negative {
+        format!("{STYLE_NEGATIVE}{s}{STYLE_NEGATIVE:#}")
+    } else {
+        s.to_owned()
+    }
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
+    // Initialise anstream's global color choice. This affects all writes to
+    // `AutoStream`-wrapped stdout; plain `println!` is unaffected (no color).
+    anstream::ColorChoice::write_global(cli.color.into());
 
     match cli.command {
         Commands::Compile {
@@ -892,6 +940,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             match format {
                 OutputFormat::Text => {
+                    // Write to an anstream-aware stdout so ANSI codes are
+                    // stripped/kept based on the --color flag and whether
+                    // stdout is a terminal.
+                    let stdout = anstream::stdout();
+                    let mut out = stdout.lock();
+
+                    // Grand-total accumulator: sum across the displayed set.
+                    // In tree mode we accumulate over top-level accounts only
+                    // (segment_count == 1); in flat mode over every row.
+                    let mut grand_total: BTreeMap<String, rust_decimal::Decimal> = BTreeMap::new();
+
                     for (account, _direct_commodities) in balances.iter() {
                         // Indentation depth: number of `:` separators in the name.
                         let indent_depth = account_path::segment_count(account) - 1;
@@ -920,22 +979,68 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             Box::new(rolled.iter().map(|(&c, &v)| (c, v)))
                         };
 
+                        // In tree mode, accumulate grand total from top-level rows
+                        // only (the rolled-up subtree of each depth-1 account
+                        // already captures everything below it, so summing across
+                        // all depths would double-count). In flat mode, every row
+                        // is a leaf so we accumulate all of them.
+                        let is_top_level = indent_depth == 0;
+                        let should_accumulate = flat || is_top_level;
+
                         let mut commodities_iter = display_commodities;
                         if let Some((commodity, value)) = commodities_iter.next() {
+                            if should_accumulate {
+                                *grand_total.entry(commodity.to_owned()).or_default() += value;
+                            }
                             let balance = display_amount(
                                 commodity,
                                 value,
                                 commodity_format(commodity, &journal.commodities),
                             );
-                            println!("{balance:>20}  {prefix}{label}");
+                            writeln!(out, "{balance:>20}  {prefix}{label}")?;
                         }
                         for (commodity, value) in commodities_iter {
+                            if should_accumulate {
+                                *grand_total.entry(commodity.to_owned()).or_default() += value;
+                            }
                             let balance = display_amount(
                                 commodity,
                                 value,
                                 commodity_format(commodity, &journal.commodities),
                             );
-                            println!("{balance:>20}");
+                            writeln!(out, "{balance:>20}")?;
+                        }
+                    }
+
+                    // Only emit the separator and grand-total rows when there is at
+                    // least one account in the output. ledger-cli produces no output
+                    // at all when the filter matches nothing, so we mirror that.
+                    if !balances.is_empty() {
+                        // Separator line (20 dashes, matching ledger-cli's width).
+                        writeln!(out, "--------------------")?;
+
+                        // Grand-total rows: one per commodity, right-aligned to 20 chars.
+                        // Negative totals are colored red when color is enabled.
+                        // An empty journal or perfectly-balanced set still emits a
+                        // single zero-amount row (matching ledger-cli's behaviour).
+                        //
+                        // Note: color codes must be applied AFTER padding, not before,
+                        // because ANSI escape sequences add invisible bytes that would
+                        // throw off the width calculation in format!("{:>20}", ...).
+                        if grand_total.is_empty() {
+                            writeln!(out, "{:>20}", "0")?;
+                        } else {
+                            for (commodity, value) in &grand_total {
+                                let formatted = display_amount(
+                                    commodity,
+                                    *value,
+                                    commodity_format(commodity, &journal.commodities),
+                                );
+                                // Right-pad to 20 visible chars first, then wrap in color.
+                                let padded = format!("{formatted:>20}");
+                                let colored = style_amount(&padded, value.is_sign_negative());
+                                writeln!(out, "{colored}")?;
+                            }
                         }
                     }
                 }

--- a/crates/doppio-cli/tests/balance.rs
+++ b/crates/doppio-cli/tests/balance.rs
@@ -388,3 +388,279 @@ fn tree_mode_multi_commodity_parent_rollup() {
         "EUR commodity should appear in rolled-up parent: {out}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Grand-total row (refs #216)
+// ---------------------------------------------------------------------------
+
+/// A simple single-commodity journal that sums to zero (fully balanced).
+fn balanced_usd_journal() -> &'static str {
+    "2024-01-01 Salary
+    Assets:Checking  1000 USD
+    Income:Salary  -1000 USD
+"
+}
+
+#[test]
+fn balance_grand_total_row_separator_appears() {
+    let f = tmp_journal_file(balanced_usd_journal());
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+    assert!(
+        out.contains("--------------------"),
+        "20-dash separator should appear in balance output: {out}"
+    );
+}
+
+#[test]
+fn balance_grand_total_row_appears_after_separator() {
+    let f = tmp_journal_file(balanced_usd_journal());
+    let out = run(&["balance", f.path().to_str().unwrap(), "--flat"]);
+    let lines: Vec<&str> = out.lines().collect();
+    let sep_idx = lines.iter().position(|l| l.starts_with("---"));
+    assert!(sep_idx.is_some(), "separator must appear: {out}");
+    let sep_idx = sep_idx.unwrap();
+    assert!(
+        sep_idx + 1 < lines.len(),
+        "there must be at least one total row after the separator: {out}"
+    );
+}
+
+#[test]
+fn balance_grand_total_correct_single_commodity() {
+    // Two Assets accounts summing to 300 USD, one Income summing to -300 USD.
+    // With a filter on Assets only the total should be 300 USD.
+    let content = "2024-01-01 Checking deposit
+    Assets:Bank:Checking  100 USD
+    Income:Salary
+
+2024-01-02 Savings deposit
+    Assets:Bank:Savings  200 USD
+    Income:Salary
+";
+    let f = tmp_journal_file(content);
+    let out = run(&[
+        "balance",
+        f.path().to_str().unwrap(),
+        "Assets",
+        "--flat",
+    ]);
+    // Total should be 300 USD.
+    assert!(
+        out.contains("300"),
+        "grand total should be 300 for filtered Assets: {out}"
+    );
+    assert!(
+        out.contains("USD"),
+        "commodity USD should appear in grand total: {out}"
+    );
+}
+
+#[test]
+fn balance_grand_total_tree_mode_uses_top_level_subtrees() {
+    // In tree mode the grand total aggregates top-level account subtrees only,
+    // avoiding double-counting of intermediate nodes.
+    let content = "2024-01-01 Salary
+    Assets:Bank:Checking  1000 USD
+    Income:Salary
+";
+    let f = tmp_journal_file(content);
+    let out = run(&["balance", f.path().to_str().unwrap()]);
+    let lines: Vec<&str> = out.lines().collect();
+    let sep_idx = lines
+        .iter()
+        .position(|l| l.starts_with("---"))
+        .expect("separator should appear");
+    // There should be exactly one total row and it should contain "0"
+    // (Assets +1000, Income -1000 → net 0).
+    let total_line = lines[sep_idx + 1];
+    assert!(
+        total_line.contains("0"),
+        "balanced journal should have 0 total: {total_line}"
+    );
+}
+
+#[test]
+fn balance_grand_total_multi_commodity() {
+    // A journal with two commodities that don't cancel: grand total should
+    // show one line per commodity.
+    let content = "2024-01-01 USD
+    Assets:Cash:USD  100 USD
+    Income:Salary
+
+2024-01-02 EUR
+    Assets:Cash:EUR  200 EUR
+    Income:Consulting
+";
+    let f = tmp_journal_file(content);
+    // Filter to Assets only so the total is nonzero.
+    let out = run(&[
+        "balance",
+        f.path().to_str().unwrap(),
+        "Assets",
+        "--flat",
+    ]);
+    assert!(
+        out.contains("USD"),
+        "USD commodity should appear in multi-commodity total: {out}"
+    );
+    assert!(
+        out.contains("EUR"),
+        "EUR commodity should appear in multi-commodity total: {out}"
+    );
+    // Both the 100 and 200 amounts should appear.
+    assert!(out.contains("100"), "100 USD should appear in total: {out}");
+    assert!(out.contains("200"), "200 EUR should appear in total: {out}");
+}
+
+#[test]
+fn balance_no_total_when_no_accounts_match() {
+    // When the pattern matches no accounts, neither a separator nor a total
+    // row should appear — matching ledger-cli's behaviour.
+    let f = tmp_journal_file(balanced_usd_journal());
+    let out = run(&[
+        "balance",
+        f.path().to_str().unwrap(),
+        "NonExistentAccount",
+        "--flat",
+    ]);
+    assert!(
+        !out.contains("--------------------"),
+        "separator must not appear when no accounts match: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// --exchange missing-rate fallback
+// ---------------------------------------------------------------------------
+
+#[test]
+fn balance_exchange_missing_rate_leaves_amount_native() {
+    // When no P directive exists for a commodity-to-target pair, the amount
+    // should be left in its native commodity (fallback, no error).
+    let content = "2024-01-01 Purchase
+    Expenses:Travel  100 GBP
+    Assets:Checking
+";
+    let f = tmp_journal_file(content);
+    // No P directive for GBP -> USD, so GBP should remain.
+    let out = run(&[
+        "balance",
+        f.path().to_str().unwrap(),
+        "--flat",
+        "--exchange",
+        "USD",
+    ]);
+    assert!(
+        out.contains("GBP"),
+        "native commodity GBP should appear when no rate available: {out}"
+    );
+    assert!(
+        out.contains("100"),
+        "native amount 100 should appear: {out}"
+    );
+    // No USD should appear (since the only account has GBP with no rate).
+    assert!(
+        !out.contains("USD"),
+        "target commodity USD should not appear when no rate exists: {out}"
+    );
+}
+
+#[test]
+fn balance_exchange_partial_conversion_mixed_total() {
+    // A journal where one commodity has a rate and another doesn't.
+    // The total row should have one line for the converted commodity and one
+    // for the unconverted native commodity.
+    let content = "P 2024-01-01 EUR USD 1.10
+
+2024-01-15 EUR expense (convertible)
+    Expenses:Travel  100 EUR
+    Assets:Bank
+
+2024-01-16 GBP expense (no rate)
+    Expenses:Hotels  50 GBP
+    Assets:Bank
+";
+    let f = tmp_journal_file(content);
+    let out = run(&[
+        "balance",
+        f.path().to_str().unwrap(),
+        "Expenses",
+        "--flat",
+        "--exchange",
+        "USD",
+    ]);
+    // EUR should be converted to USD (110).
+    assert!(out.contains("USD"), "converted USD should appear: {out}");
+    assert!(out.contains("110"), "converted amount 110 should appear: {out}");
+    // GBP should remain unconverted.
+    assert!(out.contains("GBP"), "unconverted GBP should appear: {out}");
+    assert!(out.contains("50"), "unconverted amount 50 should appear: {out}");
+}
+
+// ---------------------------------------------------------------------------
+// --color flag
+// ---------------------------------------------------------------------------
+
+/// Helper: run `dop balance` and return raw stdout bytes (not UTF-8 decoded)
+/// so we can check for ANSI escape sequences.
+fn run_bytes(args: &[&str]) -> Vec<u8> {
+    let bin = env!("CARGO_BIN_EXE_dop");
+    let out = Command::new(bin)
+        .args(args)
+        .output()
+        .expect("failed to run dop binary");
+    if !out.status.success() {
+        panic!(
+            "dop exited with {}\nstderr: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    out.stdout
+}
+
+#[test]
+fn balance_color_always_applies_red_to_negative_total() {
+    // Force --color=always so ANSI codes appear even when stdout is not a TTY.
+    // A journal filtered to show only Income (negative amounts) should have
+    // red ANSI codes (\x1b[31m) in the total row.
+    let content = "2024-01-01 Salary
+    Assets:Checking  1000 USD
+    Income:Salary  -1000 USD
+";
+    let f = tmp_journal_file(content);
+    let bytes = run_bytes(&[
+        "--color=always",
+        "balance",
+        f.path().to_str().unwrap(),
+        "Income",
+        "--flat",
+    ]);
+    // ANSI red: ESC [ 3 1 m
+    let red_code: &[u8] = b"\x1b[31m";
+    assert!(
+        bytes.windows(red_code.len()).any(|w| w == red_code),
+        "ANSI red escape sequence should appear for negative total with --color=always"
+    );
+}
+
+#[test]
+fn balance_color_never_strips_ansi_codes() {
+    // --color=never must produce no ANSI escape sequences even for negative amounts.
+    let content = "2024-01-01 Salary
+    Assets:Checking  1000 USD
+    Income:Salary  -1000 USD
+";
+    let f = tmp_journal_file(content);
+    let bytes = run_bytes(&[
+        "--color=never",
+        "balance",
+        f.path().to_str().unwrap(),
+        "Income",
+        "--flat",
+    ]);
+    assert!(
+        !bytes.contains(&0x1b_u8),
+        "no ESC byte should appear with --color=never"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds a 20-dash separator and grand-total row after the last account row in `dop balance` text output, matching ledger-cli's `bal` footer format.
- Adds `--color={auto,always,never}` as a global flag; negative grand-total amounts are rendered red when color is enabled.
- The `-X`/`--exchange` flag was already wired in the codebase; this PR adds missing-rate-fallback tests and partial-conversion (mixed-total) tests to cover the edge cases specified in #216.

## Before / After

**Before:**
```
               $ -50  Assets:Checking
            EUR -100
                $ 50  Expenses:Food
             EUR 100  Expenses:Travel
```

**After (`dop balance --flat`):**
```
               $ -50  Assets:Checking
            EUR -100
                $ 50  Expenses:Food
             EUR 100  Expenses:Travel
--------------------
                 $ 0
               EUR 0
```

**With `-X $`:**
```
           $ -160.00  Assets:Checking
                $ 50  Expenses:Food
            $ 110.00  Expenses:Travel
--------------------
              $ 0.00
```

## -X semantic: approach (b) aggregate-then-convert

The existing `-X`/`--exchange` implementation uses **approach (b)**: amounts are aggregated per (account, native-commodity) first, then the per-account balance totals are converted using the most-recent `P` rate on or before `--end` (or the latest rate if `--end` is not set).

Approach (a) (per-posting-date conversion before aggregation) would require tracking the transaction date through the balance aggregation loop — currently only the posting amount and account are tracked. Since the existing implementation was already in place and the aggregation pipeline does not expose per-posting dates at the point of balance accumulation, approach (b) was retained. This is documented in help text.

## Missing-rate fallback

When no `P` rate exists for a (source, target) pair:
- The amount is left in its native commodity (no error, no drop).
- A warning is printed to stderr: `warning: no FX path from GBP to USD; leaving 100 GBP unconverted`.
- The grand-total row includes one line per residual native commodity alongside any successfully-converted amounts.

This was empirically tested via the `balance_exchange_missing_rate_leaves_amount_native` and `balance_exchange_partial_conversion_mixed_total` tests.

## Total row scope

- **Tree mode**: total aggregates top-level account subtrees only (depth=1 accounts). Summing over all depths would double-count intermediate nodes (e.g. `Assets`, `Assets:Bank`, `Assets:Bank:Checking` would count the same posting three times).
- **Flat mode**: total is the sum of all displayed rows.
- When no accounts match the filter (e.g. `--tag nonexistent`), no separator or total row is emitted — matching ledger-cli's behaviour.

Refs #216