### PR TITLE
[doppio] HIR::append_entry for external journal construction

### DIFF
--- a/crates/doppio/src/resolution.rs
+++ b/crates/doppio/src/resolution.rs
@@ -91,6 +91,67 @@ impl Default for HIR {
     }
 }
 
+impl HIR {
+    /// Construct an empty `HIR`. Alias for [`HIR::default()`] with a clearer
+    /// name for the "build a journal from scratch" use case.
+    ///
+    /// The returned `HIR` has one default [`Context`] in `contexts` so that
+    /// [`HIR::append_entry`] always associates new entries with a valid
+    /// context index.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append an [`Entry`] to the journal.
+    ///
+    /// The entry is recorded against the most-recently-added [`Context`] in
+    /// `self.contexts` (i.e. `contexts.len() - 1`). An `HIR` built via
+    /// [`HIR::new()`] or [`HIR::default()`] always starts with one context,
+    /// so callers constructing journals externally don't need to populate
+    /// `contexts` themselves.
+    ///
+    /// # Invariant
+    ///
+    /// Every entry's `context_id` must be a valid index into
+    /// [`HIR::contexts`]. `append_entry` maintains this invariant. The only
+    /// way to violate it is to mutate `contexts` (e.g. `truncate` it below
+    /// the index of an existing entry's `context_id`); avoid doing so on an
+    /// `HIR` you plan to pass to [`crate::elaborate`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use chrono::NaiveDate;
+    /// use rust_decimal::Decimal;
+    /// use doppio::resolution::{Entry, HIR, Posting, Transaction};
+    /// use doppio::{LedgerFrontend, Frontend};
+    ///
+    /// let mut hir = HIR::new();
+    /// for (account, amount) in [
+    ///     ("Expenses:Groceries", Decimal::from(75u32)),
+    ///     ("Assets:Checking", Decimal::from(-75i32)),
+    /// ] {
+    ///     // Imagine `txn` built per-row from a CSV import; here just one txn.
+    ///     # let _ = (account, amount);
+    /// }
+    /// let txn = Transaction::new(NaiveDate::from_ymd_opt(2024, 3, 10).unwrap(), "Market Run")
+    ///     .with_posting(Posting::new("Expenses:Groceries").with_amount((Decimal::from(75u32), "USD")))
+    ///     .with_posting(Posting::new("Assets:Checking"));
+    /// hir.append_entry(Entry::Transaction(txn));
+    ///
+    /// let mut out = Vec::new();
+    /// doppio::write_journal(&LedgerFrontend, &hir, &mut out).unwrap();
+    /// assert!(String::from_utf8(out).unwrap().contains("Market Run"));
+    /// ```
+    pub fn append_entry(&mut self, entry: Entry) {
+        let context_id = self.contexts.len() - 1;
+        self.entries.push(ResolutionEntry {
+            context_id,
+            data: entry,
+        });
+    }
+}
+
 /// A body posting within a resolved automated posting rule.
 ///
 /// `amount` is `None` when the source posting was a null posting (no amount
