### PR TITLE
chore(release): v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-06-04
+
+### Added
+
+- **`HIR::append_entry` and `HIR::new` for external journal construction** (#333,
+  closes #328). `resolution::HIR` now exposes `new()` and `append_entry(Entry)`
+  on its public surface, and the `Entry`, `AssertionDirective`, and
+  `PadDirective` types are public. Downstream consumers can now construct an
+  `HIR` programmatically and feed it to `Frontend::write_journal` to emit
+  source text in any of the three frontend formats. The `ResolutionEntry`
+  wrapper stays private — `append_entry` handles the `context_id` plumbing so
+  external callers never touch it.
+
+### CLI
+
+- **`dop balance` and `dop register`: positional pattern accepts multiple
+  values** (#331). The positional `PATTERN` argument is now `PATTERNS...`; an
+  account matches if it satisfies **any** of the supplied case-insensitive
+  regex patterns. Existing single-pattern invocations (`dop balance file.ledger
+  Expenses`) continue to work unchanged. Omitting all patterns continues to
+  match every account.
+
+### Web / wasm
+
+- **`doppio-wasm` `compile(source, frontend, config?)`** accepts an optional
+  third config dict with two keys (#315, refs #311):
+  - `opener: (path: string) => string | null` — synchronous JS callback
+    invoked for each `include` directive. Throwing surfaces as a parse error;
+    returning `null`/`undefined` means "not found".
+  - `basePath: string` — directory the parser treats as the entry file's
+    base when joining relative include paths.
+  The two-argument call shape is unchanged. The transitional `compile_multi`
+  export from the interim PR #315 is folded into this unified API.
+- **`web/dop` extracted as a standalone npm-publishable package** (#329,
+  closes #327). The browser-side `.dop` reader (TypeScript) moves out of
+  `web/dashboard/src/lib/dop/` into its own `web/dop/` workspace package
+  (`doppio-dop`); the dashboard becomes a consumer via npm workspace. Proto
+  generation is owned by `doppio-dop`.
+- **Web dashboard: canonical-commodity selector** (#314, closes #312). New
+  "Display as" dropdown in the FilterBar converts all KPI / chart aggregates
+  to a single chosen commodity via the journal's `P` price directives.
+  Unconvertible commodities surface in an amber banner.
+- **CI: dual-deploy of dashboard and compile demo to GitHub Pages** (#310).
+  `/doppio/dashboard/` (Vue SPA) and `/doppio/compile/` (wasm demo) are now
+  both deployed under a single Pages artifact with a landing page at
+  `/doppio/`.
+
+### Dev infrastructure
+
+- **`shell.nix`** for Nix-based development environments (#332).
+
 ### doppio-categorize 0.2.0 - 2026-05-16
 
 **Breaking changes** (part of #319, builds on #320).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "doppio"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "doppio-cli"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anstream 1.0.0",
  "anstyle",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "doppio-wasm"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "console_error_panic_hook",
  "doppio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "3"
 # Shared metadata that applies to every member crate by default. Crates
 # can override individual fields locally.
 [workspace.package]
-version = "2.3.0"
+version = "2.4.0"
 edition = "2024"
 rust-version = "1.95.0"
 repository = "https://github.com/alevy/doppio"

--- a/README.md
+++ b/README.md
@@ -68,10 +68,11 @@ Parses the source file, runs it through the full compilation pipeline, and write
 ```
 dop balance my-journal.ledger
 dop balance my-journal.dop --depth 2 --begin 2024-01-01 --cleared
-dop balance my-journal.dop --pattern "^Expenses" --format json
+dop balance my-journal.dop "^Expenses" --format json
+dop balance my-journal.dop "^Expenses" "^Income" --format json
 ```
 
-Prints account balances grouped by commodity, with a grand-total footer per commodity beneath a divider. By default, output is rendered as an indented tree where parent rows show the sum of every descendant; pass `--flat` to revert to the classic single-line-per-account form. Flags: `--depth N` (truncate hierarchy), `--flat`, `--begin`/`--end` (date range), `--cleared` (cleared transactions only), `--tag KEY` (transactions tagged with `KEY`), `--pattern REGEX` (filter accounts), `-X`/`--exchange COMMODITY` (convert balances to `COMMODITY` using `P` price directives), `--format text|json|csv`.
+Prints account balances grouped by commodity, with a grand-total footer per commodity beneath a divider. By default, output is rendered as an indented tree where parent rows show the sum of every descendant; pass `--flat` to revert to the classic single-line-per-account form. Accepts one or more positional `PATTERN` arguments — case-insensitive regex filters on account names, OR-matched (an account is included if it satisfies any pattern). Flags: `--depth N` (truncate hierarchy), `--flat`, `--begin`/`--end` (date range), `--cleared` (cleared transactions only), `--tag KEY` (transactions tagged with `KEY`), `-X`/`--exchange COMMODITY` (convert balances to `COMMODITY` using `P` price directives), `--format text|json|csv`.
 
 When stdout is a terminal, balance output is colorized: negative amounts appear in red and account names in blue, matching ledger-cli's color scheme. Pass `--color=never` to suppress color or `--color=always` to force it even when piped. The `NO_COLOR` environment variable is also honoured.
 
@@ -80,9 +81,10 @@ When stdout is a terminal, balance output is colorized: negative amounts appear 
 ```
 dop register my-journal.ledger
 dop register my-journal.dop Expenses --format csv
+dop register my-journal.dop Expenses Income --format csv
 ```
 
-Lists individual postings with running totals per commodity, optionally filtered to accounts matching a regex pattern. Flags: `--begin`/`--end` (date range), `--cleared`, `--tag KEY`, `--format text|json|csv`.
+Lists individual postings with running totals per commodity, optionally filtered to accounts matching one or more case-insensitive regex patterns (OR-matched). Flags: `--begin`/`--end` (date range), `--cleared`, `--tag KEY`, `--format text|json|csv`.
 
 ### `print` -- re-emit canonical Ledger source
 
@@ -124,7 +126,7 @@ The library exposes the pipeline stages as modules, plus top-level entry points:
 |---|---|
 | `compile(source, parser)` | Full pipeline: source text -> elaborated `Journal` |
 | `eval_transaction(txn, ctx)` | Elaborate a single `resolution::Transaction` -- validate balance, infer null posting, apply aliases |
-| `write_ledger(txns, writer)` | Serialize `resolution::Transaction` values to canonical Ledger source text |
+| `Frontend::write_journal(hir, writer)` | Serialize a `resolution::HIR` to canonical source text in the frontend's format (ledger / hledger / Beancount). Build an HIR programmatically with `HIR::new()` + `HIR::append_entry(entry)`. Supersedes the deprecated `write_ledger`. |
 | `write_dop` / `read_dop` | Round-trip an `elaboration::Journal` to/from a `.dop` file (8-byte header + optional deflate + protobuf) |
 
 The `resolution::Transaction` and `resolution::Posting` builder APIs are the intended construction layer for programmatic use:

--- a/docs/SUPPORTED_FEATURES.md
+++ b/docs/SUPPORTED_FEATURES.md
@@ -1,6 +1,6 @@
 # doppio: Supported Ledger features
 
-**Last updated**: 2026-05-11 (doppio v2.3.0)
+**Last updated**: 2026-06-04 (doppio v2.4.0)
 
 Feature-by-feature comparison of doppio's syntax surface against
 [ledger-cli](https://ledger-cli.org/) and [hledger](https://hledger.org/).

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,6 +1,6 @@
 # doppio Requirements
 
-**Last updated**: 2026-05-11 (doppio v2.3.0)
+**Last updated**: 2026-06-04 (doppio v2.4.0)
 
 ---
 


### PR DESCRIPTION
## Summary

Minor release. v2.4.0 bundles the changes since v2.3.0 (2026-05-11): one additive library API, one additive CLI behavior change, one additive `doppio-wasm` API change, web-only feature work, and dev infrastructure.

- **doppio (lib)**: `HIR::append_entry` + `HIR::new`; `Entry`/`AssertionDirective`/`PadDirective` become public — unblocks external journal construction so downstream consumers can call `Frontend::write_journal` with a programmatically-built HIR (#333, closes #328).
- **doppio-cli**: `dop balance` / `dop register` accept multiple positional patterns, OR-matched (#331). Existing single-pattern invocations continue to work.
- **doppio-wasm**: `compile(source, frontend, config?)` accepts an optional config dict with `opener` (sync JS include callback) and `basePath` (#315, refs #311). Two-argument call shape unchanged.
- **Web**: `web/dop` extracted as standalone npm package (#329, closes #327); dashboard canonical-commodity selector (#314, closes #312); CI dual-deploys dashboard and compile demo to Pages (#310).
- **Dev**: `shell.nix` for Nix-based development (#332).

`.dop` wire format unchanged at v3; v2.3.0-built `.dop` files load unchanged in v2.4.0. MSRV unchanged at 1.95.0. No flag removed or renamed — no breaking changes to the documented public surfaces per RELEASE.md.

`doppio-categorize` 0.1.1 (2026-05-12) and 0.2.0 (2026-05-16) were released independently between v2.3.0 and v2.4.0; their CHANGELOG sub-sections move under the new heading.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo test --doc`
- [x] `cargo doc --no-deps` (41 warnings, all pre-existing tech debt per RELEASE.md "Known doc warnings"; tracking issue still TBD)
- [x] `cargo publish --dry-run -p doppio`
- [x] `cargo publish --dry-run -p doppio-cli`
- [x] End-to-end smoke against `betterbytes-org/ledger` (release binary `balance` + `compile` round-trip + manual CLI sweep + multi-pattern `dop balance file.ledger Expenses Assets`)
- [x] `.dop` version-rejection smoke against `crates/doppio-cli/tests/fixtures/v0.1.0.dop` and `v0.2.0.dop`

After merge: `cargo publish -p doppio && cargo publish -p doppio-cli`, tag `v2.4.0`, push tag, `gh release create v2.4.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)