### PR TITLE
fix(resolution): canonicalise commodity through alias map before keying inferred_scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Commodity aliases no longer leave phantom raw-symbol entries in the
+  compiled journal** (#336). A Ledger journal that declares `commodity USD\n
+  alias $` and then writes postings as `$100` now produces a single `USD`
+  entry in the elaborated `commodities` map; previously the alias `$` also
+  appeared as a separate entry with no link back to its canonical commodity,
+  even though the posting itself was correctly rebranded to `USD`. The same
+  fix applies to the `C N1 X = N2 Y` chain-conversion form.
+
 ## [2.4.0] - 2026-06-04
 
 ### Added

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -6930,6 +6930,44 @@ commodity BTC
         );
     }
 
+    /// Aliased postings must not leave a phantom raw-symbol entry in the
+    /// elaborated `commodities` map. The elaborator rebrands postings to the
+    /// canonical commodity, so an entry keyed by the alias is orphan metadata
+    /// with no link back to the canonical. (#336)
+    #[test]
+    fn test_alias_does_not_create_phantom_commodity_entry() {
+        let input = "\
+commodity USD
+  alias $
+
+2024-01-01 Test
+  Assets:Checking  $100
+  Equity:Opening
+";
+        let journal = elaborate(input);
+
+        // Posting itself is canonicalised — sanity check, since the bug
+        // sits one level deeper than this.
+        let checking = journal.transactions[0]
+            .postings
+            .iter()
+            .find(|p| p.account == "Assets:Checking")
+            .unwrap();
+        assert_eq!(checking.amount_in("USD"), Some(dec!(100)));
+
+        // The commodities map must not contain the alias key.
+        assert!(
+            !journal.commodities.contains_key("$"),
+            "alias `$` should not appear as a separate commodity in the \
+             elaborated journal; commodities keys = {:?}",
+            journal.commodities.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            journal.commodities.contains_key("USD"),
+            "canonical commodity `USD` should be present"
+        );
+    }
+
     /// `C` directive does not retroactively affect transactions that appeared
     /// before it in the source file (context-versioning invariant).
     #[test]

--- a/crates/doppio/src/resolution.rs
+++ b/crates/doppio/src/resolution.rs
@@ -1324,10 +1324,24 @@ impl TryFrom<ast::Journal> for HIR {
                             }
                         }
                         for (commodity, scale) in scales {
+                            // Canonicalise through the active context's alias
+                            // map before keying `commodity_properties`. Without
+                            // this, a posting written as `$100` under
+                            // `commodity USD\n  alias $` would create a phantom
+                            // `$` entry in the elaborated journal's commodities
+                            // map (the elaborator rebrands the posting itself
+                            // to `USD`, so no consumer can ever see `$` — it is
+                            // orphan metadata). Same shape applies to the `C`
+                            // chain. (#336)
+                            let canonical = context
+                                .commodity_conversions
+                                .get(&commodity)
+                                .map(|(c, _)| c.clone())
+                                .unwrap_or(commodity);
                             let props = result
                                 .global_context
                                 .commodity_properties
-                                .entry(commodity)
+                                .entry(canonical)
                                 .or_default();
                             props.inferred_scale = props.inferred_scale.max(scale);
                         }


### PR DESCRIPTION
## Summary

A Ledger journal that declared `commodity USD` / `alias \$` and then wrote postings as `\$100` produced **two** entries in the elaborated `commodities` map — `USD` and `\$` — with no field linking them. The posting itself was correctly rebranded to `USD`, so the `\$` entry was orphan metadata no consumer could associate back.

The leak sat in the AST → HIR scale-collection pass: `resolution.rs:1318-1334` walked each posting amount with `collect_scales_from_expr` and inserted `(commodity, scale)` into `global_context.commodity_properties` keyed by the raw token from the source. The active context's `commodity_conversions` alias map was not consulted — even though it had already been populated by the earlier `commodity X / alias Y` (or `C N1 X = N2 Y`) directive. The elaborator's posting-level alias resolution at `elaborator.rs:2963` ran later, but by then `commodity_properties` was already polluted, and the pollution rode through to the protobuf `commodities` map at `elaborator.rs:2183-2195`.

Fix is two lines of logic: resolve the commodity through `context.commodity_conversions` before keying `commodity_properties`. The same fix covers the `C` chain case (chains are already fixpoint-resolved by `resolve_commodity_conversion_chains`, so a single lookup suffices).

Closes #336.

## Test plan

- [x] New regression test: `test_alias_does_not_create_phantom_commodity_entry` asserts on the **keys** of `journal.commodities` (not just on posting amounts — the existing `test_alias_divisor_one_regression` missed the leak because it only checked the posting).
- [x] Stash-revert confirmed: the test FAILS on the pre-fix tree (`panicked at elaborator.rs:6959`) and PASSES with the fix.
- [x] Full doppio test suite passes (430 lib + 49 parity + 12 writer_roundtrip + 3 proto_evolution + 2 hir_external_construction).
- [x] Full workspace `cargo test` passes.
- [x] `cargo fmt --check` clean.
- [x] No new clippy warnings (the 6 errors `cargo clippy -D warnings` surfaces in this branch are all pre-existing on main).

## Out of scope

- The `commodity` directive arm at `resolution.rs:1115` still keys `commodity_properties` by the directive's own declared name. That is correct for a normal `commodity USD / alias \$` declaration (USD is canonical), but degenerates if a journal contains contradictory pairs like `commodity USD / alias \$` followed by `commodity \$ / format ...`. That's a separate semantic question (which is canonical?) and isn't what #336 is about.
- Format directive populated by `commodity X / format ...` for an aliased X is unaffected — `format` is stored on the directive's own declared name, which is canonical by construction.