### PR TITLE
fix(elaborator): canonicalise P-directive primary commodity through alias map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@
   appeared as a separate entry with no link back to its canonical commodity,
   even though the posting itself was correctly rebranded to `USD`. The same
   fix applies to the `C N1 X = N2 Y` chain-conversion form.
+- **`P` directive primary commodity now canonicalised through the alias map**
+  (#338). A `P 2024-06-01 $ 1.10 EUR` under `commodity USD\n  alias $` now
+  emits `HistoricalPrice.commodity = "USD"` in the elaborated journal;
+  previously the primary commodity was copied straight from the AST while the
+  price RHS was already canonicalised, leaving `dop prices` and any downstream
+  price lookup against the canonical posting commodity unable to find the
+  entry.
 
 ## [2.4.0] - 2026-06-04
 

--- a/crates/doppio/src/elaborator.rs
+++ b/crates/doppio/src/elaborator.rs
@@ -2171,10 +2171,21 @@ pub fn elaborate(
         for hp in value.prices {
             let (price, price_commodity) =
                 evaluator::eval_and_normalize_amount(hp.price, final_context, &state)?;
+            // Canonicalise the primary commodity through the alias map. The
+            // price expression on the RHS already routes through
+            // `eval_and_normalize_amount`, which applies the alias map to
+            // `price_commodity`; the primary commodity is a separate `String`
+            // copied straight from the AST and would otherwise leave an alias
+            // in the elaborated journal (#338).
+            let commodity = final_context
+                .commodity_conversions
+                .get(&hp.commodity)
+                .map(|(c, _)| c.clone())
+                .unwrap_or(hp.commodity);
             prices.push(crate::elaboration::HistoricalPrice {
                 date: hp.date.to_epoch_days(),
                 time: hp.time,
-                commodity: hp.commodity,
+                commodity,
                 price: Some(crate::decimal_to_proto(price)),
                 price_commodity,
             });
@@ -6966,6 +6977,36 @@ commodity USD
             journal.commodities.contains_key("USD"),
             "canonical commodity `USD` should be present"
         );
+    }
+
+    /// Same bug shape as #336/#337 at the `P` directive site: the primary
+    /// commodity of a `P` directive must be canonicalised through the alias
+    /// map; otherwise the elaborated `HistoricalPrice.commodity` retains the
+    /// raw source token and downstream price lookups against the canonical
+    /// posting commodity miss the entry. (#338)
+    #[test]
+    fn test_p_directive_primary_commodity_alias_resolved() {
+        let input = "\
+commodity USD
+  alias $
+
+P 2024-06-01 $ 1.10 EUR
+
+2024-06-02 Test
+  Assets:Wallet  $100
+  Equity:Opening
+";
+        let journal = elaborate(input);
+
+        assert_eq!(journal.prices.len(), 1);
+        let hp = &journal.prices[0];
+        assert_eq!(
+            hp.commodity, "USD",
+            "P directive primary commodity must be canonicalised through the \
+             alias map; got `{}`",
+            hp.commodity
+        );
+        assert_eq!(hp.price_commodity, "EUR");
     }
 
     /// `C` directive does not retroactively affect transactions that appeared


### PR DESCRIPTION
## Summary

Follow-up to #337 covering the second site with the same bug shape (audited in #336 / #337 PR thread).

The `P` directive's price expression already routes through `eval_and_normalize_amount`, which applies the alias map to the price-side commodity. The primary commodity — `hp.commodity`, the thing whose price is being declared — is a separate `String` copied straight from the AST into the elaborated `HistoricalPrice.commodity` without ever consulting `commodity_conversions`.

Closes #338.

## Reproducer

```ledger
commodity USD
  alias \$

P 2024-06-01 \$ 1.10 EUR

2024-06-02 Test
  Assets:Wallet  \$100
  Equity:Opening
```

Before:

```
\$ dop prices /tmp/p_alias.ledger
P 2024-06-01 \$ 1.10 EUR
```

After:

```
\$ dop prices /tmp/p_alias.ledger
P 2024-06-01 USD 1.10 EUR
```

## Fix

Same one-line pattern as #337 (`unwrap_or` over `commodity_conversions.get`). `final_context` is used because `P` directives are already evaluated against the final context for the price-RHS — keeps the two halves of the directive consistent.

## Test plan

- [x] New regression test `test_p_directive_primary_commodity_alias_resolved` asserts `journal.prices[0].commodity == "USD"`.
- [x] Stash-revert confirmed: test panics on the pre-fix tree, passes with the fix.
- [x] `cargo test -p doppio --lib --tests`: 431 lib + 49 parity + 12 writer_roundtrip + 3 proto_evolution + 2 hir_external_construction — all pass.
- [x] `cargo test --workspace --lib --tests`: all pass.
- [x] `cargo fmt --check` clean; no new clippy warnings.
- [x] CLI verified: `dop prices` on the reproducer now emits `P 2024-06-01 USD 1.10 EUR`.