@@ -617,7 +678,7 @@ pub(crate) struct ResolutionEntry {
 
 /// A resolved journal entry.
 #[derive(Debug)]
-pub(crate) enum Entry {
+pub enum Entry {
     /// A double-entry transaction with resolved dates and extracted metadata.
     Transaction(Transaction),
     /// A standalone balance assertion directive.
@@ -636,7 +697,7 @@ pub(crate) enum Entry {
 /// (back-dated to `date`) that posts the difference between
 /// `target_account` and `source_account`."
 #[derive(Debug)]
-pub(crate) struct PadDirective {
+pub struct PadDirective {
     /// The date the pad applies on.
     pub date: chrono::NaiveDate,
     /// The account whose balance will be brought to the next assertion.
@@ -651,7 +712,7 @@ pub(crate) struct PadDirective {
 /// in the HIR for use by the elaboration stage; enforcement is a follow-up
 /// (tracked in issue #37).
 #[derive(Debug)]
-pub(crate) struct AssertionDirective {
+pub struct AssertionDirective {
     /// The date at which the balance assertion applies.
     pub date: chrono::NaiveDate,
     /// The account whose balance is being asserted.

--- a/crates/doppio/tests/hir_external_construction.rs
+++ b/crates/doppio/tests/hir_external_construction.rs
@@ -1,0 +1,115 @@
+//! External-construction round-trip tests for `resolution::HIR`.
+//!
+//! Verifies that callers outside the `doppio` crate can build an `HIR` from
+//! scratch (via `HIR::new()` + `HIR::append_entry`), serialise it through
+//! each frontend, and re-parse the result without error.
+//!
+//! These tests exercise only the public API, mirroring the external-caller
+//! experience: the import-and-emit use case for tools like bookie.
+
+use std::path::Path;
+
+use chrono::NaiveDate;
+use rust_decimal::Decimal;
+
+use doppio::resolution::{Entry, HIR, HistoricalPrice, Posting, Transaction};
+use doppio::{BeancountFrontend, Frontend, HledgerFrontend, LedgerFrontend};
+
+fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+    NaiveDate::from_ymd_opt(y, m, d).expect("valid date")
+}
+
+fn no_opener() -> Box<doppio::frontend::Opener> {
+    Box::new(|_| Ok(String::new()))
+}
+
+fn render<F: Frontend>(frontend: &F, hir: &HIR) -> String {
+    let mut buf = Vec::new();
+    doppio::write_journal(frontend, hir, &mut buf).expect("write_journal succeeds");
+    String::from_utf8(buf).expect("output is valid UTF-8")
+}
+
+fn roundtrip<F: Frontend>(frontend: &F, text: &str) -> HIR {
+    let opener = no_opener();
+    frontend
+        .parse(text, Path::new(""), &opener)
+        .unwrap_or_else(|e| panic!("re-parse failed: {e}"))
+}
+
+#[test]
+fn append_entry_writes_through_all_frontends() {
+    // "USD" rather than "$" because beancount commodities must start with an
+    // uppercase ASCII letter -- $ is not a valid beancount commodity.
+    let txn = Transaction::new(date(2024, 3, 10), "Market Run")
+        .with_posting(Posting::new("Expenses:Groceries").with_amount((Decimal::from(75u32), "USD")))
+        .with_posting(Posting::new("Assets:Checking"));
+
+    let mut hir = HIR::new();
+    hir.append_entry(Entry::Transaction(txn));
+
+    for (name, text) in [
+        ("ledger", render(&LedgerFrontend, &hir)),
+        ("hledger", render(&HledgerFrontend, &hir)),
+        ("beancount", render(&BeancountFrontend, &hir)),
+    ] {
+        assert!(
+            !text.trim().is_empty(),
+            "[{name}] output should be non-empty"
+        );
+        assert!(
+            text.contains("Market Run"),
+            "[{name}] output should contain the description; got:\n{text}"
+        );
+        assert!(
+            text.contains("Expenses:Groceries"),
+            "[{name}] output should contain the first account; got:\n{text}"
+        );
+        assert!(
+            text.contains("Assets:Checking"),
+            "[{name}] output should contain the second account; got:\n{text}"
+        );
+    }
+
+    // Round-trip: each frontend should re-parse its own output to exactly
+    // one transaction. `transactions()` consumes the HIR; clone-by-render-and-parse
+    // means each assertion gets a fresh parsed HIR.
+    let parsed = roundtrip(&LedgerFrontend, &render(&LedgerFrontend, &hir));
+    assert_eq!(parsed.transactions().count(), 1, "ledger round-trip");
+    let parsed = roundtrip(&HledgerFrontend, &render(&HledgerFrontend, &hir));
+    assert_eq!(parsed.transactions().count(), 1, "hledger round-trip");
+    let parsed = roundtrip(&BeancountFrontend, &render(&BeancountFrontend, &hir));
+    assert_eq!(parsed.transactions().count(), 1, "beancount round-trip");
+}
+
+#[test]
+fn append_entry_with_prices() {
+    let txn = Transaction::new(date(2024, 6, 1), "Stock Purchase")
+        .with_posting(Posting::new("Assets:Brokerage").with_amount((Decimal::from(10u32), "AAPL")))
+        .with_posting(Posting::new("Assets:Cash").with_amount((Decimal::from(-1750i32), "USD")));
+
+    let price = HistoricalPrice {
+        date: date(2024, 6, 1),
+        time: None,
+        commodity: "AAPL".to_string(),
+        price: (Decimal::from(175u32), "USD").into(),
+    };
+
+    let mut hir = HIR::new();
+    hir.prices.push(price);
+    hir.append_entry(Entry::Transaction(txn));
+
+    for (name, text) in [
+        ("ledger", render(&LedgerFrontend, &hir)),
+        ("hledger", render(&HledgerFrontend, &hir)),
+        ("beancount", render(&BeancountFrontend, &hir)),
+    ] {
+        assert!(
+            text.contains("Stock Purchase"),
+            "[{name}] should contain transaction description; got:\n{text}"
+        );
+        assert!(
+            text.contains("AAPL") && text.contains("175"),
+            "[{name}] should contain the price directive; got:\n{text}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #328. Supersedes #330 (closed in favor of this simpler shape).

## Design

`HIR` gains two methods that let callers outside `doppio` build a journal from scratch and pass it to `Frontend::write_journal`:

```rust
impl HIR {
    pub fn new() -> Self;                          // alias for default()
    pub fn append_entry(&mut self, entry: Entry);  // pushes with current context_id
}
```

Plus visibility flips: `Entry`, `AssertionDirective`, `PadDirective` are now `pub`. `ResolutionEntry` stays private — `append_entry` handles the `context_id` plumbing so external callers never have to know about it.

## Why this shape over a builder

The realistic consumer pattern is imperative — a downstream tool like `bookie` reads from external sources (CSV imports, bank API, etc.) and iterates appending each row as a transaction. `&mut self` fits that flow; a chain-style builder would require collecting rows up-front.

Discussed at length in #330's review thread; the builder approach was rejected as adding API surface for limited benefit.

## The one invariant

Every entry's `context_id` must be a valid index into `HIR::contexts` — the elaborator dereferences it on every entry. `HIR::new()`/`default()` populates `contexts` with one default `Context`, and `append_entry` always sets `context_id = contexts.len() - 1`, so the invariant is maintained automatically. Documented in the method's doc-comment.

## Tests

- `crates/doppio/tests/hir_external_construction.rs` exercises the public API end-to-end:
  - **`append_entry_writes_through_all_frontends`** — builds a 2-posting transaction, appends it, writes through each of `LedgerFrontend` / `HledgerFrontend` / `BeancountFrontend`, and re-parses each output (round-trip check that the emitted text is valid in the target format).
  - **`append_entry_with_prices`** — same shape with a `HistoricalPrice` pushed alongside; verifies the price directive appears in all three frontend outputs.
- Doc-example on `HIR::append_entry` runs as a doctest.

## Local gates

- `cargo fmt --all` — clean
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo test -p doppio` — 429 unit + 76 integration tests pass (including the 2 new ones)