### PR TITLE
release: v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [2.4.1] - 2026-06-09
+
 ### Fixed
 
 - **Commodity aliases no longer leave phantom raw-symbol entries in the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "doppio"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "chrono",
  "criterion",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "doppio-cli"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "anstream 1.0.0",
  "anstyle",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "doppio-wasm"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "console_error_panic_hook",
  "doppio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "3"
 # Shared metadata that applies to every member crate by default. Crates
 # can override individual fields locally.
 [workspace.package]
-version = "2.4.0"
+version = "2.4.1"
 edition = "2024"
 rust-version = "1.95.0"
 repository = "https://github.com/alevy/doppio"

--- a/docs/SUPPORTED_FEATURES.md
+++ b/docs/SUPPORTED_FEATURES.md
@@ -1,6 +1,6 @@
 # doppio: Supported Ledger features
 
-**Last updated**: 2026-06-04 (doppio v2.4.0)
+**Last updated**: 2026-06-09 (doppio v2.4.1)
 
 Feature-by-feature comparison of doppio's syntax surface against
 [ledger-cli](https://ledger-cli.org/) and [hledger](https://hledger.org/).

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,6 +1,6 @@
 # doppio Requirements
 
-**Last updated**: 2026-06-04 (doppio v2.4.0)
+**Last updated**: 2026-06-09 (doppio v2.4.1)
 
 ---
 


### PR DESCRIPTION
Patch release covering two alias-resolution bug fixes.

## Changes since v2.4.0

- #337 — Commodity alias scale-collection: phantom raw-symbol entries no longer pollute the elaborated `commodities` map.
- #339 — `P` directive primary commodity now canonicalised through the alias map.

## Verification

- Workspace `cargo test --lib --tests`: all pass.
- `cargo fmt --check`: clean.
- `dop prices` on the #338 reproducer now emits `P 2026-06-01 USD 1.10 EUR` (was `$ 1.10 EUR`).
- No API surface changes; no `.dop` format-version bump; no CLI flag changes.

## Post-merge checklist (per RELEASE.md)

- [ ] `cargo publish --dry-run` clean
- [ ] `cargo publish`
- [ ] `git tag -a v2.4.1 && git push origin v2.4.1`
- [ ] `gh release create v2.4.1` with CHANGELOG section