### PR TITLE
ci(web): deploy both dashboard and compile demo to Pages

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -46,10 +46,10 @@ jobs:
         run: npm test
       - name: Type-check and build
         run: npm run build
-      - name: Upload Pages artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v3
+      - name: Upload dashboard dist
+        uses: actions/upload-artifact@v4
         with:
+          name: dashboard-dist
           path: web/dashboard/dist
 
   build-compile:
@@ -82,21 +82,16 @@ jobs:
           ls -lh web/compile/dist/
           echo "==> pkg/ contents:"
           ls -lh web/compile/dist/pkg/
-      # Deploying the compile demo to GitHub Pages alongside the dashboard
-      # is deferred — the `pages` concurrency group + actions/deploy-pages
-      # currently target a single artifact. Build is in CI so regressions
-      # are caught; standing up a combined-deploy job is a followup.
-      - name: Upload compile-demo artifact (for inspection)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      - name: Upload compile dist
         uses: actions/upload-artifact@v4
         with:
-          name: web-compile-dist
+          name: compile-dist
           path: web/compile/dist
 
   deploy:
     name: Deploy to GitHub Pages
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: build-dashboard
+    needs: [build-dashboard, build-compile]
     runs-on: ubuntu-latest
     permissions:
       pages: write
@@ -105,5 +100,63 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Download dashboard dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dashboard-dist
+          path: _site/dashboard
+      - name: Download compile dist
+        uses: actions/download-artifact@v4
+        with:
+          name: compile-dist
+          path: _site/compile
+      - name: Write landing page
+        run: |
+          cat > _site/index.html <<'HTML'
+          <!doctype html>
+          <html lang="en">
+            <head>
+              <meta charset="UTF-8" />
+              <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+              <title>doppio · web demos</title>
+              <link rel="icon" href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><text y='14' font-size='14'>%E2%98%95</text></svg>" />
+              <style>
+                body { font: 16px/1.5 system-ui, sans-serif; max-width: 38em; margin: 4em auto; padding: 0 1em; color: #111; }
+                h1 { font-size: 1.6em; margin-bottom: 0.25em; }
+                p.tag { color: #666; margin-top: 0; }
+                ul { list-style: none; padding: 0; }
+                li { margin: 1.25em 0; padding: 1em 1.25em; border: 1px solid #e5e5e5; border-radius: 8px; }
+                li a { font-weight: 600; text-decoration: none; color: #2563eb; }
+                li a:hover { text-decoration: underline; }
+                li p { margin: 0.25em 0 0; color: #444; }
+                footer { margin-top: 3em; color: #888; font-size: 0.9em; }
+                footer a { color: #2563eb; }
+              </style>
+            </head>
+            <body>
+              <h1>doppio</h1>
+              <p class="tag">Browser demos for the doppio ledger compiler.</p>
+              <ul>
+                <li>
+                  <a href="dashboard/">Dashboard</a>
+                  <p>Loads a pre-compiled <code>.dop</code> journal and renders KPIs, category breakdowns, and income/expense charts. Validates the <code>.dop</code>-format-as-API claim end-to-end via a JS-native reader.</p>
+                </li>
+                <li>
+                  <a href="compile/">Compile</a>
+                  <p>Paste ledger / hledger / Beancount source and compile it to <code>.dop</code> in the browser via WebAssembly. No server round-trip.</p>
+                </li>
+              </ul>
+              <footer>
+                <a href="https://github.com/alevy/doppio">github.com/alevy/doppio</a>
+              </footer>
+            </body>
+          </html>
+          HTML
+          echo "==> _site/ layout:"
+          ls -lhR _site | head -40
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
       - id: deployment
         uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -258,11 +258,14 @@ python3 scripts/parity_check.py --negative  # broken-fixture controls
 Requires `hledger`, `ledger`, and the `beancount` Python package on
 PATH (`pip install 'beancount==3.2.0'`).
 
-## Web demo
+## Web demos
 
-A small browser app under [`web/dashboard/`](./web/dashboard/) renders balance, register, and chart views over a `.dop` file using a JS-native protobuf decoder -- no Rust or WASM at runtime. It serves as the working validator of doppio's format-as-API claim: any non-Rust language can read `.dop` files via the published [`proto/doppio.proto`](./proto/doppio.proto) schema.
+Two browser apps live in this repo and are deployed to GitHub Pages from `main`:
 
-Live preview: <https://alevy.github.io/doppio/> (deployed automatically from `main`).
+- **Dashboard** ([`web/dashboard/`](./web/dashboard/), live at <https://alevy.github.io/doppio/dashboard/>) — renders balance, register, and chart views over a `.dop` file using a JS-native protobuf decoder. No Rust or WASM at runtime. Validates doppio's format-as-API claim: any non-Rust language can read `.dop` files via the published [`proto/doppio.proto`](./crates/doppio/proto/doppio.proto) schema.
+- **Compile** ([`web/compile/`](./web/compile/), live at <https://alevy.github.io/doppio/compile/>) — paste ledger / hledger / Beancount source and compile it to a `.dop` byte-stream in the browser via the [`doppio-wasm`](./crates/doppio-wasm/) shim. No server round-trip.
+
+A small landing page at <https://alevy.github.io/doppio/> links to both.
 
 ## Changelog
 

--- a/crates/doppio-cli/README.md
+++ b/crates/doppio-cli/README.md
@@ -58,8 +58,9 @@ commands.
   reference, library API, supported feature matrix.
 - [`docs/SUPPORTED_FEATURES.md`](https://github.com/alevy/doppio/blob/main/docs/SUPPORTED_FEATURES.md) --
   what ledger-cli / hledger features are implemented.
-- [Web demo](https://alevy.github.io/doppio/) -- a browser dashboard
-  that reads a `.dop` file via a JS-native protobuf decoder.
+- [Web demos](https://alevy.github.io/doppio/) -- a dashboard that
+  reads a `.dop` file via a JS-native protobuf decoder, and a compile
+  page that runs the doppio pipeline in the browser via wasm.
 
 ## License
 

--- a/web/dashboard/vite.config.ts
+++ b/web/dashboard/vite.config.ts
@@ -2,11 +2,11 @@ import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 import { fileURLToPath, URL } from "node:url";
 
-// gh-pages serves this app from https://alevy.github.io/doppio/.
+// gh-pages serves this app from https://alevy.github.io/doppio/dashboard/.
 // Local dev (npm run dev) uses base "/" automatically.
 export default defineConfig(({ command }) => ({
   plugins: [vue()],
-  base: command === "build" ? "/doppio/" : "/",
+  base: command === "build" ? "/doppio/dashboard/" : "/",
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),


### PR DESCRIPTION
## Summary

GitHub Pages currently only serves the dashboard, mounted at `/doppio/`. The compile demo was built in CI but its output was only uploaded as a non-Pages CI artifact (the inline comment in `web.yml` explicitly deferred wiring up multi-artifact deploy because `actions/upload-pages-artifact` only allows a single artifact).

This PR ships both demos by restructuring the workflow to combine both build outputs into one Pages artifact:

- `/doppio/` — small landing page linking to both demos
- `/doppio/dashboard/` — Vue SPA (was at `/doppio/`)
- `/doppio/compile/` — wasm-bindgen compile demo

### Changes

- `web/dashboard/vite.config.ts`: `base` `/doppio/` → `/doppio/dashboard/` so asset URLs match the new mount point.
- `.github/workflows/web.yml`:
  - `build-dashboard` uploads regular artifact `dashboard-dist` (was a Pages artifact).
  - `build-compile` uploads regular artifact `compile-dist` (was `web-compile-dist`, inspection-only).
  - Artifact uploads are now unconditional; only the `deploy` job remains gated on push-to-main.
  - New `deploy` step downloads both artifacts into `_site/dashboard` and `_site/compile`, writes a minimal landing `_site/index.html`, then uploads as the Pages artifact and deploys.
- `README.md` and `crates/doppio-cli/README.md`: link both new URLs.

The compile demo uses purely relative paths (`./app.js`, `./pkg/...`), so it works under any sub-path without rebuild.

## Test plan

- [ ] CI green
- [ ] After merge: <https://alevy.github.io/doppio/> renders the landing page
- [ ] After merge: <https://alevy.github.io/doppio/dashboard/> renders the dashboard (sample.dop loads, charts populate)
- [ ] After merge: <https://alevy.github.io/doppio/compile/> compiles a pasted journal end-to-end