### PR TITLE
chore: release doppio-categorize 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-### doppio-categorize 0.2.0
+### doppio-categorize 0.2.0 - 2026-05-16
 
 **Breaking changes** (part of #319, builds on #320).
 


### PR DESCRIPTION
Release `doppio-categorize 0.2.0` to crates.io.

`Cargo.toml` was bumped to `0.2.0` in #322; `Cargo.lock` is already in sync. This PR only date-stamps the CHANGELOG entry for the release.

## What's in 0.2.0

Breaking architectural rewrite. The `Index` is now payee-primary; per-known-account bucketing is removed. Cold-start scenarios (new credit card, new checking account) now return meaningful suggestions instead of empty results.

Full changelog entry: see `CHANGELOG.md`.

Headline measurement lift on the household corpus, leave-one-account-out cohort top-1: **0.1% → 43.8%**. Uniform-holdout accuracy unchanged (72.0%).

Closes the v0.2 conversation tracked in #319, #320, #322, #323. Follow-up work to recover more cold-start signal via richer payee normalization is filed as #324.

## Downstream

Consumers (bb-ledger, bookie, future web UI) need this on crates.io before they can pick up the architecture change.