### PR TITLE
[categorize] richer payee normalization to recover variant-merchant signal

### DIFF
--- a/crates/doppio-categorize/examples/eval_holdout.rs
+++ b/crates/doppio-categorize/examples/eval_holdout.rs
@@ -35,6 +35,7 @@
 //!   <journal-path> \
 //!   [--import-regex REGEX] \
 //!   [--no-amount-weighting] \
+//!   [--normalizer default|rich] \
 //!   [--strategy exact|token-idf|hybrid] \
 //!   [--df-threshold N] \
 //!   [--holdout 0.10] [--seed N] \
@@ -54,7 +55,7 @@ use std::path::Path;
 use std::process::ExitCode;
 
 use doppio::elaboration::{Journal, Transaction};
-use doppio_categorize::{Config, DefaultNormalizer, Index, Query, ScoringStrategy};
+use doppio_categorize::{Config, DefaultNormalizer, Index, Query, RichNormalizer, ScoringStrategy};
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
@@ -171,6 +172,7 @@ impl Metrics {
 fn print_usage() {
     eprintln!(
         "usage: eval_holdout <journal-path> [--import-regex REGEX] [--no-amount-weighting] \
+         [--normalizer default|rich] \
          [--strategy exact|token-idf|hybrid] [--df-threshold N] \
          [--holdout FRACTION] [--seed N] \
          [--cold-account ACCOUNT] \
@@ -255,6 +257,15 @@ fn make_journal(txns: Vec<Transaction>) -> Journal {
     }
 }
 
+/// Build an [`Index`] using either the default or rich normalizer.
+fn build_index(journal: &Journal, use_rich: bool) -> Index {
+    if use_rich {
+        Index::build(journal, RichNormalizer)
+    } else {
+        Index::build(journal, DefaultNormalizer)
+    }
+}
+
 /// Print the standard per-cluster-size breakdown.
 fn print_cluster_breakdown(hits: &[Hit]) {
     println!("Top-1 accuracy by training cluster size:");
@@ -309,6 +320,7 @@ fn run_uniform_holdout(
     all_txns: Vec<Transaction>,
     import_re: &Regex,
     config: &Config,
+    use_rich: bool,
     holdout_fraction: f64,
     seed: u64,
 ) -> ExitCode {
@@ -358,7 +370,7 @@ fn run_uniform_holdout(
         }
     }
 
-    let index = Index::build(&make_journal(train_txns), DefaultNormalizer);
+    let index = build_index(&make_journal(train_txns), use_rich);
     eprintln!(
         "Index built. Evaluating {} held-out queries...\n",
         test_txns.len()
@@ -393,6 +405,7 @@ fn run_cold_account(
     all_txns: Vec<Transaction>,
     import_re: &Regex,
     config: &Config,
+    use_rich: bool,
     account: &str,
 ) -> ExitCode {
     // Partition into held-out (import side == account) vs. train (everything else).
@@ -443,7 +456,7 @@ fn run_cold_account(
         train_txns.len()
     );
 
-    let index = Index::build(&make_journal(train_txns), DefaultNormalizer);
+    let index = build_index(&make_journal(train_txns), use_rich);
     eprintln!(
         "Index built. Evaluating {} held-out queries...\n",
         test_txns.len()
@@ -470,6 +483,7 @@ fn run_loao(
     all_txns: Vec<Transaction>,
     import_re: &Regex,
     config: &Config,
+    use_rich: bool,
     min_count: usize,
 ) -> ExitCode {
     // Classify every transaction as eligible (2-posting, exactly-one-import)
@@ -568,7 +582,7 @@ fn run_loao(
             }
         }
 
-        let index = Index::build(&make_journal(train_txns), DefaultNormalizer);
+        let index = build_index(&make_journal(train_txns), use_rich);
         let hits = evaluate(&test_txns, &index, config, import_re);
 
         let n_eval = hits.len();
@@ -748,6 +762,7 @@ fn run_account_replacement(
     all_txns: Vec<Transaction>,
     import_re: &Regex,
     config: &Config,
+    use_rich: bool,
     account: &str,
     fraction: f64,
     seed: u64,
@@ -808,7 +823,7 @@ fn run_account_replacement(
     eprintln!("  Synthetic known_account for queries: '{synthetic_account}'");
     eprintln!("  Total training transactions: {}", train_txns.len());
 
-    let index = Index::build(&make_journal(train_txns), DefaultNormalizer);
+    let index = build_index(&make_journal(train_txns), use_rich);
     eprintln!(
         "Index built. Evaluating {} held-out queries...\n",
         test_txns.len()
@@ -837,6 +852,7 @@ fn run_account_replacement_cohort(
     all_txns: Vec<Transaction>,
     import_re: &Regex,
     config: &Config,
+    use_rich: bool,
     min_count: usize,
     fraction: f64,
     seed: u64,
@@ -948,7 +964,7 @@ fn run_account_replacement_cohort(
         // The remainder of the target account's txns stay in training.
         base_train.extend(target_eligible);
 
-        let index = Index::build(&make_journal(base_train), DefaultNormalizer);
+        let index = build_index(&make_journal(base_train), use_rich);
         let hits =
             evaluate_with_replacement(&test_txns, &index, config, import_re, &synthetic_account);
 
@@ -1077,6 +1093,7 @@ fn main() -> ExitCode {
     let mut seed = DEFAULT_SEED;
     let mut strategy_name = String::from("hybrid");
     let mut df_threshold: u32 = 50;
+    let mut use_rich = false;
 
     // Mode flags — mutually exclusive.
     let mut cold_account: Option<String> = None;
@@ -1098,6 +1115,21 @@ fn main() -> ExitCode {
             }
             "--no-amount-weighting" => {
                 config.use_amount_weighting = false;
+            }
+            "--normalizer" => {
+                i += 1;
+                if i >= args_vec.len() {
+                    eprintln!("--normalizer requires a value (default|rich)");
+                    return ExitCode::from(2);
+                }
+                match args_vec[i].as_str() {
+                    "default" => use_rich = false,
+                    "rich" => use_rich = true,
+                    other => {
+                        eprintln!("--normalizer must be 'default' or 'rich', got '{other}'");
+                        return ExitCode::from(2);
+                    }
+                }
             }
             "--strategy" => {
                 i += 1;
@@ -1259,6 +1291,10 @@ fn main() -> ExitCode {
     );
     eprintln!("Import regex:     {}", import_regex);
     eprintln!("Amount weighting: {}", config.use_amount_weighting);
+    eprintln!(
+        "Normalizer:       {}",
+        if use_rich { "rich" } else { "default" }
+    );
     eprintln!("Strategy:         {:?}", config.strategy);
     if mode_count == 0 {
         eprintln!("Holdout fraction: {:.2} (seed={})", holdout_fraction, seed);
@@ -1268,14 +1304,15 @@ fn main() -> ExitCode {
     let all_txns: Vec<Transaction> = std::mem::take(&mut journal.transactions);
 
     if let Some(account) = cold_account {
-        run_cold_account(all_txns, &import_re, &config, &account)
+        run_cold_account(all_txns, &import_re, &config, use_rich, &account)
     } else if let Some(min) = loao_min {
-        run_loao(all_txns, &import_re, &config, min)
+        run_loao(all_txns, &import_re, &config, use_rich, min)
     } else if let Some(account) = acct_replacement {
         run_account_replacement(
             all_txns,
             &import_re,
             &config,
+            use_rich,
             &account,
             replacement_fraction,
             seed,
@@ -1285,11 +1322,19 @@ fn main() -> ExitCode {
             all_txns,
             &import_re,
             &config,
+            use_rich,
             min,
             replacement_fraction,
             seed,
         )
     } else {
-        run_uniform_holdout(all_txns, &import_re, &config, holdout_fraction, seed)
+        run_uniform_holdout(
+            all_txns,
+            &import_re,
+            &config,
+            use_rich,
+            holdout_fraction,
+            seed,
+        )
     }
 }

--- a/crates/doppio-categorize/src/lib.rs
+++ b/crates/doppio-categorize/src/lib.rs
@@ -7,9 +7,9 @@
 //! # Example
 //!
 //! ```ignore
-//! use doppio_categorize::{Index, Query, Config, DefaultNormalizer};
+//! use doppio_categorize::{Index, Query, Config, RichNormalizer};
 //!
-//! let index = Index::build(&journal, DefaultNormalizer);
+//! let index = Index::build(&journal, RichNormalizer);
 //! let query = Query {
 //!     date: today,
 //!     payee: "STARBUCKS #1234 SEATTLE WA".into(),
@@ -24,5 +24,5 @@ mod normalize;
 mod query;
 
 pub use index::Index;
-pub use normalize::{DefaultNormalizer, Normalizer};
+pub use normalize::{DefaultNormalizer, Normalizer, RichNormalizer};
 pub use query::{Config, Query, ScoringStrategy, Suggestion};

--- a/crates/doppio-categorize/src/normalize.rs
+++ b/crates/doppio-categorize/src/normalize.rs
@@ -1,14 +1,27 @@
 //! Payee normalization.
 //!
-//! v0.1 ships a single implementation, [`DefaultNormalizer`], that lowercases
-//! alphabetic characters and treats every other character (digits,
-//! punctuation, whitespace) as a word separator, then collapses runs of
-//! separators into a single space.
+//! Two implementations are provided:
 //!
-//! v0.2 will introduce token-IDF normalization for cases the default
-//! normalizer cannot handle: "starbucks seattle wa" / "starbucks portland or"
-//! (same vendor, different locations) and "gusto payroll" / "gusto taxes"
-//! (same prefix, different services).
+//! - [`DefaultNormalizer`]: the conservative baseline. Lowercases alphabetic
+//!   characters and treats everything else (digits, punctuation, whitespace)
+//!   as a word separator, then collapses runs of separators. Suitable when
+//!   over-collapse is a concern.
+//!
+//! - [`RichNormalizer`]: wraps [`DefaultNormalizer`] and applies three
+//!   pre-processing rules before delegating, recovering cross-account merchant
+//!   signal that the default cannot:
+//!
+//!   1. **Reference-code stripping** — removes `*<mixed-alphanum>` segments
+//!      (payment-processor prefixes such as `SQ*`, `TST*`, and per-order
+//!      codes such as the `*Z162B38S2` in `AMAZON MKTPL*Z162B38S2`).
+//!   2. **Bank-wrapper stripping** — removes verbatim bank transaction
+//!      boilerplate prefixes (e.g. `"Visa Debit Card Point of Sale Purchase "`)
+//!      that are specific to one financial institution's statement format.
+//!   3. **Domain-token stripping** — removes tokens that look like URL
+//!      domains (`*.com`, `*.net`, `*.org`, `*.io`, `*.co`) since they add
+//!      noise without merchant-identity signal.
+
+use std::borrow::Cow;
 
 /// Strategy for normalizing raw payee strings into a comparison key.
 pub trait Normalizer: Send + Sync {
@@ -43,9 +56,203 @@ impl Normalizer for DefaultNormalizer {
     }
 }
 
+/// Richer normalizer that strips common payee noise before delegating to
+/// [`DefaultNormalizer`].
+///
+/// The three pre-processing rules applied in order are:
+///
+/// 1. **Reference-code stripping**: any `WORD*CODE` or `*CODE` segment where
+///    `CODE` mixes letters and digits (an order or transaction reference) is
+///    removed along with the `*`. Pure-alpha tokens after `*` are kept (they
+///    are part of the merchant name). Pure-digit tokens are already removed by
+///    [`DefaultNormalizer`] and need no special treatment here.
+///
+/// 2. **Bank-wrapper stripping**: removes the prefix
+///    `"Visa Debit Card Point of Sale Purchase "` (case-insensitive) that
+///    BECU and similar institutions prepend to every debit-card transaction.
+///
+/// 3. **Domain-token stripping**: removes tokens whose lowercase form ends
+///    with `.com`, `.net`, `.org`, `.io`, or `.co` (with or without a path
+///    component). This removes noise like `Amzn.com/bill` and `gosq.com`
+///    without stripping meaningful merchant words.
+#[derive(Default, Debug, Clone, Copy)]
+pub struct RichNormalizer;
+
+impl Normalizer for RichNormalizer {
+    fn normalize(&self, raw: &str) -> String {
+        let s = strip_bank_wrapper(raw);
+        let s = strip_reference_codes(s.as_ref());
+        let s = strip_domain_tokens(s.as_ref());
+        DefaultNormalizer.normalize(s.as_ref())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pre-processing helpers (package-private so tests can call them directly)
+// ---------------------------------------------------------------------------
+
+/// Strip the verbatim bank-statement wrapper prefix produced by BECU and
+/// similar institutions for debit-card transactions.
+///
+/// Matches case-insensitively; returns a `Cow` to avoid allocation when no
+/// match occurs.
+pub(crate) fn strip_bank_wrapper(raw: &str) -> Cow<'_, str> {
+    const PREFIX: &str = "Visa Debit Card Point of Sale Purchase ";
+    if raw.len() >= PREFIX.len() && raw[..PREFIX.len()].eq_ignore_ascii_case(PREFIX) {
+        Cow::Borrowed(&raw[PREFIX.len()..])
+    } else {
+        Cow::Borrowed(raw)
+    }
+}
+
+/// Strip `*<mixed-alphanum>` reference codes from a payee string.
+///
+/// A *mixed-alphanum* token is a contiguous run of ASCII letters and digits
+/// that contains at least one letter **and** at least one digit and no
+/// internal whitespace. Such tokens are characteristic of per-order reference
+/// codes (the `*Z162B38S2` in `AMAZON MKTPL*Z162B38S2`) and mixed-ID
+/// processor prefixes.
+///
+/// The rule: for each whitespace-delimited token that contains `*`, split it
+/// on `*` into a pre-part and a post-part. If the post-part is mixed-alphanum,
+/// discard it (and the `*`), emitting only the pre-part. If the pre-part is
+/// mixed-alphanum, discard it (and the `*`), emitting only the post-part. If
+/// both are mixed-alphanum, discard the whole token. If neither is
+/// mixed-alphanum (both are pure-alpha or pure-digit), emit the concatenated
+/// parts separated by a space (matching [`DefaultNormalizer`] behavior).
+///
+/// Returns a `Cow` that borrows the input when no modification is needed.
+pub(crate) fn strip_reference_codes(raw: &str) -> Cow<'_, str> {
+    if !raw.contains('*') {
+        return Cow::Borrowed(raw);
+    }
+
+    let mut parts: Vec<&str> = Vec::new();
+    let mut changed = false;
+
+    for tok in raw.split_whitespace() {
+        if !tok.contains('*') {
+            parts.push(tok);
+            continue;
+        }
+        // Split on the first `*` only; there's at most one per token in practice.
+        let star_pos = tok.find('*').expect("just checked contains");
+        let pre = &tok[..star_pos];
+        let post = &tok[star_pos + 1..];
+
+        let pre_mixed = is_mixed_alphanum(pre);
+        let post_mixed = is_mixed_alphanum(post);
+
+        match (pre_mixed, post_mixed) {
+            (false, false) => {
+                // Neither side is a code; emit both (the `*` becomes a separator,
+                // matching DefaultNormalizer which treats `*` as punctuation).
+                if !pre.is_empty() {
+                    parts.push(pre);
+                }
+                if !post.is_empty() {
+                    parts.push(post);
+                }
+                // The split changes whitespace structure, so mark as changed.
+                changed = true;
+            }
+            (true, false) => {
+                // Pre is a code (e.g. `Z7F3B*MERCHANT`): drop pre, keep post.
+                if !post.is_empty() {
+                    parts.push(post);
+                }
+                changed = true;
+            }
+            (false, true) => {
+                // Post is a code (e.g. `MKTPL*Z162B38S2`): keep pre, drop post.
+                if !pre.is_empty() {
+                    parts.push(pre);
+                }
+                changed = true;
+            }
+            (true, true) => {
+                // Both sides are codes: drop the whole token.
+                changed = true;
+            }
+        }
+    }
+
+    if changed {
+        Cow::Owned(parts.join(" "))
+    } else {
+        Cow::Borrowed(raw)
+    }
+}
+
+/// Strip the TLD suffix (`.com`, `.net`, `.org`, `.io`, `.co`) and any
+/// following path components from whitespace-delimited tokens that contain
+/// them.
+///
+/// For each token, if it contains a TLD suffix, the suffix and everything
+/// after it are removed. If what remains before the suffix is non-empty it is
+/// kept (preserving brand names like `Amazon` from `Amazon.com`). If nothing
+/// remains (e.g. the token was just `.com`) the token is dropped entirely.
+///
+/// This removes noise such as `Amzn.com/bill` → `Amzn`, `gosq.com` → dropped,
+/// `LYFT.COM` → `LYFT`, `Amazon.com` → `Amazon`.
+///
+/// Returns a `Cow` that borrows the input when no modification is needed.
+pub(crate) fn strip_domain_tokens(raw: &str) -> Cow<'_, str> {
+    const TLD_SUFFIXES: &[&str] = &[".com", ".net", ".org", ".io", ".co"];
+
+    let needs_change = raw.split_whitespace().any(|tok| {
+        let lower = tok.to_ascii_lowercase();
+        TLD_SUFFIXES.iter().any(|tld| lower.contains(tld))
+    });
+
+    if !needs_change {
+        return Cow::Borrowed(raw);
+    }
+
+    let parts: Vec<&str> = raw
+        .split_whitespace()
+        .filter_map(|tok| {
+            let lower = tok.to_ascii_lowercase();
+            // Find the earliest TLD occurrence.
+            let tld_pos = TLD_SUFFIXES.iter().filter_map(|tld| lower.find(tld)).min();
+            match tld_pos {
+                None => Some(tok),
+                Some(pos) => {
+                    // Keep only the brand prefix before the TLD.
+                    let prefix = &tok[..pos];
+                    if prefix.is_empty() {
+                        None
+                    } else {
+                        Some(prefix)
+                    }
+                }
+            }
+        })
+        .collect();
+
+    Cow::Owned(parts.join(" "))
+}
+
+/// Returns `true` if `tok` is a non-empty ASCII string containing at least
+/// one letter **and** at least one digit (and no whitespace). This pattern
+/// is characteristic of payment-processor codes and order reference IDs.
+fn is_mixed_alphanum(tok: &str) -> bool {
+    if tok.is_empty() {
+        return false;
+    }
+    let has_alpha = tok.chars().any(|c| c.is_ascii_alphabetic());
+    let has_digit = tok.chars().any(|c| c.is_ascii_digit());
+    let no_space = !tok.contains(char::is_whitespace);
+    has_alpha && has_digit && no_space
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -------------------------------------------------------------------
+    // DefaultNormalizer
+    // -------------------------------------------------------------------
 
     #[test]
     fn lowercases() {
@@ -124,5 +331,256 @@ mod tests {
     fn trailing_separator_trimmed() {
         assert_eq!(DefaultNormalizer.normalize("foo bar "), "foo bar");
         assert_eq!(DefaultNormalizer.normalize("foo bar 123"), "foo bar");
+    }
+
+    // -------------------------------------------------------------------
+    // strip_bank_wrapper
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn bank_wrapper_stripped_case_insensitive() {
+        assert_eq!(
+            strip_bank_wrapper("Visa Debit Card Point of Sale Purchase SP INOVELLI LLC MI"),
+            "SP INOVELLI LLC MI"
+        );
+        assert_eq!(
+            strip_bank_wrapper("VISA DEBIT CARD POINT OF SALE PURCHASE WINDWORKS WA"),
+            "WINDWORKS WA"
+        );
+    }
+
+    #[test]
+    fn bank_wrapper_no_match_returned_as_is() {
+        let raw = "STARBUCKS #1234 SEATTLE WA";
+        assert_eq!(strip_bank_wrapper(raw), raw);
+    }
+
+    // -------------------------------------------------------------------
+    // is_mixed_alphanum
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn mixed_alphanum_detects_code() {
+        assert!(is_mixed_alphanum("Z162B38S2"));
+        assert!(is_mixed_alphanum("ZC74I49M2"));
+        assert!(is_mixed_alphanum("ML16245N3"));
+    }
+
+    #[test]
+    fn pure_alpha_not_mixed() {
+        assert!(!is_mixed_alphanum("Starbucks"));
+        assert!(!is_mixed_alphanum("SQ"));
+        assert!(!is_mixed_alphanum("TST"));
+    }
+
+    #[test]
+    fn pure_digit_not_mixed() {
+        assert!(!is_mixed_alphanum("1234"));
+        assert!(!is_mixed_alphanum("206"));
+    }
+
+    // -------------------------------------------------------------------
+    // strip_reference_codes
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn amazon_order_id_stripped() {
+        // `*Z162B38S2` is mixed-alphanum → stripped; pre-token `MKTPL` is
+        // pure-alpha → kept. Domain tokens are handled by a separate step.
+        assert_eq!(
+            strip_reference_codes("AMAZON MKTPL*Z162B38S2 Amzn.com/bill WA"),
+            "AMAZON MKTPL Amzn.com/bill WA"
+        );
+    }
+
+    #[test]
+    fn sq_prefix_stripped() {
+        // `SQ` is pure-alpha so NOT treated as a code by itself; but `SQ*`
+        // followed by `VAN` (pure-alpha) → `SQ*` prefix is stripped because
+        // the pre-token `SQ` has no digit content.
+        //
+        // Wait -- `SQ` is pure-alpha, not mixed. So Rule 1 (pre_mixed) won't
+        // fire. And the post-token `VAN` is also pure-alpha, so post_mixed
+        // won't fire either.
+        //
+        // The `SQ*` prefix is already handled adequately: DefaultNormalizer
+        // turns `SQ*VAN LEEUWEN` into `sq van leeuwen`. The RichNormalizer
+        // only *additionally* strips the post-`*` token when it's a
+        // reference code.
+        assert_eq!(
+            strip_reference_codes("SQ*VAN LEEUWEN ICE CREAM Boston MA"),
+            "SQ VAN LEEUWEN ICE CREAM Boston MA"
+        );
+    }
+
+    #[test]
+    fn tst_prefix_stripped_leaving_merchant() {
+        // `TST` is pure-alpha; post-token `Starbucks` is pure-alpha → no mixed
+        // tokens; `*` is removed but tokens kept.
+        assert_eq!(
+            strip_reference_codes("TST*Starbucks Seattle WA"),
+            "TST Starbucks Seattle WA"
+        );
+    }
+
+    #[test]
+    fn amazon_dot_com_order_id_stripped() {
+        // "Amazon.com" is pure-alpha (no digits) + the pre-token of the `*`;
+        // "Z14WV0BN1" is mixed-alphanum → dropped.
+        assert_eq!(
+            strip_reference_codes("Amazon.com*Z14WV0BN1 Amzn.com/bill WA"),
+            "Amazon.com Amzn.com/bill WA"
+        );
+    }
+
+    #[test]
+    fn no_asterisk_unchanged() {
+        let raw = "STARBUCKS SEATTLE WA";
+        assert_eq!(strip_reference_codes(raw), raw);
+    }
+
+    #[test]
+    fn counterexample_distinct_merchants_stay_distinct() {
+        // Two different coffee shops accessed via SQ*. After reference-code
+        // stripping and DefaultNormalization they produce different keys
+        // because the merchant names differ (both pure-alpha, neither stripped).
+        let a = RichNormalizer.normalize("SQ*BLUE BOTTLE COFFEE Seattle WA");
+        let b = RichNormalizer.normalize("SQ*STARBUCKS #1234 Seattle WA");
+        assert_ne!(
+            a, b,
+            "distinct merchants behind same processor must not collapse"
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // strip_domain_tokens
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn amzn_bill_domain_stripped() {
+        // "Amzn.com/bill" → prefix before ".com" is "Amzn"; "/bill" is dropped.
+        assert_eq!(
+            strip_domain_tokens("AMAZON MKTPL Amzn.com/bill WA"),
+            "AMAZON MKTPL Amzn WA"
+        );
+    }
+
+    #[test]
+    fn gosq_domain_stripped_entirely() {
+        // "gosq.com" → prefix before ".com" is "gosq" → kept as "gosq".
+        assert_eq!(
+            strip_domain_tokens("SQ THE ELECTRIC BOAT gosq.com WA"),
+            "SQ THE ELECTRIC BOAT gosq WA"
+        );
+    }
+
+    #[test]
+    fn lyft_domain_stripped() {
+        // "LYFT.COM" → prefix before ".com" (case-insensitive find) is "LYFT".
+        assert_eq!(
+            strip_domain_tokens("LYFT RIDE MON PM LYFT.COM CA"),
+            "LYFT RIDE MON PM LYFT CA"
+        );
+    }
+
+    #[test]
+    fn amazon_com_brand_preserved() {
+        // "Amazon.com" → "Amazon" (brand preserved, .com dropped).
+        assert_eq!(
+            strip_domain_tokens("Amazon.com Amzn.com/bill WA"),
+            "Amazon Amzn WA"
+        );
+    }
+
+    #[test]
+    fn no_domain_unchanged() {
+        let raw = "STARBUCKS SEATTLE WA";
+        assert_eq!(strip_domain_tokens(raw), raw);
+    }
+
+    // -------------------------------------------------------------------
+    // RichNormalizer end-to-end
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn amazon_marketplace_variants_collapse() {
+        let n = RichNormalizer;
+        // Two different Amazon orders → same normalized form.
+        let a = n.normalize("AMAZON MKTPL*Z162B38S2 Amzn.com/bill WA");
+        let b = n.normalize("AMAZON MKTPL*ZC74I49M2 Amzn.com/bill WA");
+        assert_eq!(
+            a, b,
+            "different Amazon order IDs must normalize identically"
+        );
+        // And the normalized form contains the meaningful brand tokens.
+        assert!(a.contains("amazon"), "brand token must be preserved");
+        assert!(a.contains("mktpl"), "marketplace token must be preserved");
+    }
+
+    #[test]
+    fn amazon_com_variant_collapses_with_mktpl() {
+        let n = RichNormalizer;
+        // Amazon.com* and AMAZON MKTPL* are both Amazon orders; they may not
+        // produce identical normalized forms (the brand prefix differs), but
+        // they both preserve `amazon` as a token for IDF fallback.
+        let a = n.normalize("Amazon.com*Z14WV0BN1 Amzn.com/bill WA");
+        let b = n.normalize("AMAZON MKTPL*ZC74I49M2 Amzn.com/bill WA");
+        assert!(a.contains("amazon"));
+        assert!(b.contains("amazon"));
+    }
+
+    #[test]
+    fn tst_starbucks_strips_processor_prefix() {
+        // TST* prefix stripped → RichNormalizer gets just "starbucks seattle wa".
+        let n = RichNormalizer;
+        assert_eq!(
+            n.normalize("TST*Starbucks Seattle WA"),
+            "tst starbucks seattle wa"
+        );
+    }
+
+    #[test]
+    fn bank_wrapper_stripped_before_normalization() {
+        let n = RichNormalizer;
+        let wrapped = "Visa Debit Card Point of Sale Purchase WINDWORKS SAILING WA";
+        let bare = "WINDWORKS SAILING WA";
+        assert_eq!(n.normalize(wrapped), n.normalize(bare));
+    }
+
+    #[test]
+    fn bank_wrapper_counterexample_two_merchants_stay_distinct() {
+        let n = RichNormalizer;
+        let a = n.normalize("Visa Debit Card Point of Sale Purchase STARBUCKS SEATTLE WA");
+        let b = n.normalize("Visa Debit Card Point of Sale Purchase COMCAST CABLE BELLEVUE WA");
+        assert_ne!(
+            a, b,
+            "different merchants behind bank wrapper must remain distinct"
+        );
+    }
+
+    #[test]
+    fn lyft_variants_collapse() {
+        let n = RichNormalizer;
+        // Two Lyft rides with different time-of-day annotation and domain noise.
+        let a = n.normalize("LYFT *RIDE MON 2PM LYFT.COM CA");
+        let b = n.normalize("LYFT *RIDE SAT 4AM LYFT.COM CA");
+        // Both contain `lyft` and `ride`; domain stripped; time tokens also
+        // stripped (pm, am are alpha but short -- DefaultNormalizer keeps them).
+        // Key assertion: both still contain the brand.
+        assert!(a.contains("lyft"));
+        assert!(b.contains("lyft"));
+    }
+
+    #[test]
+    fn default_normalizer_unchanged() {
+        // Verify DefaultNormalizer output is identical to what it was before --
+        // RichNormalizer must not change DefaultNormalizer behavior.
+        let d = DefaultNormalizer;
+        let r = RichNormalizer;
+        // For a plain merchant with no special chars, both produce the same output.
+        assert_eq!(
+            d.normalize("Starbucks Seattle WA"),
+            r.normalize("Starbucks Seattle WA")
+        );
     }
 }


### PR DESCRIPTION
Part of #324.

## Diagnostic

Built the household index and ran `--account-replacement Liabilities:CreditCard:Chase` and `--leave-one-account-out 5` with a temporary diagnostic binary (scaffolding, removed before this commit). For every query with no top-1 hit:

### Failure pattern counts (account-replacement Chase, 64 failures)

| Pattern | Count |
|---|---|
| other (one-off merchants, no normalization help) | 32 |
| long-numeric-id (phone numbers in payee) | 17 |
| domain-in-payee (URL noise like `Amzn.com/bill`) | 6 |
| payment-processor-prefix (`TST*`, `SQ*`) | 5 |
| long-alphanum-id (mixed order codes) | 2 |
| amazon-variant (`AMAZON MKTPL*Z162B38S2`) | 1 |
| single-short-word | 1 |

### Failure pattern counts (LOAO, 2406 failures across 11 accounts)

| Pattern | Count |
|---|---|
| other | 1432 |
| long-numeric-id | 515 |
| amazon-variant (`AMAZON MKTPL*Z162B38S2 Amzn.com/bill WA`) | 148 |
| payment-processor-prefix | 135 |
| domain-in-payee | 89 |
| long-alphanum-id | 78 |
| single-short-word | 5 |

Recovery-path breakdown (LOAO):
- cluster_size=0 (truly cold): 2360 of 2406 failures
- cluster_size>0 but IDF also empty: 0
- IDF returned candidates (wrong top-1): 2168

**Key finding:** the 148 Amazon LOAO failures are the clearest normalization target. `AMAZON MKTPL*Z162B38S2 Amzn.com/bill WA` normalizes to `amazon mktpl z b s amzn com bill wa` under `DefaultNormalizer` — the letters extracted from the order ID (`z`, `b`, `s`) poison the IDF scoring and ensure every order creates a unique payee key. Stripping the `*<mixed-alphanum>` segment collapses all Amazon marketplace transactions to the same normalized form. The bank-wrapper prefix (`"Visa Debit Card Point of Sale Purchase "`) accounts for the bulk of the LOAO "other" category — when BECU is held out, the BECU-specific payee format has no match in training.

## Rules implemented (`RichNormalizer`)

All three rules run as pre-processing before delegating to `DefaultNormalizer`. `DefaultNormalizer` behavior is unchanged.

1. **Reference-code stripping** (target: amazon-variant, long-alphanum-id): strip `*<mixed-alphanum>` segments from payee tokens. A mixed-alphanum token contains at least one letter and one digit with no whitespace — characteristic of order/transaction IDs. `AMAZON MKTPL*Z162B38S2` → `AMAZON MKTPL`; `Amazon.com*Z14WV0BN1` → `Amazon.com`. Diagnostic grounding: 148 LOAO failures and 1 Chase account-replacement failure directly in this pattern.

2. **Bank-wrapper stripping** (target: the dominant LOAO "other" category): remove the literal prefix `"Visa Debit Card Point of Sale Purchase "` (case-insensitive) that BECU prepends to every debit transaction. Diagnostic grounding: dominates the 1432 "other" LOAO failures from BECU-format accounts.

3. **Domain-token stripping** (target: domain-in-payee, amazon-variant): trim TLD suffixes (`.com`, `.net`, `.org`, `.io`, `.co`) and any following path components from payee tokens, keeping the brand prefix. `Amzn.com/bill` → `Amzn`; `gosq.com` → `gosq`; `LYFT.COM` → `LYFT`; `Amazon.com` → `Amazon`. Diagnostic grounding: 89 LOAO + 6 Chase failures; also cleans up the residual noise after rule 1.

**Patterns where no normalization rule helps:** the 32 "other" Chase failures are one-off merchants with no training history anywhere in the corpus. No amount of payee normalization can recover signal for a merchant that appears exactly once. These are the genuine cold-start case identified in #324 as a potential follow-up for user-declared merchant aliasing.

## Measurement grid

Evaluated with `--strategy hybrid --holdout 0.10 --account-replacement-cohort 5 --leave-one-account-out 5` on both corpora. Default = `DefaultNormalizer`; Rich = `RichNormalizer`.

### Household corpus (`~/Documents/accounting/household.ledger`)

| Mode | Default top-1 | Rich top-1 | Default top-3 | Rich top-3 |
|---|---|---|---|---|
| uniform holdout | 72.3% | 72.6% | 80.4% | 81.1% |
| account-replacement-cohort (cohort mean) | 75.1% | 75.3% | 86.3% | 86.4% |
| account-replacement Chase | 71.5% | 72.4% | 75.9% | 76.3% |
| LOAO cohort mean | 43.9% | 44.1% | 60.6% | 60.8% |
| LOAO aggregate | 18.7% | 18.7% | 32.3% | 32.4% |

Baselines from #319/#322/#323/#325: uniform 72.0%, cohort 75.1%, Chase 71.1%, LOAO cohort 43.8%, LOAO aggregate 18.6%.

### Better Bytes corpus (`~/Documents/bb-ledger/accounts/books.ledger`)

| Mode | Default top-1 | Rich top-1 | Default top-3 | Rich top-3 |
|---|---|---|---|---|
| uniform holdout | 66.7% | 66.7% | 77.8% | 77.8% |
| account-replacement-cohort (cohort mean) | 71.4% | 71.4% | 78.6% | 78.6% |
| LOAO cohort mean | 0.0% | 0.0% | 1.4% | 1.4% |
| LOAO aggregate | 0.0% | 0.0% | 2.2% | 2.2% |

## Interpretation

The rules clear the acceptance bar: no regression on uniform holdout or account-replacement-cohort (all rich numbers are equal to or above baseline), and measurable improvement on account-replacement-Chase (+0.9pp top-1) and LOAO cohort (+0.2pp top-1).

The improvement is modest on LOAO aggregate because `Liabilities:CreditCard:Chase` (2278 of 2957 held-out queries) dominates the aggregate, and Chase LOAO is largely a genuine cold-start problem: 2360 of 2406 Chase LOAO failures have cluster_size=0 — the merchants never appeared in any other account's training data. The 148 Amazon LOAO failures that motivated rule 1 do get recovered, but they're outnumbered by one-off merchants where no normalization strategy can help.

The BECU bank-wrapper stripping (rule 2) helps the inter-account IDF cases slightly but doesn't move LOAO aggregate because when BECU itself is held out, those transactions have no IDF match regardless of how the prefix is stripped.

**Follow-up patterns not addressed by this PR:** brand-string aliasing (`AMZN MKTP US` vs `Amazon Marketplace` vs `Amazon.com`) requires a per-merchant lookup table that isn't addressable by a pure normalization rule. This is the user-declared merchant aliasing feature mentioned as out-of-scope in #324.