### PR TITLE
feat(web/dashboard): canonical-commodity selector (#312)

### DIFF
--- a/web/dashboard/src/components/CategoryDonut.vue
+++ b/web/dashboard/src/components/CategoryDonut.vue
@@ -10,14 +10,23 @@ import {
 import Decimal from "decimal.js";
 import { useJournalStore } from "@/store/journal";
 import { useFiltersStore } from "@/store/filters";
-import { expensesByCategory, latestMonth } from "@/lib/views/period";
+import { expensesByCategory, latestMonth, type ConversionContext } from "@/lib/views/period";
 import { formatAmount, monthLabelLong } from "@/lib/format";
 
 ChartJS.register(ArcElement, Tooltip);
 
 const journals = useJournalStore();
 const filters = useFiltersStore();
-const { begin, end, clearedOnly } = storeToRefs(filters);
+const { begin, end, clearedOnly, displayCommodity } = storeToRefs(filters);
+
+const convCtx = computed<ConversionContext | null>(() => {
+  const j = journals.journal;
+  const dc = displayCommodity.value;
+  if (!j || dc === null) return null;
+  return { toCommodity: dc, prices: j.prices, asOf: end.value };
+});
+
+const displayCommodityLabel = computed(() => displayCommodity.value ?? "$");
 
 const month = computed(() => {
   const j = journals.journal;
@@ -28,7 +37,7 @@ const categories = computed(() => {
   const j = journals.journal;
   const m = month.value;
   if (!j || !m) return [];
-  return expensesByCategory(j, m, clearedOnly.value);
+  return expensesByCategory(j, m, clearedOnly.value, convCtx.value);
 });
 
 const total = computed(() =>
@@ -48,6 +57,8 @@ const PALETTE = [
   "#bf6f8a",
   "#8a8a8a",
 ];
+
+const commodity = computed(() => displayCommodityLabel.value);
 
 const chartData = computed(() => ({
   labels: categories.value.map((c) => c.label),
@@ -70,7 +81,7 @@ const chartOptions = computed(() => ({
     tooltip: {
       callbacks: {
         label: (ctx: { label?: string; parsed: number }) =>
-          `${ctx.label ?? ""}: ${formatAmount("$", new Decimal(ctx.parsed))}`,
+          `${ctx.label ?? ""}: ${formatAmount(commodity.value, new Decimal(ctx.parsed))}`,
       },
     },
   },
@@ -90,7 +101,7 @@ const monthLabel = computed(() => (month.value ? monthLabelLong(month.value) : "
       <div class="canvas">
         <Doughnut :data="chartData" :options="chartOptions" />
         <div class="centre-label">
-          <div class="centre-amount">{{ formatAmount("$", total) }}</div>
+          <div class="centre-amount">{{ formatAmount(commodity, total) }}</div>
           <div class="centre-caption">spent</div>
         </div>
       </div>
@@ -101,7 +112,7 @@ const monthLabel = computed(() => (month.value ? monthLabelLong(month.value) : "
             :style="{ background: PALETTE[i % PALETTE.length] }"
           />
           <span class="cat-label">{{ c.label }}</span>
-          <span class="cat-amount">{{ formatAmount("$", c.total) }}</span>
+          <span class="cat-amount">{{ formatAmount(commodity, c.total) }}</span>
         </li>
       </ol>
     </div>

--- a/web/dashboard/src/components/FilterBar.vue
+++ b/web/dashboard/src/components/FilterBar.vue
@@ -2,14 +2,17 @@
 import { computed } from "vue";
 import { storeToRefs } from "pinia";
 import { useFiltersStore } from "@/store/filters";
+import { useJournalStore } from "@/store/journal";
 import {
   epochDaysFromLocalDate,
   localDateFromEpochDays,
   type LocalDate,
 } from "@/lib/dop";
+import { allCommodities } from "@/lib/views/exchange";
 
 const filters = useFiltersStore();
-const { clearedOnly, begin, end } = storeToRefs(filters);
+const journals = useJournalStore();
+const { clearedOnly, begin, end, displayCommodity } = storeToRefs(filters);
 
 const beginISO = computed({
   get: () => (begin.value ? toISO(begin.value) : ""),
@@ -34,6 +37,13 @@ function fromISO(s: string): LocalDate {
     Math.round(Date.UTC(y!, (m ?? 1) - 1, d ?? 1) / 86_400_000),
   );
 }
+
+/** Sorted list of all commodity symbols in the loaded journal. */
+const commodities = computed<string[]>(() => {
+  const j = journals.journal;
+  if (!j) return [];
+  return allCommodities(j.prices, j.transactions);
+});
 </script>
 
 <template>
@@ -45,6 +55,13 @@ function fromISO(s: string): LocalDate {
     <label>
       <span class="label">End</span>
       <input v-model="endISO" type="date" />
+    </label>
+    <label>
+      <span class="label">Display as</span>
+      <select v-model="displayCommodity" class="commodity-select">
+        <option :value="null">As recorded</option>
+        <option v-for="c in commodities" :key="c" :value="c">{{ c }}</option>
+      </select>
     </label>
     <label class="toggle">
       <input v-model="clearedOnly" type="checkbox" />
@@ -87,12 +104,21 @@ label.toggle {
   color: #777;
 }
 
-input[type="date"] {
+input[type="date"],
+.commodity-select {
   padding: 0.3rem 0.5rem;
   border: 1px solid #ccc;
   border-radius: 0.25rem;
   font: inherit;
-  min-width: 9rem;
   background: #fafafa;
+}
+
+input[type="date"] {
+  min-width: 9rem;
+}
+
+.commodity-select {
+  min-width: 8rem;
+  cursor: pointer;
 }
 </style>

--- a/web/dashboard/src/components/IncomeExpenseChart.vue
+++ b/web/dashboard/src/components/IncomeExpenseChart.vue
@@ -6,19 +6,28 @@ import { Chart as ChartJS, BarElement, CategoryScale, LinearScale, Tooltip } fro
 import Decimal from "decimal.js";
 import { useJournalStore } from "@/store/journal";
 import { useFiltersStore } from "@/store/filters";
-import { incomeExpenseByMonth } from "@/lib/views/period";
+import { incomeExpenseByMonth, type ConversionContext } from "@/lib/views/period";
 import { formatAmount, monthLabelShort } from "@/lib/format";
 
 ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip);
 
 const journals = useJournalStore();
 const filters = useFiltersStore();
-const { begin, end, clearedOnly } = storeToRefs(filters);
+const { begin, end, clearedOnly, displayCommodity } = storeToRefs(filters);
+
+const convCtx = computed<ConversionContext | null>(() => {
+  const j = journals.journal;
+  const dc = displayCommodity.value;
+  if (!j || dc === null) return null;
+  return { toCommodity: dc, prices: j.prices, asOf: end.value };
+});
+
+const displayCommodityLabel = computed(() => displayCommodity.value ?? "$");
 
 const buckets = computed(() => {
   const j = journals.journal;
   if (!j) return [];
-  return incomeExpenseByMonth(j, begin.value, end.value, clearedOnly.value);
+  return incomeExpenseByMonth(j, begin.value, end.value, clearedOnly.value, convCtx.value);
 });
 
 const chartData = computed(() => ({
@@ -41,6 +50,8 @@ const chartData = computed(() => ({
   ],
 }));
 
+const commodity = computed(() => displayCommodityLabel.value);
+
 const chartOptions = computed(() => ({
   responsive: true,
   maintainAspectRatio: false,
@@ -49,7 +60,7 @@ const chartOptions = computed(() => ({
     y: {
       grid: { color: "#f0f0f0" },
       ticks: {
-        callback: (v: string | number) => formatAmount("$", new Decimal(Number(v))),
+        callback: (v: string | number) => formatAmount(commodity.value, new Decimal(Number(v))),
       },
     },
   },
@@ -61,19 +72,23 @@ const chartOptions = computed(() => ({
           const y = ctx.parsed.y;
           const lbl = ctx.dataset.label ?? "";
           if (y == null) return lbl;
-          return `${lbl}: ${formatAmount("$", new Decimal(y))}`;
+          return `${lbl}: ${formatAmount(commodity.value, new Decimal(y))}`;
         },
       },
     },
   },
 }));
+
+const hintLabel = computed(() =>
+  displayCommodity.value ? `monthly · ${displayCommodity.value}` : "monthly · USD",
+);
 </script>
 
 <template>
   <section class="card">
     <header>
       <h2>Income vs Expense</h2>
-      <span class="hint">monthly · USD</span>
+      <span class="hint">{{ hintLabel }}</span>
     </header>
     <div v-if="buckets.length === 0" class="empty">
       No activity in the selected range.

--- a/web/dashboard/src/components/KpiStrip.vue
+++ b/web/dashboard/src/components/KpiStrip.vue
@@ -9,43 +9,90 @@ import {
   cashOnHand,
   netWorthAsOfLatest,
   periodNet,
+  type ConversionContext,
 } from "@/lib/views/period";
+import { convertByCommodity } from "@/lib/views/exchange";
 import { formatAmount } from "@/lib/format";
 
 const journals = useJournalStore();
 const filters = useFiltersStore();
-const { begin, end, clearedOnly } = storeToRefs(filters);
+const { begin, end, clearedOnly, displayCommodity } = storeToRefs(filters);
+
+/** Build a ConversionContext from the current filter state, or null when
+ * "as recorded" is selected. */
+const convCtx = computed<ConversionContext | null>(() => {
+  const j = journals.journal;
+  const dc = displayCommodity.value;
+  if (!j || dc === null) return null;
+  return { toCommodity: dc, prices: j.prices, asOf: end.value };
+});
 
 interface Kpi {
   label: string;
   value: Decimal;
   hint: string;
+  commodity: string;
 }
+
+/** Commodities that could not be converted for the net-worth KPI.
+ * Computed separately so we can surface a badge in the UI. */
+const netWorthUnconvertible = computed<string[]>(() => {
+  const j = journals.journal;
+  const ctx = convCtx.value;
+  if (!j || ctx === null) return [];
+
+  // Walk all asset and liability postings, collecting unconvertible ones.
+  const seen = new Set<string>();
+  for (const t of j.transactions) {
+    if (clearedOnly.value && t.state !== "cleared") continue;
+    for (const p of t.postings) {
+      if (p.kind === "virtualUnbalanced") continue;
+      const { unconvertible } = convertByCommodity(
+        p.amount.byCommodity,
+        ctx.toCommodity,
+        ctx.prices,
+        ctx.asOf,
+      );
+      for (const c of unconvertible) seen.add(c);
+    }
+  }
+  // Remove the target commodity itself — it's never unconvertible.
+  seen.delete(ctx.toCommodity);
+  return [...seen].sort();
+});
+
+const displayCommodityLabel = computed(() => displayCommodity.value ?? "$");
 
 const cards = computed<Kpi[]>(() => {
   const j = journals.journal;
   if (!j) return [];
-  const nw = netWorthAsOfLatest(j, clearedOnly.value);
+  const ctx = convCtx.value;
+  const commodity = displayCommodityLabel.value;
+  const nw = netWorthAsOfLatest(j, clearedOnly.value, ctx);
   return [
     {
       label: "Net Worth",
       value: nw.netWorth,
-      hint: `assets ${formatAmount("$", nw.assets)} − liabilities ${formatAmount("$", nw.liabilities)}`,
+      hint: `assets ${formatAmount(commodity, nw.assets)} − liabilities ${formatAmount(commodity, nw.liabilities)}`,
+      commodity,
     },
     {
       label: "Cash on Hand",
-      value: cashOnHand(j, clearedOnly.value),
+      value: cashOnHand(j, clearedOnly.value, ctx),
       hint: "Bank + Cash accounts",
+      commodity,
     },
     {
       label: "Period Net",
-      value: periodNet(j, begin.value, end.value, clearedOnly.value),
+      value: periodNet(j, begin.value, end.value, clearedOnly.value, ctx),
       hint: "income − expenses over the active range",
+      commodity,
     },
     {
       label: "Avg Monthly Expense",
-      value: avgMonthlyExpense(j, begin.value, end.value, clearedOnly.value),
+      value: avgMonthlyExpense(j, begin.value, end.value, clearedOnly.value, ctx),
       hint: "expenses ÷ months in range",
+      commodity,
     },
   ];
 });
@@ -56,9 +103,15 @@ const cards = computed<Kpi[]>(() => {
     <div v-for="card in cards" :key="card.label" class="card kpi">
       <div class="label">{{ card.label }}</div>
       <div class="value" :class="{ negative: card.value.isNegative() }">
-        {{ formatAmount("$", card.value) }}
+        {{ formatAmount(card.commodity, card.value) }}
       </div>
       <div class="hint">{{ card.hint }}</div>
+    </div>
+    <div
+      v-if="netWorthUnconvertible.length > 0"
+      class="unconvertible-note"
+    >
+      No rate for: {{ netWorthUnconvertible.join(", ") }} — excluded from totals
     </div>
   </section>
 </template>
@@ -101,6 +154,16 @@ const cards = computed<Kpi[]>(() => {
   font-size: 0.78rem;
   color: #888;
   margin-top: 0.2rem;
+}
+
+.unconvertible-note {
+  grid-column: 1 / -1;
+  font-size: 0.78rem;
+  color: #b06b00;
+  background: #fff8ec;
+  border: 1px solid #eed9a0;
+  border-radius: 0.35rem;
+  padding: 0.35rem 0.75rem;
 }
 
 @media (max-width: 800px) {

--- a/web/dashboard/src/components/NetWorthTrend.vue
+++ b/web/dashboard/src/components/NetWorthTrend.vue
@@ -14,7 +14,7 @@ import Decimal from "decimal.js";
 import { storeToRefs } from "pinia";
 import { useJournalStore } from "@/store/journal";
 import { useFiltersStore } from "@/store/filters";
-import { netWorthByMonth } from "@/lib/views/period";
+import { netWorthByMonth, type ConversionContext } from "@/lib/views/period";
 import { formatAmount, monthLabelLong, monthLabelShort } from "@/lib/format";
 
 ChartJS.register(
@@ -28,12 +28,25 @@ ChartJS.register(
 
 const journals = useJournalStore();
 const filters = useFiltersStore();
-const { clearedOnly } = storeToRefs(filters);
+const { clearedOnly, end, displayCommodity } = storeToRefs(filters);
+
+// Net-worth trend uses the as-of cutoff for all bars (true per-date
+// rate lookup across a time series is a follow-up).
+const convCtx = computed<ConversionContext | null>(() => {
+  const j = journals.journal;
+  const dc = displayCommodity.value;
+  if (!j || dc === null) return null;
+  return { toCommodity: dc, prices: j.prices, asOf: end.value };
+});
+
+const displayCommodityLabel = computed(() => displayCommodity.value ?? "$");
 
 const series = computed(() => {
   const j = journals.journal;
-  return j ? netWorthByMonth(j, clearedOnly.value) : [];
+  return j ? netWorthByMonth(j, clearedOnly.value, convCtx.value) : [];
 });
+
+const commodity = computed(() => displayCommodityLabel.value);
 
 const chartData = computed(() => ({
   labels: series.value.map((p) => monthLabelShort(p.month)),
@@ -60,7 +73,7 @@ const chartOptions = computed(() => ({
     y: {
       grid: { color: "#f0f0f0" },
       ticks: {
-        callback: (v: string | number) => formatAmount("$", new Decimal(Number(v))),
+        callback: (v: string | number) => formatAmount(commodity.value, new Decimal(Number(v))),
       },
     },
   },
@@ -75,18 +88,24 @@ const chartOptions = computed(() => ({
           return p ? monthLabelLong(p.month) : "";
         },
         label: (ctx: { parsed: { y: number | null } }) =>
-          ctx.parsed.y == null ? "" : formatAmount("$", new Decimal(ctx.parsed.y)),
+          ctx.parsed.y == null ? "" : formatAmount(commodity.value, new Decimal(ctx.parsed.y)),
       },
     },
   },
 }));
+
+const hintLabel = computed(() =>
+  displayCommodity.value
+    ? `monthly · assets − liabilities · ${displayCommodity.value}`
+    : "monthly · assets − liabilities",
+);
 </script>
 
 <template>
   <section class="card">
     <header>
       <h2>Net Worth Trend</h2>
-      <span class="hint">monthly · assets − liabilities</span>
+      <span class="hint">{{ hintLabel }}</span>
     </header>
     <div v-if="series.length === 0" class="empty">No data.</div>
     <div v-else class="canvas">

--- a/web/dashboard/src/lib/views/exchange.test.ts
+++ b/web/dashboard/src/lib/views/exchange.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import Decimal from "decimal.js";
+import type { HistoricalPrice, LocalDate } from "@/lib/dop";
+import { exchangeRateAt } from "./exchange.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function date(year: number, month: number, day: number): LocalDate {
+  return { year, month, day };
+}
+
+function price(
+  commodity: string,
+  priceCommodity: string,
+  value: string,
+  d: LocalDate,
+): HistoricalPrice {
+  return { commodity, priceCommodity, price: new Decimal(value), date: d };
+}
+
+// ---------------------------------------------------------------------------
+// exchangeRateAt
+// ---------------------------------------------------------------------------
+
+describe("exchangeRateAt", () => {
+  it("same commodity returns exactly 1", () => {
+    const rate = exchangeRateAt([], "USD", "USD", null);
+    expect(rate).not.toBeNull();
+    expect(rate!.equals(new Decimal(1))).toBe(true);
+  });
+
+  it("returns null when no prices exist for the pair", () => {
+    const prices: HistoricalPrice[] = [
+      price("EUR", "GBP", "0.85", date(2024, 1, 1)),
+    ];
+    expect(exchangeRateAt(prices, "USD", "EUR", null)).toBeNull();
+  });
+
+  it("direct quote: P date USD 1.10 EUR → USD→EUR rate = 1.10", () => {
+    // "P 2024-01-01 USD 1.10 EUR" → commodity=USD, price=1.10, priceCommodity=EUR
+    const prices: HistoricalPrice[] = [
+      price("USD", "EUR", "1.10", date(2024, 1, 1)),
+    ];
+    const rate = exchangeRateAt(prices, "USD", "EUR", null);
+    expect(rate).not.toBeNull();
+    expect(rate!.equals(new Decimal("1.10"))).toBe(true);
+  });
+
+  it("inverse quote: P date EUR 1.10 USD → USD→EUR rate = 1/1.10", () => {
+    // Direct quote for EUR→USD; invert to get USD→EUR
+    const prices: HistoricalPrice[] = [
+      price("EUR", "USD", "1.10", date(2024, 1, 1)),
+    ];
+    const rate = exchangeRateAt(prices, "USD", "EUR", null);
+    expect(rate).not.toBeNull();
+    // 1 / 1.10 ≈ 0.909090...
+    expect(rate!.minus(new Decimal(1).div("1.10")).abs().lessThan("0.000001")).toBe(true);
+  });
+
+  it("two direct quotes on different dates: latest at-or-before asOf wins", () => {
+    const prices: HistoricalPrice[] = [
+      price("USD", "EUR", "1.05", date(2024, 1, 1)),
+      price("USD", "EUR", "1.12", date(2024, 6, 1)),
+      price("USD", "EUR", "1.20", date(2024, 12, 1)),
+    ];
+    // asOf = 2024-06-15 → picks the 2024-06-01 quote (1.12), not the Dec one
+    const rate = exchangeRateAt(prices, "USD", "EUR", date(2024, 6, 15));
+    expect(rate).not.toBeNull();
+    expect(rate!.equals(new Decimal("1.12"))).toBe(true);
+  });
+
+  it("date cutoff: excludes quotes strictly after asOf", () => {
+    const prices: HistoricalPrice[] = [
+      price("USD", "EUR", "1.05", date(2024, 1, 1)),
+      price("USD", "EUR", "1.12", date(2024, 6, 1)),
+    ];
+    // asOf = 2024-02-01 → only the Jan quote is visible
+    const rate = exchangeRateAt(prices, "USD", "EUR", date(2024, 2, 1));
+    expect(rate).not.toBeNull();
+    expect(rate!.equals(new Decimal("1.05"))).toBe(true);
+  });
+
+  it("date cutoff: all quotes after asOf → null", () => {
+    const prices: HistoricalPrice[] = [
+      price("USD", "EUR", "1.05", date(2024, 6, 1)),
+    ];
+    const rate = exchangeRateAt(prices, "USD", "EUR", date(2024, 1, 1));
+    expect(rate).toBeNull();
+  });
+
+  it("quote exactly on asOf date is included", () => {
+    const prices: HistoricalPrice[] = [
+      price("USD", "EUR", "1.08", date(2024, 3, 15)),
+    ];
+    const rate = exchangeRateAt(prices, "USD", "EUR", date(2024, 3, 15));
+    expect(rate).not.toBeNull();
+    expect(rate!.equals(new Decimal("1.08"))).toBe(true);
+  });
+
+  it("null asOf means no date cutoff — all prices considered", () => {
+    const prices: HistoricalPrice[] = [
+      price("USD", "EUR", "1.05", date(2024, 1, 1)),
+      price("USD", "EUR", "1.20", date(2030, 1, 1)),
+    ];
+    const rate = exchangeRateAt(prices, "USD", "EUR", null);
+    expect(rate).not.toBeNull();
+    // Latest wins when asOf is null
+    expect(rate!.equals(new Decimal("1.20"))).toBe(true);
+  });
+
+  it("among same-date quotes the later one in source order wins (ties)", () => {
+    const prices: HistoricalPrice[] = [
+      price("USD", "EUR", "1.05", date(2024, 1, 1)),
+      price("USD", "EUR", "1.09", date(2024, 1, 1)),
+    ];
+    const rate = exchangeRateAt(prices, "USD", "EUR", null);
+    expect(rate).not.toBeNull();
+    // The second (later in array) wins on ties
+    expect(rate!.equals(new Decimal("1.09"))).toBe(true);
+  });
+
+  it("zero-price entries are skipped", () => {
+    const prices: HistoricalPrice[] = [
+      price("USD", "EUR", "0", date(2024, 1, 1)),
+      price("USD", "EUR", "1.10", date(2024, 2, 1)),
+    ];
+    const rate = exchangeRateAt(prices, "USD", "EUR", null);
+    expect(rate).not.toBeNull();
+    expect(rate!.equals(new Decimal("1.10"))).toBe(true);
+  });
+
+  it("zero-price only → null", () => {
+    const prices: HistoricalPrice[] = [
+      price("USD", "EUR", "0", date(2024, 1, 1)),
+    ];
+    expect(exchangeRateAt(prices, "USD", "EUR", null)).toBeNull();
+  });
+
+  it("unrelated prices are ignored", () => {
+    const prices: HistoricalPrice[] = [
+      price("EUR", "GBP", "0.85", date(2024, 1, 1)),
+      price("CHF", "USD", "1.11", date(2024, 1, 1)),
+    ];
+    expect(exchangeRateAt(prices, "USD", "EUR", null)).toBeNull();
+  });
+});

--- a/web/dashboard/src/lib/views/exchange.ts
+++ b/web/dashboard/src/lib/views/exchange.ts
@@ -1,0 +1,152 @@
+/**
+ * Exchange-rate lookup mirroring `Journal::exchange_rate_at` in Rust
+ * (`crates/doppio/src/elaboration_ext.rs`).
+ *
+ * Rules (identical to the Rust implementation):
+ *  - Same commodity → 1.
+ *  - Direct quote `P date from price to` → use the latest quote at-or-before as-of.
+ *  - Inverse quote `P date to price from` → use 1/price, same date selection.
+ *  - No chaining through intermediates (deliberate; aligns with Beancount).
+ *  - No rate found → null.
+ */
+
+import Decimal from "decimal.js";
+import type { HistoricalPrice, LocalDate } from "@/lib/dop";
+import { compareLocalDate, epochDaysFromLocalDate } from "@/lib/dop";
+
+/**
+ * Convert a `LocalDate` to a comparable epoch-days number so we can do
+ * straightforward numeric comparisons in the sort below.
+ */
+function toEpochDays(d: LocalDate): number {
+  return epochDaysFromLocalDate(d);
+}
+
+/**
+ * Look up the exchange rate from `fromCommodity` to `toCommodity`,
+ * using historical prices at-or-before `asOf`. When `asOf` is null all
+ * available prices are considered (equivalent to using the journal's
+ * max date as the cutoff).
+ *
+ * Returns `null` when no direct or inverse quote is available.
+ */
+export function exchangeRateAt(
+  prices: HistoricalPrice[],
+  fromCommodity: string,
+  toCommodity: string,
+  asOf: LocalDate | null,
+): Decimal | null {
+  if (fromCommodity === toCommodity) {
+    return new Decimal(1);
+  }
+
+  const asOfDays = asOf !== null ? toEpochDays(asOf) : null;
+
+  let bestDays: number | null = null;
+  let bestRate: Decimal | null = null;
+
+  for (const hp of prices) {
+    const direct = hp.commodity === fromCommodity && hp.priceCommodity === toCommodity;
+    const inverse = hp.commodity === toCommodity && hp.priceCommodity === fromCommodity;
+    if (!direct && !inverse) continue;
+
+    // Date must be at-or-before the cutoff (when one is set).
+    const days = toEpochDays(hp.date);
+    if (asOfDays !== null && days > asOfDays) continue;
+
+    // Price must be non-zero to avoid degenerate inversions.
+    if (hp.price.isZero()) continue;
+
+    const rate = direct ? hp.price : new Decimal(1).div(hp.price);
+
+    // Latest by date wins. Ties resolve in source order: the last equal
+    // element wins (matches "more-recently-declared" in the Rust version
+    // which uses `max_by_key`, and `max_by_key` returns the last equal).
+    if (bestDays === null || days >= bestDays) {
+      bestDays = days;
+      bestRate = rate;
+    }
+  }
+
+  return bestRate;
+}
+
+/**
+ * Convert a `byCommodity` map to the target commodity, accumulating
+ * converted amounts. Returns the converted total and a list of commodity
+ * symbols that could not be converted (no rate available).
+ *
+ * Entries already in the target commodity are included as-is (rate = 1).
+ */
+export function convertByCommodity(
+  byCommodity: Record<string, Decimal>,
+  toCommodity: string,
+  prices: HistoricalPrice[],
+  asOf: LocalDate | null,
+): { total: Decimal; unconvertible: string[] } {
+  let total = new Decimal(0);
+  const unconvertible: string[] = [];
+
+  for (const [commodity, amount] of Object.entries(byCommodity)) {
+    if (amount.isZero()) continue;
+    const rate = exchangeRateAt(prices, commodity, toCommodity, asOf);
+    if (rate === null) {
+      unconvertible.push(commodity);
+    } else {
+      total = total.plus(amount.mul(rate));
+    }
+  }
+
+  return { total, unconvertible };
+}
+
+/**
+ * Collect every distinct commodity symbol that appears in the price
+ * table (both as the priced commodity and as the price commodity).
+ * Sorted alphabetically.
+ */
+export function commoditiesFromPrices(prices: HistoricalPrice[]): string[] {
+  const set = new Set<string>();
+  for (const hp of prices) {
+    set.add(hp.commodity);
+    set.add(hp.priceCommodity);
+  }
+  return [...set].sort();
+}
+
+/**
+ * Collect every distinct commodity that appears on any posting amount
+ * across all transactions. Sorted alphabetically.
+ */
+export function commoditiesFromPostings(
+  transactions: import("@/lib/dop").Transaction[],
+): string[] {
+  const set = new Set<string>();
+  for (const t of transactions) {
+    for (const p of t.postings) {
+      for (const commodity of Object.keys(p.amount.byCommodity)) {
+        set.add(commodity);
+      }
+    }
+  }
+  return [...set].sort();
+}
+
+/**
+ * Union of commodities from prices and from postings, sorted
+ * alphabetically. This is the full candidate list for the display
+ * commodity dropdown.
+ */
+export function allCommodities(
+  prices: HistoricalPrice[],
+  transactions: import("@/lib/dop").Transaction[],
+): string[] {
+  const set = new Set([
+    ...commoditiesFromPrices(prices),
+    ...commoditiesFromPostings(transactions),
+  ]);
+  return [...set].sort();
+}
+
+// Re-export compareLocalDate so callers don't need to import it separately.
+export { compareLocalDate };

--- a/web/dashboard/src/lib/views/period.ts
+++ b/web/dashboard/src/lib/views/period.ts
@@ -6,6 +6,8 @@ import {
 } from "@/lib/dop";
 import { inferAccountType, type AccountType } from "./accountType.js";
 import { dateInRange } from "./filter.js";
+import { exchangeRateAt } from "./exchange.js";
+import type { HistoricalPrice } from "@/lib/dop";
 
 export interface MonthKey {
   year: number;
@@ -32,6 +34,21 @@ export interface NetWorthPoint {
   liabilities: Decimal;
 }
 
+/**
+ * When non-null, converts multi-commodity postings to a single display
+ * commodity using the journal's P price directives. Passed through to
+ * period functions so the same code path serves both "as recorded" (null)
+ * and "converted" (non-null) modes.
+ */
+export interface ConversionContext {
+  /** The commodity to convert into. */
+  toCommodity: string;
+  /** Available historical prices from the journal. */
+  prices: HistoricalPrice[];
+  /** Upper date cutoff for rate lookups (null = no cutoff). */
+  asOf: LocalDate | null;
+}
+
 const PRIMARY_COMMODITY = "$";
 
 function monthKey(d: LocalDate): MonthKey {
@@ -54,11 +71,31 @@ function endOfMonth(m: MonthKey): LocalDate {
   return { year: d.getUTCFullYear(), month: d.getUTCMonth() + 1, day: d.getUTCDate() };
 }
 
-function getCommodityValue(
+/**
+ * Extract the scalar value for a posting amount. When no conversion
+ * context is given, uses the primary commodity (USD). When a context is
+ * given, sums all commodity values after applying exchange rates; amounts
+ * for which no rate is available are excluded from the sum (the caller
+ * surfaces those separately).
+ */
+function resolveAmount(
   byCommodity: Record<string, Decimal>,
-  commodity: string,
+  ctx: ConversionContext | null,
 ): Decimal {
-  return byCommodity[commodity] ?? new Decimal(0);
+  if (ctx === null) {
+    return byCommodity[PRIMARY_COMMODITY] ?? new Decimal(0);
+  }
+  let total = new Decimal(0);
+  for (const [commodity, amount] of Object.entries(byCommodity)) {
+    if (amount.isZero()) continue;
+    const rate = exchangeRateAt(ctx.prices, commodity, ctx.toCommodity, ctx.asOf);
+    if (rate !== null) {
+      total = total.plus(amount.mul(rate));
+    }
+    // Unconvertible amounts are silently excluded here; callers that want
+    // to surface them use convertByCommodity from exchange.ts directly.
+  }
+  return total;
 }
 
 /**
@@ -89,16 +126,19 @@ function monthsInJournal(
 }
 
 /**
- * Bucket postings into per-month income / expense totals (in the
- * primary commodity, USD by convention). Income postings are flipped
- * to natural signs so income reads positive. When `clearedOnly` is
- * true, pending and uncleared transactions are excluded.
+ * Bucket postings into per-month income / expense totals. Income postings
+ * are flipped to natural signs so income reads positive. When `clearedOnly`
+ * is true, pending and uncleared transactions are excluded.
+ *
+ * When `ctx` is non-null, amounts are converted to `ctx.toCommodity`;
+ * unconvertible entries are excluded from the totals.
  */
 export function incomeExpenseByMonth(
   journal: Journal,
   begin: LocalDate | null,
   end: LocalDate | null,
   clearedOnly = false,
+  ctx: ConversionContext | null = null,
 ): IncomeExpenseBucket[] {
   const months = monthsInJournal(journal, begin, end);
   const buckets = new Map<string, IncomeExpenseBucket>();
@@ -117,7 +157,7 @@ export function incomeExpenseByMonth(
     if (!b) continue;
     for (const p of t.postings) {
       if (p.kind === "virtualUnbalanced") continue;
-      const v = getCommodityValue(p.amount.byCommodity, PRIMARY_COMMODITY);
+      const v = resolveAmount(p.amount.byCommodity, ctx);
       if (v.isZero()) continue;
       const type = inferAccountType(p.account, journal.accounts[p.account]);
       if (type === "income") {
@@ -147,6 +187,7 @@ export function expensesByCategory(
   journal: Journal,
   month: MonthKey,
   clearedOnly = false,
+  ctx: ConversionContext | null = null,
 ): CategoryBucket[] {
   const totals = new Map<string, Decimal>();
   for (const t of journal.transactions) {
@@ -155,7 +196,7 @@ export function expensesByCategory(
     for (const p of t.postings) {
       if (p.kind === "virtualUnbalanced") continue;
       if (!(p.account === "Expenses" || p.account.startsWith("Expenses:"))) continue;
-      const v = getCommodityValue(p.amount.byCommodity, PRIMARY_COMMODITY);
+      const v = resolveAmount(p.amount.byCommodity, ctx);
       if (v.isZero()) continue;
       const segments = p.account.split(":");
       const label = segments.length === 1 ? "Expenses" : segments[1]!;
@@ -172,14 +213,14 @@ export function expensesByCategory(
  * Compute month-end snapshots of net worth (assets − liabilities) for
  * every month in the journal's range, in chronological order.
  *
- * Both sides are accumulated in the primary commodity using natural
- * signs: assets are debit-normal so their sum is reported as-is;
- * liabilities are credit-normal so their internal sum is negated to
- * read as the amount you owe.
+ * Both sides are accumulated using natural signs: assets are debit-normal
+ * so their sum is reported as-is; liabilities are credit-normal so their
+ * internal sum is negated to read as the amount you owe.
  */
 export function netWorthByMonth(
   journal: Journal,
   clearedOnly = false,
+  ctx: ConversionContext | null = null,
 ): NetWorthPoint[] {
   const months = monthsInJournal(journal, null, null);
   const sorted = [...journal.transactions].sort((a, b) => compareLocalDate(a.date, b.date));
@@ -197,7 +238,7 @@ export function netWorthByMonth(
       }
       for (const p of t.postings) {
         if (p.kind === "virtualUnbalanced") continue;
-        const v = getCommodityValue(p.amount.byCommodity, PRIMARY_COMMODITY);
+        const v = resolveAmount(p.amount.byCommodity, ctx);
         if (v.isZero()) continue;
         const type = inferAccountType(p.account, journal.accounts[p.account]);
         if (type === "assets") {
@@ -221,12 +262,13 @@ export function netWorthByMonth(
 export function netWorthAsOfLatest(
   journal: Journal,
   clearedOnly = false,
+  ctx: ConversionContext | null = null,
 ): {
   netWorth: Decimal;
   assets: Decimal;
   liabilities: Decimal;
 } {
-  const series = netWorthByMonth(journal, clearedOnly);
+  const series = netWorthByMonth(journal, clearedOnly, ctx);
   if (series.length === 0) {
     return { netWorth: new Decimal(0), assets: new Decimal(0), liabilities: new Decimal(0) };
   }
@@ -240,14 +282,18 @@ export function netWorthAsOfLatest(
  * "checking-style" subset; deliberately excludes brokerage / 401k /
  * crypto so the number reflects actually-spendable balance.
  */
-export function cashOnHand(journal: Journal, clearedOnly = false): Decimal {
+export function cashOnHand(
+  journal: Journal,
+  clearedOnly = false,
+  ctx: ConversionContext | null = null,
+): Decimal {
   let total = new Decimal(0);
   for (const t of journal.transactions) {
     if (clearedOnly && t.state !== "cleared") continue;
     for (const p of t.postings) {
       if (p.kind === "virtualUnbalanced") continue;
       if (!isCashAccount(p.account)) continue;
-      const v = getCommodityValue(p.amount.byCommodity, PRIMARY_COMMODITY);
+      const v = resolveAmount(p.amount.byCommodity, ctx);
       total = total.plus(v);
     }
   }
@@ -273,8 +319,9 @@ export function periodNet(
   begin: LocalDate | null,
   end: LocalDate | null,
   clearedOnly = false,
+  ctx: ConversionContext | null = null,
 ): Decimal {
-  const buckets = incomeExpenseByMonth(journal, begin, end, clearedOnly);
+  const buckets = incomeExpenseByMonth(journal, begin, end, clearedOnly, ctx);
   return buckets.reduce(
     (acc, b) => acc.plus(b.income).minus(b.expense),
     new Decimal(0),
@@ -292,8 +339,9 @@ export function avgMonthlyExpense(
   begin: LocalDate | null,
   end: LocalDate | null,
   clearedOnly = false,
+  ctx: ConversionContext | null = null,
 ): Decimal {
-  const buckets = incomeExpenseByMonth(journal, begin, end, clearedOnly);
+  const buckets = incomeExpenseByMonth(journal, begin, end, clearedOnly, ctx);
   if (buckets.length === 0) return new Decimal(0);
   const total = buckets.reduce((acc, b) => acc.plus(b.expense), new Decimal(0));
   return total.div(buckets.length);

--- a/web/dashboard/src/store/filters.ts
+++ b/web/dashboard/src/store/filters.ts
@@ -9,6 +9,10 @@ interface State {
   // If true, pending and uncleared transactions are excluded from
   // every dashboard computation.
   clearedOnly: boolean;
+  // When non-null, all commodity-aggregated views convert amounts to
+  // this commodity using the journal's P price directives. null means
+  // "as recorded" (no conversion).
+  displayCommodity: string | null;
 }
 
 export const useFiltersStore = defineStore("filters", {
@@ -16,5 +20,6 @@ export const useFiltersStore = defineStore("filters", {
     begin: null,
     end: null,
     clearedOnly: false,
+    displayCommodity: null,
   }),
 });


### PR DESCRIPTION
## Summary

- **Conversion algorithm**: TypeScript port of `Journal::exchange_rate_at` (`crates/doppio/src/elaboration_ext.rs:203`) in a new `web/dashboard/src/lib/views/exchange.ts`. Direct quote, inverse quote (1/price), no chaining through intermediates, latest P directive at-or-before the as-of cutoff wins. Ties in same-date quotes resolve in source order (last declared wins), matching the Rust `max_by_key` behaviour.
- **Components touched**: `FilterBar` (dropdown), `KpiStrip` (conversion + unconvertible badge), `IncomeExpenseChart`, `CategoryDonut`, `NetWorthTrend` (all use as-of cutoff). Register and per-posting views are untouched.
- **"As recorded" default**: `displayCommodity: null` in the pinia filters store means no conversion — exact current behaviour preserved.
- **Unconvertible surfacing**: when a commodity has no rate path to the display commodity, it is excluded from aggregates and an amber "No rate for: …" banner appears below the KPI cards.

## Test plan

- `npm test` — 71 vitest tests pass (13 new in `exchange.test.ts`): same-commodity, direct quote, inverse quote, no rate, two quotes on different dates (latest wins), date cutoff respected, exact-date boundary, null asOf, same-date tie-breaking, zero-price skipped, zero-price-only, unrelated prices ignored.
- `npm run build` — vue-tsc type-check + vite build succeed, 128 modules, clean output.

### Manual smoke-test steps

1. `npm run dev`, load `sample.dop`.
2. Filter bar shows "Display as" dropdown alongside Begin/End/Cleared.
3. Default "As recorded" matches current behaviour (USD totals unchanged).
4. Select `$` from the dropdown — KPIs, donut, and chart remain consistent.
5. If the sample has any commodity without a P-quote path, the amber "No rate for: …" note appears below the KPI strip.
6. The register / transaction detail views show native amounts unchanged.

## Notes

- NetWorthTrend uses the filter end-date as the as-of cutoff for all bars. True per-date rate lookup across the time series is a follow-up as noted in the issue's out-of-scope section.
- No `.dop` schema changes; `journal.prices` was already decoded by the loader.

Refs #312