### PR TITLE
chore: release doppio-categorize 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### doppio-categorize 0.1.1 - 2026-05-12
+
+- **Bump pinned `doppio` dependency from `1.0.0` to `2.0.0`.** The published
+  `doppio-categorize 0.1.0` manifest pinned `doppio = "1.0.0"`, so projects
+  depending on both `doppio = "2.x"` and `doppio-categorize = "0.1.0"`
+  resolved to two incompatible major versions of doppio in the same tree --
+  preventing the elaboration types from unifying. No code change in
+  doppio-categorize itself; the patch bump exists solely to publish the
+  current (correctly-pinned) manifest to crates.io. SemVer-correct under the
+  pre-1.0 convention (no public-API change).
+
 ## [2.3.0] - 2026-05-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "doppio-categorize"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "doppio",

--- a/crates/doppio-categorize/Cargo.toml
+++ b/crates/doppio-categorize/Cargo.toml
@@ -2,7 +2,7 @@
 name = "doppio-categorize"
 description = "Counter-account prediction for the doppio ledger compiler -- given a partial transaction, suggest the most likely counter-account from journal history."
 readme = "README.md"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Summary

Re-publishes \`doppio-categorize\` with the correctly-pinned \`doppio = \"2.0.0\"\` dependency. The published \`doppio-categorize 0.1.0\` manifest still pins \`doppio = \"1.0.0\"\` (locked in by commit bbac92d, before the v2.0.0 cut), so any project depending on both \`doppio = \"2.x\"\` and \`doppio-categorize = \"0.1.0\"\` ends up with two incompatible major versions of doppio in the same dep graph:

\`\`\`
├── doppio v2.3.0
└── doppio-categorize v0.1.0
    ├── doppio v1.0.0
\`\`\`

The elaboration types from one crate don't satisfy the other, so downstream code can't pass \`elaboration::Journal\` into \`Index::build\`.

## What changed

- \`crates/doppio-categorize/Cargo.toml\`: bump version 0.1.0 → 0.1.1.
- \`CHANGELOG.md\`: \`[Unreleased]\` gains a \`doppio-categorize 0.1.1\` subheading explaining the dep-pin fix.

No code change in the crate itself — \`Cargo.toml\` already had \`doppio = \"2.0.0\"\` since the v2.0.0 cut (3bb79f0); this just publishes that state.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy -p doppio-categorize -- -D warnings\` clean
- [x] \`cargo test -p doppio-categorize\` 12 passed
- [x] \`cargo publish --dry-run -p doppio-categorize\` succeeds (12 files, 111.3 KiB)
- [x] CI green
- [ ] \`cargo publish\` after merge
- [ ] Tag \`categorize-v0.1.1\` pushed
- [ ] Downstream verification: \`cargo tree\` on a project depending on both shows a single \`doppio\` node