### PR TITLE
chore: release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-05-11
+
 ### Added
 
 - **Grand-total footer for `dop balance`** (refs #216): After the last account

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "doppio"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "doppio-cli"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anstream 1.0.0",
  "anstyle",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "doppio-wasm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "console_error_panic_hook",
  "doppio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "3"
 # Shared metadata that applies to every member crate by default. Crates
 # can override individual fields locally.
 [workspace.package]
-version = "2.2.0"
+version = "2.3.0"
 edition = "2024"
 rust-version = "1.95.0"
 repository = "https://github.com/alevy/doppio"

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ dop balance my-journal.dop --depth 2 --begin 2024-01-01 --cleared
 dop balance my-journal.dop --pattern "^Expenses" --format json
 ```
 
-Prints account balances grouped by commodity. Flags: `--depth N` (truncate hierarchy), `--flat` (single-line output), `--begin`/`--end` (date range), `--cleared` (cleared transactions only), `--tag KEY` (transactions tagged with `KEY`), `--pattern REGEX` (filter accounts), `--format text|json|csv`.
+Prints account balances grouped by commodity, with a grand-total footer per commodity beneath a divider. By default, output is rendered as an indented tree where parent rows show the sum of every descendant; pass `--flat` to revert to the classic single-line-per-account form. Flags: `--depth N` (truncate hierarchy), `--flat`, `--begin`/`--end` (date range), `--cleared` (cleared transactions only), `--tag KEY` (transactions tagged with `KEY`), `--pattern REGEX` (filter accounts), `-X`/`--exchange COMMODITY` (convert balances to `COMMODITY` using `P` price directives), `--format text|json|csv`.
 
 When stdout is a terminal, balance output is colorized: negative amounts appear in red and account names in blue, matching ledger-cli's color scheme. Pass `--color=never` to suppress color or `--color=always` to force it even when piped. The `NO_COLOR` environment variable is also honoured.
 

--- a/docs/SUPPORTED_FEATURES.md
+++ b/docs/SUPPORTED_FEATURES.md
@@ -1,6 +1,6 @@
 # doppio: Supported Ledger features
 
-**Last updated**: 2026-05-09 (doppio v2.2.0)
+**Last updated**: 2026-05-11 (doppio v2.3.0)
 
 Feature-by-feature comparison of doppio's syntax surface against
 [ledger-cli](https://ledger-cli.org/) and [hledger](https://hledger.org/).

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,6 +1,6 @@
 # doppio Requirements
 
-**Last updated**: 2026-05-09 (doppio v2.2.0)
+**Last updated**: 2026-05-11 (doppio v2.3.0)
 
 ---
 


### PR DESCRIPTION
## Summary

Cuts **doppio v2.3.0** — a minor release rolling up the post-2.2.0 work on `main`.

### Library

- **Per-frontend journal writers** (`#206`). The `Frontend` trait gains a `write_journal(&self, hir: &HIR, writer: &mut dyn io::Write) -> io::Result<()>` method, implemented for `LedgerFrontend`, `HledgerFrontend`, and `BeancountFrontend`. A free-function `write_journal` is added for `Box<dyn Frontend>` callers. Cross-frontend transcoding emits `; [<source-format>] …` markers for constructs without an equivalent in the target format.
- **`doppio::write_ledger` deprecated** in favor of `LedgerFrontend::write_journal`. Removal scheduled for v3.0.

### CLI (`dop`)

- **`dop print`** now emits in the source file's own frontend (ledger → ledger, hledger → hledger, beancount → beancount) instead of always-ledger.
- **`dop balance` tree-mode rollup** (refs `#216`): parent rows now show the sum of their direct postings plus every descendant, matching ledger-cli's `bal`. `--flat` is unchanged.
- **`--color={auto,always,never}` global flag** (refs `#216`): terminal-aware coloring for `dop balance` matching ledger-cli's scheme (negative amounts red, account names blue). `auto` honours TTY detection and `NO_COLOR`.
- **Grand-total footer for `dop balance`** (refs `#216`): one total line per commodity beneath a 20-dash divider, with red styling on negative totals when color is enabled. Works in tree, flat, and `-X` modes.
- **Colon-segment helper refactor**: balance-rendering path now routes through `account_path` module (`truncate`, `segment_count`, `last_segment`, `is_subtree`, `subtree_balance`) — no behaviour change.

No `.dop` wire-format change. No MSRV bump.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`
- [x] `cargo test --doc`
- [x] `cargo doc --no-deps` (pre-existing intra-doc-link warnings only)
- [x] `cargo publish --dry-run -p doppio` — exit 0
- [x] `cargo publish --dry-run --no-verify -p doppio-cli` — packaging clean (full verify is post-merge after `doppio` 2.3.0 lands on crates.io)
- [ ] CI green on this PR