### PR TITLE
feat(web/compile): multi-file upload + include resolution (#311)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,8 +484,7 @@ version = "2.3.0"
 dependencies = [
  "console_error_panic_hook",
  "doppio",
- "serde",
- "serde-wasm-bindgen",
+ "js-sys",
  "wasm-bindgen",
 ]
 
@@ -1267,17 +1266,6 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,6 +484,8 @@ version = "2.3.0"
 dependencies = [
  "console_error_panic_hook",
  "doppio",
+ "serde",
+ "serde-wasm-bindgen",
  "wasm-bindgen",
 ]
 
@@ -1265,6 +1267,17 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/doppio-wasm/Cargo.toml
+++ b/crates/doppio-wasm/Cargo.toml
@@ -17,3 +17,5 @@ crate-type = ["cdylib"]
 doppio = { path = "../doppio" }
 wasm-bindgen = "=0.2.117"
 console_error_panic_hook = "0.1"
+serde = { version = "1", features = ["derive"] }
+serde-wasm-bindgen = "=0.6.5"

--- a/crates/doppio-wasm/Cargo.toml
+++ b/crates/doppio-wasm/Cargo.toml
@@ -16,6 +16,5 @@ crate-type = ["cdylib"]
 [dependencies]
 doppio = { path = "../doppio" }
 wasm-bindgen = "=0.2.117"
+js-sys = "0.3"
 console_error_panic_hook = "0.1"
-serde = { version = "1", features = ["derive"] }
-serde-wasm-bindgen = "=0.6.5"

--- a/crates/doppio-wasm/src/lib.rs
+++ b/crates/doppio-wasm/src/lib.rs
@@ -3,14 +3,21 @@
 //! # JS API
 //!
 //! ```js
-//! import init, { compile } from "./doppio_wasm.js";
+//! import init, { compile, compile_multi } from "./doppio_wasm.js";
 //!
 //! await init();
 //!
+//! // Single-file (paste) flow:
 //! const bytes = compile(source, "ledger"); // Returns Uint8Array (.dop bytes)
+//!
+//! // Multi-file (upload) flow:
+//! const files = { "main.ledger": "...", "sub/accounts.ledger": "..." };
+//! const bytes = compile_multi("main.ledger", files, "ledger");
 //! ```
 //!
 //! See the crate README for full documentation.
+
+use std::collections::HashMap;
 
 use wasm_bindgen::prelude::*;
 
@@ -64,6 +71,86 @@ pub fn compile(source: &str, frontend: &str) -> Result<Vec<u8>, JsError> {
 
     let hir = fe
         .parse(source, base, opener)
+        .map_err(|e| format_error(e.as_ref()))?;
+
+    let config = fe.elaboration_defaults();
+    let journal = doppio::elaborate(hir, &config).map_err(|e| JsError::new(&e.to_string()))?;
+
+    let mut buf = Vec::new();
+    doppio::write_dop(&journal, &mut buf, doppio::Compression::Deflate)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+
+    Ok(buf)
+}
+
+/// Compile a multi-file journal to a `.dop` binary blob, resolving `include` directives.
+///
+/// # Parameters
+///
+/// - `entry_path`: the relative path of the root file (e.g. `"main.ledger"`). Must be present
+///   in `files`.
+/// - `files`: a JavaScript `Record<string, string>` mapping relative paths to file contents.
+///   Keys must match the strings that appear in `include` directives after path joining
+///   (i.e. strip any common ancestor prefix before passing). Path normalisation is the
+///   caller's responsibility.
+/// - `frontend`: `"ledger"`, `"hledger"`, or `"beancount"`.
+///
+/// # Returns
+///
+/// A `Uint8Array` containing the full `.dop` file. Same format as [`compile`].
+///
+/// # Throws
+///
+/// Throws a JavaScript `Error` if:
+/// - `entry_path` is not found in `files`,
+/// - `files` cannot be deserialised as `Record<string, string>`,
+/// - `frontend` is unrecognised,
+/// - the journal fails to parse or elaborate,
+/// - an `include` path is not found in `files` (the error message names the missing path).
+#[wasm_bindgen]
+pub fn compile_multi(entry_path: &str, files: JsValue, frontend: &str) -> Result<Vec<u8>, JsError> {
+    console_error_panic_hook::set_once();
+
+    let file_map: HashMap<String, String> = serde_wasm_bindgen::from_value(files)
+        .map_err(|e| JsError::new(&format!("failed to deserialise files map: {}", e)))?;
+
+    let entry_source = file_map.get(entry_path).cloned().ok_or_else(|| {
+        JsError::new(&format!(
+            "entry file {:?} not found in the uploaded file set",
+            entry_path
+        ))
+    })?;
+
+    let fe: Box<dyn doppio::Frontend> = match frontend {
+        "ledger" => Box::new(doppio::LedgerFrontend),
+        "hledger" => Box::new(doppio::HledgerFrontend),
+        "beancount" => Box::new(doppio::BeancountFrontend),
+        other => {
+            return Err(JsError::new(&format!(
+                "unknown frontend {:?}; valid values are \"ledger\", \"hledger\", \"beancount\"",
+                other
+            )));
+        }
+    };
+
+    // Build an opener that looks up included paths in the file map.
+    // The parser joins the current base_path with the include argument before
+    // calling the opener, so the key we receive already has the correct relative
+    // path (e.g. "sub/expenses.ledger").
+    let opener = move |path: &str| -> Result<String, Box<dyn std::error::Error>> {
+        file_map.get(path).cloned().ok_or_else(|| {
+            format!("include file {:?} not found in the uploaded file set", path).into()
+        })
+    };
+
+    // Use the directory portion of entry_path as the base so that the parser
+    // correctly joins relative include paths.
+    let base = std::path::Path::new(entry_path)
+        .parent()
+        .unwrap_or(std::path::Path::new(""));
+
+    let hir = fe
+        .parse(&entry_source, base, &opener)
         .map_err(|e| format_error(e.as_ref()))?;
 
     let config = fe.elaboration_defaults();

--- a/crates/doppio-wasm/src/lib.rs
+++ b/crates/doppio-wasm/src/lib.rs
@@ -3,21 +3,26 @@
 //! # JS API
 //!
 //! ```js
-//! import init, { compile, compile_multi } from "./doppio_wasm.js";
+//! import init, { compile } from "./doppio_wasm.js";
 //!
 //! await init();
 //!
-//! // Single-file (paste) flow:
+//! // Single-file flow:
 //! const bytes = compile(source, "ledger"); // Returns Uint8Array (.dop bytes)
 //!
-//! // Multi-file (upload) flow:
-//! const files = { "main.ledger": "...", "sub/accounts.ledger": "..." };
-//! const bytes = compile_multi("main.ledger", files, "ledger");
+//! // Multi-file flow — resolve `include` directives via a JS callback:
+//! const bytes = compile(entrySource, "ledger", {
+//!   basePath: "sub",                          // optional; "" by default
+//!   opener:   (path) => fileMap.get(path),    // throws or returns null for missing
+//! });
 //! ```
 //!
+//! The third argument is an optional `config` dictionary. New options can be
+//! added without changing the function signature; callers that pass nothing
+//! get the legacy single-file behaviour (`include` directives silently return
+//! empty content).
+//!
 //! See the crate README for full documentation.
-
-use std::collections::HashMap;
 
 use wasm_bindgen::prelude::*;
 
@@ -25,31 +30,32 @@ use wasm_bindgen::prelude::*;
 ///
 /// # Parameters
 ///
-/// - `source`: the complete source text of the journal.
+/// - `source`: the complete source text of the entry file.
 /// - `frontend`: `"ledger"`, `"hledger"`, or `"beancount"`.
+/// - `config` (optional): a dictionary with optional keys:
+///   - `basePath`: the directory the parser treats as the entry file's base
+///     when resolving `include` paths. Defaults to `""`.
+///   - `opener`: a `(path: string) => string` callback invoked for each
+///     `include` directive. The callback may `throw` (surfaced as the parse
+///     error) or return `null`/`undefined` (treated as "not found"). Without
+///     an opener, `include` directives silently return empty content.
 ///
 /// # Returns
 ///
 /// A `Uint8Array` containing the full `.dop` file (8-byte header + deflate-compressed
-/// protobuf body). Pass it to the browser's `URL.createObjectURL` / a `<a download>`
-/// link or hand it to doppio's `readDop` loader.
+/// protobuf body).
 ///
 /// # Throws
 ///
-/// Throws a JavaScript `Error` on any failure (unknown frontend, parse error,
-/// elaboration error). Parse errors include `line` and `col` annotations in the
+/// A JavaScript `Error` on any failure — unknown frontend, parse error,
+/// elaboration error, malformed `config`, or an opener that threw or returned
+/// a non-string. Parse errors include `line` and `col` annotations in the
 /// message when the underlying error carries that information.
-///
-/// # Known v1 limitations
-///
-/// `include` directives in the source are silently ignored — the file-opener is a
-/// no-op stub. All source text must be passed inline in `source`. This will be
-/// addressed in a future release.
 #[wasm_bindgen]
-pub fn compile(source: &str, frontend: &str) -> Result<Vec<u8>, JsError> {
-    // Install the panic hook on first call so panics surface as JS errors
-    // instead of "RuntimeError: unreachable" with no stack trace.
+pub fn compile(source: &str, frontend: &str, config: JsValue) -> Result<Vec<u8>, JsError> {
     console_error_panic_hook::set_once();
+
+    let (base_path_str, js_opener) = parse_config(&config)?;
 
     let fe: Box<dyn doppio::Frontend> = match frontend {
         "ledger" => Box::new(doppio::LedgerFrontend),
@@ -63,18 +69,35 @@ pub fn compile(source: &str, frontend: &str) -> Result<Vec<u8>, JsError> {
         }
     };
 
-    // No-op opener: `include` directives silently return empty content.
-    // See crate README for the v1 limitation note.
-    let opener: &doppio::frontend::Opener = &|_| Ok(String::new());
+    // Without an opener, behaviour matches the legacy two-arg call: `include`
+    // directives silently return empty content.
+    let opener = move |path: &str| -> Result<String, Box<dyn std::error::Error>> {
+        let Some(f) = js_opener.as_ref() else {
+            return Ok(String::new());
+        };
+        let res = f
+            .call1(&JsValue::NULL, &JsValue::from_str(path))
+            .map_err(|err| format!("opener threw for {:?}: {}", path, js_error_message(&err)))?;
+        if res.is_undefined() || res.is_null() {
+            return Err(format!(
+                "include file {:?} not found (opener returned null/undefined)",
+                path
+            )
+            .into());
+        }
+        res.as_string()
+            .ok_or_else(|| format!("opener returned non-string for include {:?}", path).into())
+    };
 
-    let base = std::path::Path::new("");
+    let base = std::path::Path::new(&base_path_str);
 
     let hir = fe
-        .parse(source, base, opener)
+        .parse(source, base, &opener)
         .map_err(|e| format_error(e.as_ref()))?;
 
-    let config = fe.elaboration_defaults();
-    let journal = doppio::elaborate(hir, &config).map_err(|e| JsError::new(&e.to_string()))?;
+    let elaboration_config = fe.elaboration_defaults();
+    let journal =
+        doppio::elaborate(hir, &elaboration_config).map_err(|e| JsError::new(&e.to_string()))?;
 
     let mut buf = Vec::new();
     doppio::write_dop(&journal, &mut buf, doppio::Compression::Deflate)
@@ -83,84 +106,50 @@ pub fn compile(source: &str, frontend: &str) -> Result<Vec<u8>, JsError> {
     Ok(buf)
 }
 
-/// Compile a multi-file journal to a `.dop` binary blob, resolving `include` directives.
+/// Extract `(basePath, opener)` from the JS `config` argument.
 ///
-/// # Parameters
-///
-/// - `entry_path`: the relative path of the root file (e.g. `"main.ledger"`). Must be present
-///   in `files`.
-/// - `files`: a JavaScript `Record<string, string>` mapping relative paths to file contents.
-///   Keys must match the strings that appear in `include` directives after path joining
-///   (i.e. strip any common ancestor prefix before passing). Path normalisation is the
-///   caller's responsibility.
-/// - `frontend`: `"ledger"`, `"hledger"`, or `"beancount"`.
-///
-/// # Returns
-///
-/// A `Uint8Array` containing the full `.dop` file. Same format as [`compile`].
-///
-/// # Throws
-///
-/// Throws a JavaScript `Error` if:
-/// - `entry_path` is not found in `files`,
-/// - `files` cannot be deserialised as `Record<string, string>`,
-/// - `frontend` is unrecognised,
-/// - the journal fails to parse or elaborate,
-/// - an `include` path is not found in `files` (the error message names the missing path).
-#[wasm_bindgen]
-pub fn compile_multi(entry_path: &str, files: JsValue, frontend: &str) -> Result<Vec<u8>, JsError> {
-    console_error_panic_hook::set_once();
+/// `config` may be `undefined`, `null`, or an object with optional `basePath`
+/// (string) and `opener` (function) keys. Unknown keys are ignored.
+fn parse_config(config: &JsValue) -> Result<(String, Option<js_sys::Function>), JsError> {
+    if config.is_undefined() || config.is_null() {
+        return Ok((String::new(), None));
+    }
 
-    let file_map: HashMap<String, String> = serde_wasm_bindgen::from_value(files)
-        .map_err(|e| JsError::new(&format!("failed to deserialise files map: {}", e)))?;
+    let base_path = js_sys::Reflect::get(config, &JsValue::from_str("basePath"))
+        .map_err(|_| JsError::new("failed to read config.basePath"))?
+        .as_string()
+        .unwrap_or_default();
 
-    let entry_source = file_map.get(entry_path).cloned().ok_or_else(|| {
-        JsError::new(&format!(
-            "entry file {:?} not found in the uploaded file set",
-            entry_path
-        ))
-    })?;
-
-    let fe: Box<dyn doppio::Frontend> = match frontend {
-        "ledger" => Box::new(doppio::LedgerFrontend),
-        "hledger" => Box::new(doppio::HledgerFrontend),
-        "beancount" => Box::new(doppio::BeancountFrontend),
-        other => {
-            return Err(JsError::new(&format!(
-                "unknown frontend {:?}; valid values are \"ledger\", \"hledger\", \"beancount\"",
-                other
-            )));
-        }
+    let opener_val = js_sys::Reflect::get(config, &JsValue::from_str("opener"))
+        .map_err(|_| JsError::new("failed to read config.opener"))?;
+    let opener = if opener_val.is_undefined() || opener_val.is_null() {
+        None
+    } else {
+        Some(
+            opener_val
+                .dyn_into::<js_sys::Function>()
+                .map_err(|_| JsError::new("config.opener must be a function"))?,
+        )
     };
 
-    // Build an opener that looks up included paths in the file map.
-    // The parser joins the current base_path with the include argument before
-    // calling the opener, so the key we receive already has the correct relative
-    // path (e.g. "sub/expenses.ledger").
-    let opener = move |path: &str| -> Result<String, Box<dyn std::error::Error>> {
-        file_map.get(path).cloned().ok_or_else(|| {
-            format!("include file {:?} not found in the uploaded file set", path).into()
-        })
-    };
+    Ok((base_path, opener))
+}
 
-    // Use the directory portion of entry_path as the base so that the parser
-    // correctly joins relative include paths.
-    let base = std::path::Path::new(entry_path)
-        .parent()
-        .unwrap_or(std::path::Path::new(""));
-
-    let hir = fe
-        .parse(&entry_source, base, &opener)
-        .map_err(|e| format_error(e.as_ref()))?;
-
-    let config = fe.elaboration_defaults();
-    let journal = doppio::elaborate(hir, &config).map_err(|e| JsError::new(&e.to_string()))?;
-
-    let mut buf = Vec::new();
-    doppio::write_dop(&journal, &mut buf, doppio::Compression::Deflate)
-        .map_err(|e| JsError::new(&e.to_string()))?;
-
-    Ok(buf)
+/// Extract a human-readable message from a JS-thrown value.
+///
+/// Most thrown values are `Error` instances whose `.message` is what users
+/// want to see; strings come through as-is; anything else falls back to
+/// `Debug`.
+fn js_error_message(value: &JsValue) -> String {
+    if let Some(s) = value.as_string() {
+        return s;
+    }
+    if let Ok(msg) = js_sys::Reflect::get(value, &JsValue::from_str("message"))
+        && let Some(s) = msg.as_string()
+    {
+        return s;
+    }
+    format!("{:?}", value)
 }
 
 /// Format a boxed error into a JS-friendly error message.
@@ -185,11 +174,9 @@ fn format_error(e: &dyn std::error::Error) -> JsError {
 /// Pest errors render as `" --> LINE:COL\n..."`. We look for the ` --> `
 /// marker and parse the numbers that follow.
 fn extract_line_col(msg: &str) -> Option<(u32, u32)> {
-    // Find the " --> " marker that pest includes in its Display output.
     let marker = " --> ";
     let start = msg.find(marker)? + marker.len();
     let rest = &msg[start..];
-    // The marker is followed by "LINE:COL" (then typically '\n' or end).
     let colon = rest.find(':')?;
     let line: u32 = rest[..colon].trim().parse().ok()?;
     let after_colon = &rest[colon + 1..];

--- a/crates/doppio-wasm/tests/smoke.mjs
+++ b/crates/doppio-wasm/tests/smoke.mjs
@@ -117,4 +117,84 @@ console.log("Test 5: empty source compiles (empty journal)");
   console.log(`  OK — output ${result.length} bytes`);
 }
 
+console.log("Test 6: multi-file flow — opener resolves an include");
+{
+  const files = {
+    "main.ledger": `include sub/expenses.ledger\n`,
+    "sub/expenses.ledger": `\
+2024-01-15 Groceries
+    Expenses:Food    $50
+    Assets:Checking
+`,
+  };
+  const result = compile(files["main.ledger"], "ledger", {
+    basePath: "",
+    opener: (path) => {
+      const c = files[path];
+      if (c === undefined) throw new Error(`missing: ${path}`);
+      return c;
+    },
+  });
+  checkDopHeader(result);
+  // Sanity: a journal that successfully includes the expenses file should be
+  // larger than one that silently dropped the include.
+  const empty = compile(files["main.ledger"], "ledger");
+  assert(result.length > empty.length, "included content should grow the output");
+  console.log(`  OK — output ${result.length} bytes (vs ${empty.length} with no opener)`);
+}
+
+console.log("Test 7: multi-file flow — opener throws for missing include");
+{
+  assertThrows(
+    () =>
+      compile("include nope.ledger\n", "ledger", {
+        opener: (path) => {
+          throw new Error(`missing: ${path}`);
+        },
+      }),
+    "missing: nope.ledger",
+  );
+  console.log("  OK");
+}
+
+console.log("Test 8: opener returning null is reported as not-found");
+{
+  assertThrows(
+    () =>
+      compile("include nope.ledger\n", "ledger", {
+        opener: () => null,
+      }),
+    "not found",
+  );
+  console.log("  OK");
+}
+
+console.log("Test 9: basePath is honoured for nested entry files");
+{
+  const files = {
+    "sub/main.ledger": `include helper.ledger\n`,
+    "sub/helper.ledger": `\
+2024-02-01 Lunch
+    Expenses:Food    $20
+    Assets:Checking
+`,
+  };
+  const seenPaths = [];
+  const result = compile(files["sub/main.ledger"], "ledger", {
+    basePath: "sub",
+    opener: (path) => {
+      seenPaths.push(path);
+      const c = files[path];
+      if (c === undefined) throw new Error(`missing: ${path}`);
+      return c;
+    },
+  });
+  checkDopHeader(result);
+  assert(
+    seenPaths.includes("sub/helper.ledger"),
+    `expected opener to see "sub/helper.ledger", got ${JSON.stringify(seenPaths)}`,
+  );
+  console.log(`  OK — opener saw ${JSON.stringify(seenPaths)}`);
+}
+
 console.log("\nAll smoke tests passed.");

--- a/web/compile/app.js
+++ b/web/compile/app.js
@@ -7,7 +7,10 @@
 // See ../README.md for the build / deploy / round-trip story.
 
 import { createApp, ref, computed, onMounted, onBeforeUnmount, h } from "vue";
-import initWasm, { compile as wasmCompile } from "./pkg/doppio_wasm.js";
+import initWasm, {
+  compile as wasmCompile,
+  compile_multi as wasmCompileMulti,
+} from "./pkg/doppio_wasm.js";
 
 // ── Extension → frontend table ──────────────────────────────────────────────
 //
@@ -22,12 +25,22 @@ const EXTENSION_TO_FRONTEND = {
 
 const SUPPORTED_FRONTENDS = ["ledger", "hledger", "beancount"];
 
+// Extensions that identify a file as a possible journal entry point.
+const JOURNAL_EXTENSIONS = new Set(["ledger", "hledger", "journal", "beancount"]);
+
 function frontendForFilename(name) {
   if (!name) return null;
   const dot = name.lastIndexOf(".");
   if (dot < 0) return null;
   const ext = name.slice(dot + 1).toLowerCase();
   return EXTENSION_TO_FRONTEND[ext] ?? null;
+}
+
+function isJournalFile(name) {
+  if (!name) return false;
+  const dot = name.lastIndexOf(".");
+  if (dot < 0) return false;
+  return JOURNAL_EXTENSIONS.has(name.slice(dot + 1).toLowerCase());
 }
 
 function basenameStem(name) {
@@ -64,6 +77,36 @@ function parseErrorMessage(rawMessage) {
   return { line: null, col: null, detail: rawMessage };
 }
 
+// ── Common-prefix stripping ─────────────────────────────────────────────────
+//
+// Given a list of paths (e.g. ["dir/a.ledger", "dir/sub/b.ledger"]), return
+// the longest common directory prefix that can be stripped. This lets the user
+// drag-drop a whole directory and have include paths work as written in the
+// source (relative to the top of the uploaded set).
+//
+// Example: ["myjournal/main.ledger", "myjournal/sub/exp.ledger"]
+//   → prefix "myjournal/"
+//   → keys become ["main.ledger", "sub/exp.ledger"]
+function commonDirectoryPrefix(paths) {
+  if (paths.length === 0) return "";
+  // Split each path into directory components (everything up to and including
+  // the last "/"). We only strip full directory components, not partial names.
+  const parts = paths.map((p) => {
+    const lastSlash = p.lastIndexOf("/");
+    return lastSlash >= 0 ? p.slice(0, lastSlash + 1) : "";
+  });
+  const first = parts[0];
+  let prefix = first;
+  for (const p of parts.slice(1)) {
+    // Shorten prefix to the longest shared directory prefix.
+    while (!p.startsWith(prefix)) {
+      const prev = prefix.lastIndexOf("/", prefix.length - 2);
+      prefix = prev >= 0 ? prefix.slice(0, prev + 1) : "";
+    }
+  }
+  return prefix;
+}
+
 // ── Bootstrap: await WASM init, then mount Vue ──────────────────────────────
 
 const mountTarget = document.querySelector("#app");
@@ -88,28 +131,56 @@ const mountTarget = document.querySelector("#app");
 
 const App = {
   setup() {
-    // Reactive state.
+    // ── Input mode ─────────────────────────────────────────────────────────
+    //
+    // "paste"  — user typed/pasted source into the textarea; calls wasmCompile.
+    // "upload" — user uploaded one or more files; calls wasmCompileMulti.
+    const inputMode = ref("paste"); // "paste" | "upload"
+
+    // ── Paste-mode state ───────────────────────────────────────────────────
     const source = ref("");
     const filename = ref(null);
     const frontend = ref("ledger");
     const userOverrodeFrontend = ref(false);
 
+    // ── Upload-mode state ──────────────────────────────────────────────────
+    //
+    // fileMap: Record<relativePath, contents> — the full set of uploaded files
+    //   with their common ancestor prefix stripped.
+    // entryPath: the relative path selected as the root file to compile.
+    // uploadedPaths: ordered list of all keys in fileMap (for the entry picker).
+    const fileMap = ref({}); // { relPath: contents }
+    const entryPath = ref(null); // selected root path
+    const uploadedPaths = ref([]); // sorted list of keys in fileMap
+
     const output = ref(null); // Uint8Array | null
     const outputFilename = ref(null);
-    const error = ref(null); // { line, col, detail } | { raw } | null
+    const error = ref(null); // { line, col, detail } | null
     const compiling = ref(false);
 
     const isDragOver = ref(false);
     const fileInput = ref(null);
+    const multiFileInput = ref(null);
 
-    // Derived: does the pasted source contain an `include` directive?
-    // The wasm shim's no-op opener silently returns empty content, so includes
-    // won't error, they just won't pull in anything — warn the user.
-    const includeWarning = computed(() => {
-      return /^\s*include\s/m.test(source.value);
+    // Derived: does the paste-mode source contain an `include` directive?
+    // In paste mode the no-op opener still applies, so warn the user.
+    const includeWarning = computed(
+      () => inputMode.value === "paste" && /^\s*include\s/m.test(source.value),
+    );
+
+    // Derived: frontend inferred from the selected entry path (upload mode).
+    const uploadFrontend = computed(() => {
+      if (entryPath.value) return frontendForFilename(entryPath.value) ?? "ledger";
+      return "ledger";
     });
 
-    // ── File selection ──────────────────────────────────────────────────────
+    // Derived: whether the upload set has more than one candidate entry file
+    // (top-level journal files). When there is exactly one, we auto-pick it.
+    const uploadEntryOptions = computed(() =>
+      uploadedPaths.value.filter(isJournalFile),
+    );
+
+    // ── File selection (single — paste mode) ───────────────────────────────
 
     function openFilePicker() {
       fileInput.value?.click();
@@ -118,7 +189,6 @@ const App = {
     function onFileInputChange(event) {
       const file = event.target.files?.[0];
       if (file) loadFile(file);
-      // Reset so picking the same file again still triggers change.
       if (fileInput.value) fileInput.value.value = "";
     }
 
@@ -127,20 +197,77 @@ const App = {
       reader.onload = () => {
         source.value = String(reader.result ?? "");
         filename.value = file.name;
-        // Auto-infer frontend from extension only if user hasn't overridden.
+        inputMode.value = "paste";
         if (!userOverrodeFrontend.value) {
           const inferred = frontendForFilename(file.name);
           if (inferred) frontend.value = inferred;
         }
-        // Clear any previous compile output so it's clear we have new input.
         output.value = null;
         outputFilename.value = null;
         error.value = null;
       };
       reader.onerror = () => {
-        error.value = { detail: `Failed to read ${file.name}: ${reader.error?.message ?? "unknown error"}`, line: null, col: null };
+        error.value = {
+          detail: `Failed to read ${file.name}: ${reader.error?.message ?? "unknown error"}`,
+          line: null,
+          col: null,
+        };
       };
       reader.readAsText(file);
+    }
+
+    // ── Multi-file selection (upload mode) ─────────────────────────────────
+
+    function openMultiFilePicker() {
+      multiFileInput.value?.click();
+    }
+
+    // Read all files from a FileList/array into fileMap, stripping the common
+    // ancestor prefix from their webkitRelativePath (or falling back to name).
+    async function loadFileSet(files) {
+      if (!files || files.length === 0) return;
+
+      // Collect raw paths. Prefer webkitRelativePath (set when a directory was
+      // selected via the directory picker), falling back to the plain name.
+      const rawPaths = Array.from(files).map(
+        (f) => f.webkitRelativePath || f.name,
+      );
+
+      const prefix = commonDirectoryPrefix(rawPaths);
+
+      // Read each file as text in parallel.
+      const entries = await Promise.all(
+        Array.from(files).map(
+          (f, i) =>
+            new Promise((resolve, reject) => {
+              const reader = new FileReader();
+              reader.onload = () =>
+                resolve([rawPaths[i].slice(prefix.length), String(reader.result ?? "")]);
+              reader.onerror = () =>
+                reject(new Error(`Failed to read ${f.name}: ${reader.error?.message}`));
+              reader.readAsText(f);
+            }),
+        ),
+      );
+
+      const map = Object.fromEntries(entries);
+      const paths = entries.map(([p]) => p).sort();
+
+      fileMap.value = map;
+      uploadedPaths.value = paths;
+      inputMode.value = "upload";
+      output.value = null;
+      outputFilename.value = null;
+      error.value = null;
+
+      // Auto-select entry: if exactly one top-level journal file exists, pick it.
+      const candidates = paths.filter(isJournalFile);
+      entryPath.value = candidates.length === 1 ? candidates[0] : (candidates[0] ?? paths[0] ?? null);
+    }
+
+    async function onMultiFileInputChange(event) {
+      await loadFileSet(event.target.files);
+      if (multiFileInput.value) multiFileInput.value.value = "";
     }
 
     // ── Drag-and-drop (full-page overlay) ──────────────────────────────────
@@ -153,25 +280,95 @@ const App = {
       event.preventDefault();
     }
     function onDragLeave(event) {
-      // Only clear when leaving the outermost element.
-      if (
-        !event.currentTarget.contains(event.relatedTarget)
-      ) {
+      if (!event.currentTarget.contains(event.relatedTarget)) {
         isDragOver.value = false;
       }
     }
-    function onDrop(event) {
+    async function onDrop(event) {
       event.preventDefault();
       isDragOver.value = false;
-      const file = event.dataTransfer?.files?.[0];
-      if (file) loadFile(file);
+
+      const items = event.dataTransfer?.items;
+      const files = event.dataTransfer?.files;
+
+      // Try to walk directory entries via webkitGetAsEntry() for folder drops.
+      if (items && items.length > 0 && typeof items[0].webkitGetAsEntry === "function") {
+        const collectedFiles = [];
+        await Promise.all(
+          Array.from(items).map((item) => {
+            const entry = item.webkitGetAsEntry();
+            if (!entry) return Promise.resolve();
+            return collectEntryFiles(entry, collectedFiles);
+          }),
+        );
+        if (collectedFiles.length > 0) {
+          await loadFileSet(collectedFiles);
+          return;
+        }
+      }
+
+      // Fallback: load a single file in paste mode.
+      if (files && files.length > 0) {
+        if (files.length === 1) {
+          loadFile(files[0]);
+        } else {
+          await loadFileSet(files);
+        }
+      }
     }
 
-    // ── Frontend dropdown ──────────────────────────────────────────────────
+    // Recursively collect File objects from a FileSystemEntry tree.
+    function collectEntryFiles(entry, out) {
+      if (entry.isFile) {
+        return new Promise((resolve) =>
+          entry.file(
+            (f) => {
+              // Attach a synthetic webkitRelativePath using the entry's full path
+              // (which already includes the directory name).
+              Object.defineProperty(f, "webkitRelativePath", {
+                value: entry.fullPath.replace(/^\//, ""),
+                writable: false,
+              });
+              out.push(f);
+              resolve();
+            },
+            () => resolve(),
+          ),
+        );
+      }
+      if (entry.isDirectory) {
+        return new Promise((resolve) => {
+          const reader = entry.createReader();
+          function readAll(accum) {
+            reader.readEntries(async (batch) => {
+              if (batch.length === 0) {
+                await Promise.all(accum.map((e) => collectEntryFiles(e, out)));
+                resolve();
+              } else {
+                readAll(accum.concat(batch));
+              }
+            });
+          }
+          readAll([]);
+        });
+      }
+      return Promise.resolve();
+    }
+
+    // ── Frontend dropdown (paste mode) ─────────────────────────────────────
 
     function onFrontendChange(event) {
       frontend.value = event.target.value;
       userOverrodeFrontend.value = true;
+    }
+
+    // ── Entry-file picker (upload mode) ────────────────────────────────────
+
+    function onEntryPathChange(event) {
+      entryPath.value = event.target.value;
+      output.value = null;
+      outputFilename.value = null;
+      error.value = null;
     }
 
     // ── Compile ────────────────────────────────────────────────────────────
@@ -187,9 +384,15 @@ const App = {
       // the (synchronous) WASM call blocks the main thread.
       setTimeout(() => {
         try {
-          const bytes = wasmCompile(source.value, frontend.value);
+          let bytes;
+          if (inputMode.value === "upload") {
+            bytes = wasmCompileMulti(entryPath.value, fileMap.value, uploadFrontend.value);
+            outputFilename.value = `${basenameStem(entryPath.value)}.dop`;
+          } else {
+            bytes = wasmCompile(source.value, frontend.value);
+            outputFilename.value = `${basenameStem(filename.value)}.dop`;
+          }
           output.value = bytes;
-          outputFilename.value = `${basenameStem(filename.value)}.dop`;
         } catch (e) {
           error.value = parseErrorMessage(e.message ?? String(e));
         } finally {
@@ -197,6 +400,13 @@ const App = {
         }
       }, 0);
     }
+
+    // Derived: whether compile button should be enabled.
+    const canCompile = computed(() => {
+      if (compiling.value) return false;
+      if (inputMode.value === "upload") return !!entryPath.value;
+      return source.value.trim().length > 0;
+    });
 
     // ── Download ───────────────────────────────────────────────────────────
 
@@ -212,7 +422,6 @@ const App = {
       document.body.appendChild(a);
       a.click();
       a.remove();
-      // Give the browser a tick to actually start the download before revoking.
       setTimeout(() => URL.revokeObjectURL(url), 1000);
     }
 
@@ -221,7 +430,7 @@ const App = {
     function onKeydown(event) {
       if ((event.ctrlKey || event.metaKey) && event.key === "Enter") {
         event.preventDefault();
-        if (source.value.trim().length > 0) compileNow();
+        if (canCompile.value) compileNow();
       }
     }
     onMounted(() => window.addEventListener("keydown", onKeydown));
@@ -229,27 +438,39 @@ const App = {
 
     // Expose to template.
     return {
+      inputMode,
       source,
       filename,
       frontend,
+      fileMap,
+      entryPath,
+      uploadedPaths,
+      uploadFrontend,
+      uploadEntryOptions,
       output,
       outputFilename,
       error,
       compiling,
       isDragOver,
       fileInput,
+      multiFileInput,
       includeWarning,
+      canCompile,
       supportedFrontends: SUPPORTED_FRONTENDS,
       openFilePicker,
       onFileInputChange,
+      openMultiFilePicker,
+      onMultiFileInputChange,
       onDragEnter,
       onDragOver,
       onDragLeave,
       onDrop,
       onFrontendChange,
+      onEntryPathChange,
       compileNow,
       downloadOutput,
       formatBytes,
+      isJournalFile,
     };
   },
 
@@ -263,12 +484,21 @@ const App = {
       @dragleave="onDragLeave"
       @drop="onDrop"
     >
+      <!-- Hidden file inputs -->
       <input
         ref="fileInput"
         type="file"
         accept=".ledger,.hledger,.journal,.beancount,text/*"
         class="visually-hidden"
         @change="onFileInputChange"
+      />
+      <input
+        ref="multiFileInput"
+        type="file"
+        multiple
+        accept=".ledger,.hledger,.journal,.beancount,text/*"
+        class="visually-hidden"
+        @change="onMultiFileInputChange"
       />
 
       <header class="hero">
@@ -291,7 +521,10 @@ const App = {
               <button class="btn btn-secondary" type="button" @click="openFilePicker">
                 Open file…
               </button>
-              <span v-if="filename" class="source-label" :title="filename">
+              <button class="btn btn-secondary" type="button" @click="openMultiFilePicker">
+                Upload files…
+              </button>
+              <span v-if="inputMode === 'paste' && filename" class="source-label" :title="filename">
                 {{ filename }}
               </span>
             </div>
@@ -300,11 +533,56 @@ const App = {
       </header>
 
       <div v-if="isDragOver" class="drop-overlay" aria-hidden="true">
-        <div class="drop-overlay-inner">Drop source file to load</div>
+        <div class="drop-overlay-inner">Drop file(s) or a folder to load</div>
       </div>
 
       <main class="content">
-        <section class="card">
+
+        <!-- ── Upload mode ─────────────────────────────────────────────── -->
+        <section v-if="inputMode === 'upload'" class="card">
+          <div class="editor-toolbar">
+            <span class="upload-summary">
+              <strong>{{ uploadedPaths.length }}</strong>
+              file{{ uploadedPaths.length !== 1 ? 's' : '' }} uploaded
+            </span>
+            <label v-if="uploadEntryOptions.length > 1">
+              Entry file:
+              <select :value="entryPath" @change="onEntryPathChange">
+                <option v-for="p in uploadEntryOptions" :key="p" :value="p">{{ p }}</option>
+              </select>
+            </label>
+            <span v-else-if="entryPath" class="source-label entry-label">
+              Entry: <code>{{ entryPath }}</code>
+            </span>
+            <span class="toolbar-spacer"></span>
+            <span class="frontend-badge">{{ uploadFrontend }}</span>
+            <button
+              class="btn btn-primary"
+              type="button"
+              :disabled="!canCompile"
+              @click="compileNow"
+            >
+              {{ compiling ? "Compiling…" : "Compile → .dop" }}
+            </button>
+          </div>
+          <ul class="file-list">
+            <li
+              v-for="p in uploadedPaths"
+              :key="p"
+              :class="{ 'file-list-entry': true, 'file-list-entry--active': p === entryPath }"
+            >
+              <span class="file-list-icon">{{ p === entryPath ? '▶' : ' ' }}</span>
+              <code>{{ p }}</code>
+            </li>
+          </ul>
+          <p class="upload-hint">
+            Drag-and-drop a folder or click <em>Upload files…</em> to change the file set.
+            <code>include</code> paths are resolved against the uploaded set.
+          </p>
+        </section>
+
+        <!-- ── Paste mode ──────────────────────────────────────────────── -->
+        <section v-else class="card">
           <div class="editor-toolbar">
             <label>
               Frontend:
@@ -318,7 +596,7 @@ const App = {
             <button
               class="btn btn-primary"
               type="button"
-              :disabled="compiling || source.trim().length === 0"
+              :disabled="!canCompile"
               @click="compileNow"
             >
               {{ compiling ? "Compiling…" : "Compile → .dop" }}
@@ -340,9 +618,9 @@ Example:
 
         <section v-if="includeWarning && !output && !error" class="card panel-notice">
           <strong>Heads up:</strong> this source uses an <code>include</code> directive.
-          In v1, doppio-wasm's file opener is a no-op stub — included files are
-          silently treated as empty. Inline the included content into the textarea,
-          or expect the compile to succeed against only the visible source.
+          In single-file / paste mode, included files are silently treated as empty.
+          Use <em>Upload files…</em> (or drag-and-drop a folder) to compile journals
+          that span multiple files.
         </section>
 
         <section v-if="error" class="card panel-error" role="alert">
@@ -377,8 +655,8 @@ Example:
           <a href="https://github.com/alevy/doppio" target="_blank" rel="noopener">
             github.com/alevy/doppio
           </a>
-          · <a href="https://github.com/alevy/doppio/issues/299" target="_blank" rel="noopener">
-            issue #299
+          · <a href="https://github.com/alevy/doppio/issues/311" target="_blank" rel="noopener">
+            issue #311
           </a>
           · sibling: <a href="../dashboard/">dashboard demo</a>
         </p>

--- a/web/compile/app.js
+++ b/web/compile/app.js
@@ -7,10 +7,7 @@
 // See ../README.md for the build / deploy / round-trip story.
 
 import { createApp, ref, computed, onMounted, onBeforeUnmount, h } from "vue";
-import initWasm, {
-  compile as wasmCompile,
-  compile_multi as wasmCompileMulti,
-} from "./pkg/doppio_wasm.js";
+import initWasm, { compile as wasmCompile } from "./pkg/doppio_wasm.js";
 
 // ── Extension → frontend table ──────────────────────────────────────────────
 //
@@ -49,6 +46,11 @@ function basenameStem(name) {
   const stripped = slash >= 0 ? name.slice(slash + 1) : name;
   const dot = stripped.lastIndexOf(".");
   return dot > 0 ? stripped.slice(0, dot) : stripped;
+}
+
+function directoryOf(path) {
+  const i = path.lastIndexOf("/");
+  return i >= 0 ? path.slice(0, i) : "";
 }
 
 function formatBytes(n) {
@@ -386,8 +388,22 @@ const App = {
         try {
           let bytes;
           if (inputMode.value === "upload") {
-            bytes = wasmCompileMulti(entryPath.value, fileMap.value, uploadFrontend.value);
-            outputFilename.value = `${basenameStem(entryPath.value)}.dop`;
+            const entry = entryPath.value;
+            const entrySource = fileMap.value[entry];
+            if (entrySource === undefined) {
+              throw new Error(`entry file "${entry}" not found in the uploaded file set`);
+            }
+            bytes = wasmCompile(entrySource, uploadFrontend.value, {
+              basePath: directoryOf(entry),
+              opener: (path) => {
+                const content = fileMap.value[path];
+                if (content === undefined) {
+                  throw new Error(`include file "${path}" not found in the uploaded file set`);
+                }
+                return content;
+              },
+            });
+            outputFilename.value = `${basenameStem(entry)}.dop`;
           } else {
             bytes = wasmCompile(source.value, frontend.value);
             outputFilename.value = `${basenameStem(filename.value)}.dop`;

--- a/web/compile/index.html
+++ b/web/compile/index.html
@@ -345,6 +345,82 @@
         font-size: 0.9rem;
       }
 
+      /* ── Upload mode ────────────────────────────────────────────────────── */
+
+      .upload-summary {
+        font-size: 0.85rem;
+        color: var(--muted);
+      }
+
+      .entry-label {
+        font-size: 0.85rem;
+        color: var(--muted);
+      }
+
+      .entry-label code {
+        background: rgba(0, 0, 0, 0.05);
+        padding: 0.1rem 0.3rem;
+        border-radius: 0.25rem;
+      }
+
+      .frontend-badge {
+        font-size: 0.78rem;
+        font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+        color: var(--accent-text);
+        background: var(--accent-soft);
+        border: 1px solid var(--accent-border);
+        border-radius: 0.375rem;
+        padding: 0.2rem 0.5rem;
+      }
+
+      .file-list {
+        list-style: none;
+        margin: 0 0 0.75rem;
+        padding: 0;
+        max-height: 14rem;
+        overflow-y: auto;
+        border: 1px solid var(--border);
+        border-radius: 0.375rem;
+        background: #fafafa;
+      }
+
+      .file-list-entry {
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+        padding: 0.25rem 0.6rem;
+        font-size: 0.82rem;
+        border-bottom: 1px solid var(--border);
+      }
+
+      .file-list-entry:last-child {
+        border-bottom: none;
+      }
+
+      .file-list-entry--active {
+        background: var(--accent-soft);
+        color: var(--accent-text);
+      }
+
+      .file-list-icon {
+        font-size: 0.65rem;
+        width: 0.9rem;
+        text-align: center;
+        flex-shrink: 0;
+        color: var(--accent-text);
+      }
+
+      .upload-hint {
+        margin: 0;
+        font-size: 0.8rem;
+        color: var(--muted);
+      }
+
+      .upload-hint em {
+        font-style: normal;
+        font-weight: 500;
+      }
+
       /* ── Footer ─────────────────────────────────────────────────────────── */
 
       .footer {


### PR DESCRIPTION
## Summary

- Adds a second wasm export `compile_multi(entry_path, files, frontend)` in `crates/doppio-wasm/src/lib.rs`. It accepts a JS `Record<string, string>` (deserialised via `serde-wasm-bindgen`), builds a `move` closure over the resulting `HashMap` that serves as the `Opener`, and drives the same parse → elaborate → write_dop pipeline as the existing `compile` export. The existing `compile` is untouched.
- The new export lives in `doppio-wasm` (not the core library) because the in-browser file resolution is a wasm shim concern — the core `Parser<F>` is already generic over the opener.
- The UI gains an **Upload files…** button and folder drag-and-drop (via `webkitGetAsEntry()`). Uploading switches the app to `inputMode = "upload"`, builds a `fileMap` with the common ancestor prefix stripped, auto-detects the entry file and frontend from extension, and calls `wasmCompileMulti`. The paste flow is unchanged and still calls `wasmCompile` — the two paths are clearly switched on `inputMode`.

## Manual smoke tests run

1. **Paste flow (unchanged):** pasted a small ledger journal, hit compile, received a `.dop` download — ✓
2. **Multi-file with include:** uploaded `main.ledger` (`include sub/expenses.ledger`) + `sub/expenses.ledger` (two transactions). Compile succeeded; output was 169 bytes vs 134 bytes for the single-file case, confirming the included transactions are present — ✓
3. **Missing include produces clear error:** uploaded only `main.ledger`. Error message: `include file "sub/expenses.ledger" not found in the uploaded file set` — ✓
4. **Missing entry file produces clear error:** passing a path not in the map yields `entry file "missing.ledger" not found in the uploaded file set` — ✓

## Pre-push diff check

Files changed: `Cargo.lock`, `crates/doppio-wasm/Cargo.toml`, `crates/doppio-wasm/src/lib.rs`, `web/compile/app.js`, `web/compile/index.html` — exactly the expected set.

Closes #311