### PR TITLE
feat(cli): grand-total row for dop balance (refs #216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ### Added
 
+- **Grand-total footer for `dop balance`** (refs #216): After the last account
+  row, `dop balance` now emits a separator line of 20 dashes followed by one
+  line per commodity with the grand total, matching ledger-cli's `bal` footer.
+  Multi-commodity journals produce one total line per commodity. The footer is
+  suppressed when no rows are rendered (empty journal or fully filtered). Negative
+  totals are styled red when color is enabled, using the same `color::ColorMode`
+  helpers as regular rows. Tree mode accumulates top-level subtree totals to avoid
+  double-counting intermediate parent rows; flat mode sums all displayed rows.
+  When `-X`/`--exchange` is active, converted commodities aggregate into the
+  target and residual unconverted commodities appear on separate total lines.
+
 - **`--color` global flag for terminal-aware color output** (refs #216):
   `dop balance` now renders negative amounts in red and account names in blue
   when stdout is a TTY, matching ledger-cli's `bal --force-color` color scheme.

--- a/crates/doppio-cli/src/main.rs
+++ b/crates/doppio-cli/src/main.rs
@@ -942,6 +942,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 OutputFormat::Text => {
                     let stdout = std::io::stdout();
                     let mut out = stdout.lock();
+                    let mut row_count: usize = 0;
                     for (account, _direct_commodities) in balances.iter() {
                         // Indentation depth: number of `:` separators in the name.
                         let indent_depth = account_path::segment_count(account) - 1;
@@ -986,6 +987,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             let colored_balance =
                                 color.render_amount(&balance, 20, value.is_sign_negative());
                             writeln!(out, "{colored_balance}  {prefix}{colored_label}")?;
+                            row_count += 1;
                         }
                         for (commodity, value) in commodities_iter {
                             let balance = display_amount(
@@ -996,6 +998,91 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             let colored_balance =
                                 color.render_amount(&balance, 20, value.is_sign_negative());
                             writeln!(out, "{colored_balance}")?;
+                        }
+                    }
+
+                    // Grand-total footer: separator + per-commodity totals.
+                    // Suppress when no rows were rendered (empty journal or
+                    // filtered to nothing).
+                    if row_count > 0 {
+                        // Grand total is the sum of all direct (leaf) balances —
+                        // the same values that were accumulated into `balances`
+                        // before the tree-rollup step.  This avoids double-
+                        // counting intermediate parent rows that were
+                        // materialised for display only.
+                        let mut grand_total: BTreeMap<String, rust_decimal::Decimal> =
+                            BTreeMap::new();
+                        for (_account, direct_commodities) in balances.iter() {
+                            // In tree mode only root-level accounts (no parent
+                            // present in the map) contribute, so we skip any
+                            // account whose parent IS present — otherwise
+                            // every ancestor-and-descendant pair would be
+                            // double-counted.  In flat mode every row is a
+                            // leaf anyway, so the same logic is correct.
+                            let has_parent_in_map = {
+                                let mut pos = 0;
+                                let mut found = false;
+                                while let Some(colon_off) = _account[pos..].find(':') {
+                                    let prefix_end = pos + colon_off;
+                                    let parent = &_account[..prefix_end];
+                                    if balances.contains_key(parent) {
+                                        found = true;
+                                        break;
+                                    }
+                                    pos = prefix_end + 1;
+                                }
+                                found
+                            };
+                            if flat || !has_parent_in_map {
+                                // Flat mode: sum the direct balance.
+                                // Tree mode root: sum the direct balance of
+                                // each leaf account (roots have no ancestor).
+                                // We'll accumulate all leaf postings by
+                                // traversing the subtree.
+                                if flat {
+                                    for (commodity, amount) in direct_commodities {
+                                        *grand_total.entry(commodity.clone()).or_default() +=
+                                            amount;
+                                    }
+                                } else {
+                                    // In tree mode, sum all direct balances
+                                    // from every account in the subtree rooted
+                                    // at this top-level account.
+                                    for (acct, commodities) in balances.iter() {
+                                        if account_path::is_subtree(_account, acct) {
+                                            for (commodity, amount) in commodities {
+                                                *grand_total
+                                                    .entry(commodity.clone())
+                                                    .or_default() += amount;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        // Separator: 20 dashes, matching the amount column width.
+                        writeln!(out, "{}", "-".repeat(20))?;
+                        let mut total_iter = grand_total.iter();
+                        if let Some((commodity, value)) = total_iter.next() {
+                            let total_str = display_amount(
+                                commodity,
+                                *value,
+                                commodity_format(commodity, &journal.commodities),
+                            );
+                            let colored_total =
+                                color.render_amount(&total_str, 20, value.is_sign_negative());
+                            writeln!(out, "{colored_total}")?;
+                        }
+                        for (commodity, value) in total_iter {
+                            let total_str = display_amount(
+                                commodity,
+                                *value,
+                                commodity_format(commodity, &journal.commodities),
+                            );
+                            let colored_total =
+                                color.render_amount(&total_str, 20, value.is_sign_negative());
+                            writeln!(out, "{colored_total}")?;
                         }
                     }
                 }

--- a/crates/doppio-cli/tests/balance.rs
+++ b/crates/doppio-cli/tests/balance.rs
@@ -288,6 +288,127 @@ fn balance_exchange_converts_eur_to_usd() {
     );
 }
 
+#[test]
+fn balance_exchange_missing_rate_leaves_amount_native() {
+    // No price directive for GBP→USD.  `dop balance -X USD` should keep the
+    // GBP posting in its native currency and emit a warning to stderr — it
+    // must NOT silently drop or zero the amount.
+    let content = "2024-01-15 London expense
+    Expenses:Travel  50 GBP
+    Assets:Checking
+";
+    let f = tmp_journal_file(content);
+    let bin = env!("CARGO_BIN_EXE_dop");
+    let result = std::process::Command::new(bin)
+        .args([
+            "balance",
+            f.path().to_str().unwrap(),
+            "--flat",
+            "--exchange",
+            "USD",
+        ])
+        .output()
+        .expect("failed to run dop");
+    // The command should succeed (exit 0) even when conversion is unavailable.
+    assert!(
+        result.status.success(),
+        "dop should exit successfully even when no FX path exists: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    let out = String::from_utf8(result.stdout).expect("non-UTF-8 stdout");
+    // The native commodity GBP must appear — the amount is kept unconverted.
+    assert!(
+        out.contains("GBP"),
+        "unconvertible commodity GBP should remain in output: {out}"
+    );
+    assert!(
+        out.contains("50"),
+        "unconverted amount 50 should appear in output: {out}"
+    );
+    // USD must not appear — there was no conversion.
+    assert!(
+        !out.contains("USD"),
+        "target commodity USD should be absent when no FX path exists: {out}"
+    );
+    // A warning should have been emitted to stderr.
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(
+        stderr.contains("GBP"),
+        "stderr warning should mention the unconverted commodity GBP: {stderr}"
+    );
+}
+
+#[test]
+fn balance_exchange_partial_conversion_mixed_total() {
+    // EUR has a USD price directive; GBP does not.
+    // After `-X USD`, the total should have both USD (from EUR) and GBP (residual).
+    let content = "P 2024-01-01 EUR USD 1.10
+
+2024-01-10 EUR expense
+    Expenses:Foreign  100 EUR
+    Assets:Checking
+
+2024-01-11 GBP expense
+    Expenses:UK  50 GBP
+    Assets:Checking
+";
+    let f = tmp_journal_file(content);
+    let bin = env!("CARGO_BIN_EXE_dop");
+    let result = std::process::Command::new(bin)
+        .args([
+            "balance",
+            f.path().to_str().unwrap(),
+            "--flat",
+            "--exchange",
+            "USD",
+        ])
+        .output()
+        .expect("failed to run dop");
+    assert!(
+        result.status.success(),
+        "dop should exit successfully with partial conversion: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    let out = String::from_utf8(result.stdout).expect("non-UTF-8 stdout");
+    // EUR was converted → USD should appear (110 USD from 100 EUR × 1.10).
+    assert!(
+        out.contains("USD"),
+        "converted commodity USD should appear in output: {out}"
+    );
+    assert!(
+        out.contains("110"),
+        "converted amount 110 USD should appear in output: {out}"
+    );
+    // GBP had no path → it remains native in the output.
+    assert!(
+        out.contains("GBP"),
+        "unconverted commodity GBP should remain in output: {out}"
+    );
+    assert!(
+        out.contains("50"),
+        "unconverted amount 50 GBP should appear in output: {out}"
+    );
+    // The grand-total footer should show both commodities — USD for the
+    // converted EUR lines and GBP for the residual line.
+    let lines: Vec<&str> = out.lines().collect();
+    let sep_idx = lines.iter().position(|l| l.starts_with("----"));
+    assert!(
+        sep_idx.is_some(),
+        "grand-total separator line should be present: {out}"
+    );
+    // Lines after the separator are the grand total.
+    let footer: Vec<&str> = sep_idx.map(|i| lines[i + 1..].to_vec()).unwrap_or_default();
+    let footer_str = footer.join("\n");
+    assert!(
+        footer_str.contains("USD"),
+        "grand total should include USD for converted amounts: {footer_str}"
+    );
+    assert!(
+        footer_str.contains("GBP"),
+        "grand total should include GBP residual for unconverted amounts: {footer_str}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Tree-mode balance rollup (refs #216)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds a separator line (20 dashes) + per-commodity grand-total row after the last account row in `dop balance --format=text`, matching ledger-cli's `bal` footer.
- Also adds two integration tests covering the already-existing `-X`/`--exchange` missing-rate-fallback behaviour (no new `-X` feature added).

## Before / after

**Before** (`dop balance`):
```
       $ 1950.00  Assets
       $ 1950.00    Checking
         $ 50.00  Expenses
         $ 50.00    Food
      $ -2000.00  Income
      $ -2000.00    Salary
```

**After** (`dop balance`):
```
       $ 1950.00  Assets
       $ 1950.00    Checking
         $ 50.00  Expenses
         $ 50.00    Food
      $ -2000.00  Income
      $ -2000.00    Salary
--------------------
          $ 0.00
```

**`dop balance -X USD` with partial conversion** (EUR has a rate, GBP does not):
```
         GBP -50  Assets:Checking
     USD -110.00
      USD 110.00  Expenses:Foreign
          GBP 50  Expenses:UK
--------------------
           GBP 0
        USD 0.00
```

## Behaviour details

- **Tree mode**: grand total sums only top-level subtree totals — intermediate parent rows (materialised by PR #304's rollup logic) are not double-counted.
- **Flat mode**: grand total sums all displayed rows' direct balances.
- **Empty journal / fully filtered**: footer suppressed (no rows = no footer).
- **Color**: negative totals are red via the existing `color::ColorMode::render_amount` — same code path as regular rows.
- **`-X`/`--exchange`**: converted commodities fold into the target; commodities with no FX path appear as separate residual lines in the footer.

## New exchange fallback tests

- `balance_exchange_missing_rate_leaves_amount_native` — GBP posting with no GBP→USD price; asserts output keeps GBP, not USD.
- `balance_exchange_partial_conversion_mixed_total` — mixed journal (EUR has USD path, GBP doesn't); asserts grand-total footer has both USD and GBP lines.

Refs #216