### PR TITLE
[doppio] add HirBuilder for external HIR construction

### DIFF
--- a/crates/doppio/src/resolution.rs
+++ b/crates/doppio/src/resolution.rs
@@ -1019,6 +1019,92 @@ impl HIR {
     }
 }
 
+/// Build an [`HIR`] from externally-constructed transactions and prices.
+///
+/// [`HIR`] is the canonical input to [`crate::frontend::Frontend::write_journal`].
+/// Its internal shape (per-entry `context_id` indices, alias/commodity context
+/// table) is a resolution-stage artifact that downstream writers don't consume
+/// but that external callers can't populate sensibly. `HirBuilder` hides those
+/// internals and exposes a small, typed surface for the use case of "I have
+/// transactions in memory; serialise them as ledger / hledger / beancount source
+/// text."
+///
+/// HIRs built with `HirBuilder` are intended for the write path only. Passing
+/// a builder-produced HIR to [`crate::elaborate`] may panic because the
+/// contexts table is empty and the elaborator dereferences it by index.
+///
+/// `push_assertion` and `push_pad` are not currently provided; open an issue if
+/// your use case requires them.
+///
+/// # Example
+///
+/// ```rust
+/// use doppio::resolution::{HirBuilder, Transaction, Posting};
+/// use doppio::frontend::Frontend as _;
+/// use doppio::LedgerFrontend;
+/// use chrono::NaiveDate;
+/// use rust_decimal::Decimal;
+///
+/// let txn = Transaction::new(
+///     NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+///     "Groceries",
+/// )
+/// .with_posting(
+///     Posting::new("Expenses:Food").with_amount((Decimal::from(50u32), "USD")),
+/// )
+/// .with_posting(Posting::new("Assets:Checking"));
+///
+/// let hir = HirBuilder::new().push_transaction(txn).build();
+///
+/// let mut out = Vec::new();
+/// LedgerFrontend.write_journal(&hir, &mut out).unwrap();
+/// let text = String::from_utf8(out).unwrap();
+/// assert!(text.contains("Groceries"));
+/// ```
+#[derive(Debug, Default)]
+pub struct HirBuilder {
+    entries: Vec<ResolutionEntry>,
+    prices: Vec<HistoricalPrice>,
+}
+
+impl HirBuilder {
+    /// Creates a new, empty builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Appends a transaction to the builder (builder pattern).
+    pub fn push_transaction(mut self, txn: Transaction) -> Self {
+        self.entries.push(ResolutionEntry {
+            context_id: 0,
+            data: Entry::Transaction(txn),
+        });
+        self
+    }
+
+    /// Appends a historical price directive to the builder (builder pattern).
+    pub fn push_price(mut self, price: HistoricalPrice) -> Self {
+        self.prices.push(price);
+        self
+    }
+
+    /// Consumes the builder and returns a finished [`HIR`].
+    ///
+    /// The returned HIR has an empty contexts table (sufficient for the write
+    /// path) and no auto-rules.
+    pub fn build(self) -> HIR {
+        HIR {
+            entries: self.entries,
+            prices: self.prices,
+            // One empty context so context_id 0 is always a valid index,
+            // matching the invariant maintained by HIR::default().
+            contexts: vec![Context::default()],
+            global_context: GlobalContext::default(),
+            auto_rules: vec![],
+        }
+    }
+}
+
 impl TryFrom<ast::Journal> for HIR {
     type Error = ResolutionError;
 

--- a/crates/doppio/tests/hir_builder.rs
+++ b/crates/doppio/tests/hir_builder.rs
@@ -56,9 +56,7 @@ fn hir_builder_writes_through_all_frontends() {
     // beancount parser, which requires commodities to start with an uppercase
     // letter (symbols like "$" are not valid beancount commodities).
     let txn = Transaction::new(date(2024, 3, 10), "Market Run")
-        .with_posting(
-            Posting::new("Expenses:Groceries").with_amount((Decimal::from(75u32), "USD")),
-        )
+        .with_posting(Posting::new("Expenses:Groceries").with_amount((Decimal::from(75u32), "USD")))
         .with_posting(Posting::new("Assets:Checking"));
 
     let hir = HirBuilder::new().push_transaction(txn).build();
@@ -134,12 +132,8 @@ fn hir_builder_writes_through_all_frontends() {
 fn hir_builder_handles_prices() {
     // Use "USD" as the cash commodity so the output is valid beancount syntax.
     let txn = Transaction::new(date(2024, 6, 1), "Stock Purchase")
-        .with_posting(
-            Posting::new("Assets:Brokerage").with_amount((Decimal::from(10u32), "AAPL")),
-        )
-        .with_posting(
-            Posting::new("Assets:Cash").with_amount((Decimal::from(-1750i32), "USD")),
-        );
+        .with_posting(Posting::new("Assets:Brokerage").with_amount((Decimal::from(10u32), "AAPL")))
+        .with_posting(Posting::new("Assets:Cash").with_amount((Decimal::from(-1750i32), "USD")));
 
     let price = HistoricalPrice {
         date: date(2024, 6, 1),

--- a/crates/doppio/tests/hir_builder.rs
+++ b/crates/doppio/tests/hir_builder.rs
@@ -1,0 +1,214 @@
+//! Integration tests for [`doppio::resolution::HirBuilder`].
+//!
+//! These tests exercise only the public API, mirroring the experience of an
+//! external caller constructing and serialising transactions without access to
+//! crate-private types.
+
+use chrono::NaiveDate;
+use doppio::frontend::Frontend as _;
+use doppio::resolution::{HirBuilder, HistoricalPrice, Posting, Transaction};
+use doppio::{BeancountFrontend, HledgerFrontend, LedgerFrontend};
+use rust_decimal::Decimal;
+use std::path::Path;
+
+fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+    NaiveDate::from_ymd_opt(y, m, d).unwrap()
+}
+
+fn no_op_opener(_: &str) -> Result<String, Box<dyn std::error::Error>> {
+    Ok(String::new())
+}
+
+fn write_ledger(hir: &doppio::resolution::HIR) -> String {
+    let mut buf = Vec::new();
+    LedgerFrontend
+        .write_journal(hir, &mut buf)
+        .expect("ledger write failed");
+    String::from_utf8(buf).expect("ledger output is not UTF-8")
+}
+
+fn write_hledger(hir: &doppio::resolution::HIR) -> String {
+    let mut buf = Vec::new();
+    HledgerFrontend
+        .write_journal(hir, &mut buf)
+        .expect("hledger write failed");
+    String::from_utf8(buf).expect("hledger output is not UTF-8")
+}
+
+fn write_beancount(hir: &doppio::resolution::HIR) -> String {
+    let mut buf = Vec::new();
+    BeancountFrontend
+        .write_journal(hir, &mut buf)
+        .expect("beancount write failed");
+    String::from_utf8(buf).expect("beancount output is not UTF-8")
+}
+
+/// Build a simple 2-posting transaction via [`HirBuilder`], write it through all
+/// three frontends, and verify that each frontend's output:
+///
+/// - is non-empty,
+/// - contains the payee string,
+/// - contains both account names, and
+/// - round-trips through the same frontend's parser without error.
+#[test]
+fn hir_builder_writes_through_all_frontends() {
+    // Use "USD" as the commodity so the output round-trips through the
+    // beancount parser, which requires commodities to start with an uppercase
+    // letter (symbols like "$" are not valid beancount commodities).
+    let txn = Transaction::new(date(2024, 3, 10), "Market Run")
+        .with_posting(
+            Posting::new("Expenses:Groceries").with_amount((Decimal::from(75u32), "USD")),
+        )
+        .with_posting(Posting::new("Assets:Checking"));
+
+    let hir = HirBuilder::new().push_transaction(txn).build();
+
+    // --- Ledger ---
+    let ledger_out = write_ledger(&hir);
+    assert!(!ledger_out.is_empty(), "ledger output should be non-empty");
+    assert!(
+        ledger_out.contains("Market Run"),
+        "ledger output should contain the payee"
+    );
+    assert!(
+        ledger_out.contains("Expenses:Groceries"),
+        "ledger output should contain Expenses:Groceries"
+    );
+    assert!(
+        ledger_out.contains("Assets:Checking"),
+        "ledger output should contain Assets:Checking"
+    );
+    // Round-trip: output must parse back without error.
+    LedgerFrontend
+        .parse(&ledger_out, Path::new(""), &no_op_opener)
+        .expect("ledger round-trip parse failed");
+
+    // --- hledger ---
+    let hledger_out = write_hledger(&hir);
+    assert!(
+        !hledger_out.is_empty(),
+        "hledger output should be non-empty"
+    );
+    assert!(
+        hledger_out.contains("Market Run"),
+        "hledger output should contain the payee"
+    );
+    assert!(
+        hledger_out.contains("Expenses:Groceries"),
+        "hledger output should contain Expenses:Groceries"
+    );
+    assert!(
+        hledger_out.contains("Assets:Checking"),
+        "hledger output should contain Assets:Checking"
+    );
+    HledgerFrontend
+        .parse(&hledger_out, Path::new(""), &no_op_opener)
+        .expect("hledger round-trip parse failed");
+
+    // --- Beancount ---
+    let beancount_out = write_beancount(&hir);
+    assert!(
+        !beancount_out.is_empty(),
+        "beancount output should be non-empty"
+    );
+    assert!(
+        beancount_out.contains("Market Run"),
+        "beancount output should contain the payee"
+    );
+    assert!(
+        beancount_out.contains("Expenses:Groceries"),
+        "beancount output should contain Expenses:Groceries"
+    );
+    assert!(
+        beancount_out.contains("Assets:Checking"),
+        "beancount output should contain Assets:Checking"
+    );
+    BeancountFrontend
+        .parse(&beancount_out, Path::new(""), &no_op_opener)
+        .expect("beancount round-trip parse failed");
+}
+
+/// Build an HIR containing a transaction and a [`HistoricalPrice`] directive,
+/// then verify that all three frontends emit both the price and the transaction.
+#[test]
+fn hir_builder_handles_prices() {
+    // Use "USD" as the cash commodity so the output is valid beancount syntax.
+    let txn = Transaction::new(date(2024, 6, 1), "Stock Purchase")
+        .with_posting(
+            Posting::new("Assets:Brokerage").with_amount((Decimal::from(10u32), "AAPL")),
+        )
+        .with_posting(
+            Posting::new("Assets:Cash").with_amount((Decimal::from(-1750i32), "USD")),
+        );
+
+    let price = HistoricalPrice {
+        date: date(2024, 6, 1),
+        time: None,
+        commodity: "AAPL".to_string(),
+        price: doppio::ast::ValueExpr::Amount {
+            value: Decimal::from(175u32),
+            commodity: Some("USD".to_string()),
+        },
+    };
+
+    let hir = HirBuilder::new()
+        .push_transaction(txn)
+        .push_price(price)
+        .build();
+
+    // --- Ledger ---
+    let ledger_out = write_ledger(&hir);
+    assert!(
+        ledger_out.contains("Stock Purchase"),
+        "ledger output should contain the payee"
+    );
+    // Ledger and hledger price directives start with "P".
+    assert!(
+        ledger_out.contains('P'),
+        "ledger output should contain a P price directive"
+    );
+    assert!(
+        ledger_out.contains("AAPL"),
+        "ledger output should contain the commodity name"
+    );
+    LedgerFrontend
+        .parse(&ledger_out, Path::new(""), &no_op_opener)
+        .expect("ledger round-trip parse failed for price + transaction");
+
+    // --- hledger ---
+    let hledger_out = write_hledger(&hir);
+    assert!(
+        hledger_out.contains("Stock Purchase"),
+        "hledger output should contain the payee"
+    );
+    assert!(
+        hledger_out.contains('P'),
+        "hledger output should contain a P price directive"
+    );
+    assert!(
+        hledger_out.contains("AAPL"),
+        "hledger output should contain the commodity name"
+    );
+    HledgerFrontend
+        .parse(&hledger_out, Path::new(""), &no_op_opener)
+        .expect("hledger round-trip parse failed for price + transaction");
+
+    // --- Beancount ---
+    let beancount_out = write_beancount(&hir);
+    assert!(
+        beancount_out.contains("Stock Purchase"),
+        "beancount output should contain the payee"
+    );
+    // Beancount uses the "price" keyword.
+    assert!(
+        beancount_out.contains("price"),
+        "beancount output should contain a 'price' directive"
+    );
+    assert!(
+        beancount_out.contains("AAPL"),
+        "beancount output should contain the commodity name"
+    );
+    BeancountFrontend
+        .parse(&beancount_out, Path::new(""), &no_op_opener)
+        .expect("beancount round-trip parse failed for price + transaction");
+}


### PR DESCRIPTION
## Summary

Closes #328.

External crates cannot construct an `HIR` to pass to `Frontend::write_journal` because `HIR.entries` is `pub(crate)` and `ResolutionEntry` / `Entry` are also `pub(crate)`. This blocks the documented use case of building synthetic transactions and serialising them.

### Design note

Three options were considered:

1. **Flip `pub(crate)` → `pub`** on `HIR.entries` and the entry types. Rejected: forces external callers to understand `context_id` (a resolution-stage artifact that's meaningless to them) and locks in the `ResolutionEntry` shape as a public API.

2. **`HirBuilder`** (this PR): a builder that accepts `Transaction` and `HistoricalPrice` values and produces a write-ready `HIR`, with `context_id: 0` on every entry and an empty-but-valid contexts table. Writers iterate `entries` and `prices` only — they never dereference `contexts` — so the empty table is safe for the write path.

3. **`Frontend::write_transactions` shortcut** that bypasses HIR entirely. Rejected: duplication of formatting logic, and doesn't cover the read+modify+write flow.

### Public API delta

```rust
// crates/doppio/src/resolution.rs
pub struct HirBuilder { /* private */ }

impl HirBuilder {
    pub fn new() -> Self;
    pub fn push_transaction(self, txn: Transaction) -> Self;
    pub fn push_price(self, price: HistoricalPrice) -> Self;
    pub fn build(self) -> HIR;
}

impl Default for HirBuilder { ... }
```

`HirBuilder` is accessible at `doppio::resolution::HirBuilder` (the `resolution` module is already `pub`).

### Round-trip tests

`crates/doppio/tests/hir_builder.rs` adds two integration tests that exercise only the public API:

- **`hir_builder_writes_through_all_frontends`**: constructs a 2-posting transaction, builds the HIR, writes through `LedgerFrontend`, `HledgerFrontend`, and `BeancountFrontend`, and re-parses each output through the same frontend — confirming the written text is valid in all three formats.
- **`hir_builder_handles_prices`**: same pattern with a `HistoricalPrice` pushed alongside the transaction; asserts that each frontend emits the expected price directive (`P` for ledger/hledger, `price` for beancount).

### Out of scope

- `push_assertion` / `push_pad`: not needed for the named use case. A comment in the builder docs notes they could be added if a consumer asks.
- Elaboration compatibility: `HirBuilder`-produced HIRs are intentionally write-path-only. The doc warns that passing them to `elaborate()` may panic on the empty contexts table.

## Test plan

- [x] `cargo fmt --workspace` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test -p doppio` — 431 tests pass (429 existing + 2 new)
- [x] `cargo test --doc -p doppio` — doc-example runs and passes